### PR TITLE
Add docker-compose specification and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /usr/src/app/requirements.txt
 
 COPY ./app /usr/src/app
 
-ENTRYPOINT ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0"]
+
+CMD ["--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,3 @@ COPY ./requirements.txt /usr/src/app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /usr/src/app/requirements.txt
 
 COPY ./app /usr/src/app
-
-ENTRYPOINT ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0"]
-
-CMD ["--port", "8000"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ COPY ./requirements.txt /usr/src/app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /usr/src/app/requirements.txt
 
 COPY ./app /usr/src/app
+
+ENTRYPOINT ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ INFO:     Application startup complete.
 ```
 You can verify the API is running once you receive info messages similar to the above in your terminal.
 
+### Troubleshooting
+If you get a 401 response to your API request with an `"Unauthorized: "` error message, your `USERNAME` and `PASSWORD` pair may be incorrect. Verify that these environment variables have been exported and/or have the correct values.
+
 ## Testing
 
 Neurobagel API utilizes [Pytest](https://docs.pytest.org/en/7.2.x/) framework for testing.

--- a/README.md
+++ b/README.md
@@ -39,16 +39,21 @@ NOTE: Currently, to access the API, you must be connected to the McGill network.
 ## Local installation
 
 ### Set the environment variables
-Create a `.env` file to house the environment variables used by the app. To run the API, at least two environment variables must be set, `USER` and `PASSWORD`.  
+Create a `.env` file to house the environment variables used by the app. To run the API, at least two environment variables must be set, `USERNAME` and `PASSWORD`.  
 The contents of a minimal `.env` file:
 ```bash
-USER=someuser
+USERNAME=someuser
 PASSWORD=somepassword
 ```
 
 An optional third environment variable `DOG_ROOT` may be set in `.env` to use a different IP address for the graph database.
 
-The below instructions for Docker and Python assume that you have at least set `USER` and `PASSWORD` in your current environment.
+To export all the variables in your `.env` file in one step, run the following:
+```bash
+export $(cat .env | xargs)
+```
+
+The below instructions for Docker and Python assume that you have at least set `USERNAME` and `PASSWORD` in your current environment.
 
 ### Docker
 First, [install docker](https://docs.docker.com/get-docker/).
@@ -64,6 +69,8 @@ If needed, update your .env file with optional environment variables for the doc
 - `STARDOG_TAG`: Tag for Stardog Docker image (default: `7.7.3-java11-preview`)
 - `STARDOG_ROOT`: Path to directory on host machine containing a Stardog license file (default: `~/stardog-home`)
 
+Note: To avoid conflicts related to [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/), ensure that any variables defined in your `.env` file are not already set in your current shell environment with **different** values.
+
 Then spin up the containers using Docker Compose:
 ```bash
 docker compose up -d
@@ -73,14 +80,14 @@ docker compose up -d
 ```bash
 source .env # set your environment variables 
 docker pull neurobagel/api
-docker run --name api -p 8000:8000 --env USER --env PASSWORD neurobagel/api
+docker run -d --name api -p 8000:8000 --env USERNAME --env PASSWORD neurobagel/api
 ```
 #### Option 3: Build the image using the Dockerfile
 After cloning the current repository, build the Docker image locally:
 ```bash
 source .env # set your environment variables
 docker build -t <image_name> .
-docker run -d --name api -p 8000:8000 --env USER --env PASSWORD neurobagel/api
+docker run -d --name api -p 8000:8000 --env USERNAME --env PASSWORD neurobagel/api
 ```
 
 For Options 2 or 3, if you wish to also set `DOG_ROOT`, make sure to pass it to the container in the `docker run` command using the `--env` flag.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ USERNAME=someuser
 PASSWORD=somepassword
 ```
 
-An optional third environment variable `DOG_ROOT` may be set in `.env` to use a different IP address for the graph database.
+An optional third environment variable `GRAPH_ADDRESS` may be set in `.env` to use a different IP address for the graph database.
 
 To export all the variables in your `.env` file in one step, run the following:
 ```bash
@@ -65,7 +65,7 @@ First, [install docker-compose](https://docs.docker.com/compose/install/).
 
 If needed, update your .env file with optional environment variables for the docker-compose configuration:
 - `API_TAG`: Tag for API Docker image (default: `latest`)
-- `DOG_ROOT`: container name or IP address for the graph database (default: `graph`)
+- `GRAPH_ADDRESS`: container name or IP address for the graph database (default: `graph`)
 - `STARDOG_TAG`: Tag for Stardog Docker image (default: `7.7.3-java11-preview`)
 - `STARDOG_ROOT`: Path to directory on host machine containing a Stardog license file (default: `~/stardog-home`)
 
@@ -90,7 +90,7 @@ docker build -t <image_name> .
 docker run -d --name api -p 8000:8000 --env USERNAME --env PASSWORD neurobagel/api
 ```
 
-For Options 2 or 3, if you wish to also set `DOG_ROOT`, make sure to pass it to the container in the `docker run` command using the `--env` flag.
+For Options 2 or 3, if you wish to also set `GRAPH_ADDRESS`, make sure to pass it to the container in the `docker run` command using the `--env` flag.
 
 NOTE: In case you're connecting to the McGill network via VPN and you started the container before connecting to the VPN, make sure to configure your VPN client to allow local (LAN) access when using the VPN.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The Neurobagel API is a REST API, developed in [Python](https://www.python.org/)
 
 - [Quickstart](#quickstart)
 - [Local installation](#local-installation)
+    - [Docker](#docker)
+    - [Python](#python)
 - [Testing](#testing)
 - [License](#license)
 
@@ -37,45 +39,55 @@ NOTE: Currently, to access the API, you must be connected to the McGill network.
 ## Local installation
 
 ### Set the environment variables
-To run the API, at least two environment variables must be set, `USER` and `PASSWORD`. An optional third environment variable `DOG_ROOT` may be set to use a different IP address for the graph database.
-
-To set environment variables in macOS and Linux distributions:
-
+Create a `.env` file to house the environment variables used by the app. To run the API, at least two environment variables must be set, `USER` and `PASSWORD`.  
+The contents of a minimal `.env` file:
 ```bash
-$ export KEY=value
-
-# For example
-$ export USER=someuser
+USER=someuser
+PASSWORD=somepassword
 ```
 
-To set environment variables in Windows from CMD:
+An optional third environment variable `DOG_ROOT` may be set in `.env` to use a different IP address for the graph database.
 
-```bash
-$ set KEY=value
-
-# For example
-$ set USER=someuser
-```
-The below instructions for Docker and Python assume that you have already set `USER` and `PASSWORD` in your current environment.
+The below instructions for Docker and Python assume that you have at least set `USER` and `PASSWORD` in your current environment.
 
 ### Docker
-Follow the [official documentation](https://docs.docker.com/get-docker/) for installing Docker. You can then run a Docker container for the API in two ways:
-#### Option 1: Pull the latest image from Docker Hub
+First, [install docker](https://docs.docker.com/get-docker/).
+
+ You can then run a Docker container for the API in three ways:
+#### Option 1: Use the `docker-compose.yaml` file
+
+First, [install docker-compose](https://docs.docker.com/compose/install/).
+
+If needed, update your .env file with optional environment variables for the docker-compose configuration:
+- `API_TAG`: Tag for API Docker image (default: `latest`)
+- `DOG_ROOT`: container name or IP address for the graph database (default: `graph`)
+- `STARDOG_TAG`: Tag for Stardog Docker image (default: `7.7.3-java11-preview`)
+- `STARDOG_ROOT`: Path to directory on host machine containing a Stardog license file (default: `~/stardog-home`)
+
+Then spin up the containers using Docker Compose:
 ```bash
+docker compose up -d
+```
+
+#### Option 2: Use the latest image from Docker Hub
+```bash
+source .env # set your environment variables 
 docker pull neurobagel/api
 docker run --name api -p 8000:8000 --env USER --env PASSWORD neurobagel/api
 ```
-#### Option 2: Build the image using the Dockerfile
+#### Option 3: Build the image using the Dockerfile
 After cloning the current repository, build the Docker image locally:
 ```bash
+source .env # set your environment variables
 docker build -t <image_name> .
 docker run -d --name api -p 8000:8000 --env USER --env PASSWORD neurobagel/api
 ```
-For either option, if you wish to also set `DOG_ROOT`, make sure to pass it to the container in the `docker run` command using the `--env` flag.
+
+For Options 2 or 3, if you wish to also set `DOG_ROOT`, make sure to pass it to the container in the `docker run` command using the `--env` flag.
 
 NOTE: In case you're connecting to the McGill network via VPN and you started the container before connecting to the VPN, make sure to configure your VPN client to allow local (LAN) access when using the VPN.
 
-### **Python**
+### Python
 #### Install dependencies
 
 After cloning the repository, install the dependencies outlined in the requirements.txt file. For convenience, you can use Python's `venv` package to install dependencies in a virtual environment. You can find the instructions on creating and activating a virtual environment in the official [documentation](https://docs.python.org/3.10/library/venv.html). After setting up and activating your environment, you can install the dependencies by running the following command in your terminal:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ Interactive documentation for the API is available at https://api.neurobagel.org
 NOTE: Currently, to access the API, you must be connected to the McGill network.
 
 ## Local installation
+The below instructions assume that you have a local instance of or access to a remotely hosted graph database to be queried. If this is not the case and you need to first build a graph from data, refer to the instructions for getting started locally with [Stardog Studio](https://docs.stardog.com/stardog-applications/dockerized_access#stardog-studio).
+
+### Clone the repo
+```bash
+git clone https://github.com/neurobagel/api.git
+```
 
 ### Set the environment variables
-Create a `.env` file to house the environment variables used by the app. To run the API, at least two environment variables must be set, `USERNAME` and `PASSWORD`.  
+Create a `.env` file in the root of the repository to house the environment variables used by the app. To run the API, at least two environment variables must be set, `USERNAME` and `PASSWORD`.  
 The contents of a minimal `.env` file:
 ```bash
 USERNAME=someuser
@@ -58,20 +64,20 @@ The below instructions for Docker and Python assume that you have at least set `
 ### Docker
 First, [install docker](https://docs.docker.com/get-docker/).
 
- You can then run a Docker container for the API in three ways:
+ You can then run a Docker container for the API in one of three ways:
 #### Option 1: Use the `docker-compose.yaml` file
 
 First, [install docker-compose](https://docs.docker.com/compose/install/).
 
-If needed, update your .env file with optional environment variables for the docker-compose configuration:
+If needed, update your `.env` file with optional environment variables for the docker-compose configuration:
 - `API_TAG`: Tag for API Docker image (default: `latest`)
 - `GRAPH_ADDRESS`: container name or IP address for the graph database (default: `graph`)
 - `STARDOG_TAG`: Tag for Stardog Docker image (default: `7.7.3-java11-preview`)
 - `STARDOG_ROOT`: Path to directory on host machine containing a Stardog license file (default: `~/stardog-home`)
 
-Note: To avoid conflicts related to [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/), ensure that any variables defined in your `.env` file are not already set in your current shell environment with **different** values.
+NOTE: To avoid conflicts related to [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/), ensure that any variables defined in your `.env` file are not already set in your current shell environment with **different** values.
 
-Then spin up the containers using Docker Compose:
+Use Docker Compose to spin up the containers by running the following in the repository root (where the `docker-compose.yml` file is):
 ```bash
 docker compose up -d
 ```
@@ -93,6 +99,14 @@ docker run -d --name api -p 8000:8000 --env USERNAME --env PASSWORD neurobagel/a
 For Options 2 or 3, if you wish to also set `GRAPH_ADDRESS`, make sure to pass it to the container in the `docker run` command using the `--env` flag.
 
 NOTE: In case you're connecting to the McGill network via VPN and you started the container before connecting to the VPN, make sure to configure your VPN client to allow local (LAN) access when using the VPN.
+
+#### Send a test query to the API
+By default, after running the above steps, the API should be served at localhost, http://127.0.0.1:8000/query, on the machine where you launched the Dockerized app. To check that the API is running and can access the knowledge graph as expected, you can navigate to the interactive API docs in your local browser (http://127.0.0.1:8000/docs) and enter a sample query, or send an HTTP request in your terminal using `curl`:
+``` bash
+# example: query for female subjects in graph 
+curl -L http://127.0.0.1:8000/query/?sex=female
+```
+The response should be a list of dictionaries containing info about datasets with participants matching the query.
 
 ### Python
 #### Install dependencies

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -61,7 +61,7 @@ async def get(
             ),
             headers=util.QUERY_HEADER,
             auth=httpx.BasicAuth(
-                os.environ.get("USER"), os.environ.get("PASSWORD")
+                os.environ.get("USERNAME"), os.environ.get("PASSWORD")
             ),
         )
     except httpx.ConnectTimeout as exc:

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -5,10 +5,10 @@ from collections import namedtuple
 from typing import Optional
 
 # Request constants
-DOG_ROOT = os.environ.get("DOG_ROOT", "206.12.99.17")
-DOG_DB = "test_data"
-DOG_PORT = 5820
-QUERY_URL = f"http://{DOG_ROOT}:{DOG_PORT}/{DOG_DB}/query"
+GRAPH_ADDRESS = os.environ.get("GRAPH_ADDRESS", "206.12.99.17")
+GRAPH_DB = "test_data"
+GRAPH_PORT = 5820
+QUERY_URL = f"http://{GRAPH_ADDRESS}:{GRAPH_PORT}/{GRAPH_DB}/query"
 QUERY_HEADER = {
     "Content-Type": "application/sparql-query",
     "Accept": "application/sparql-results+json",

--- a/app/main.py
+++ b/app/main.py
@@ -22,10 +22,13 @@ app.add_middleware(
 
 @app.on_event("startup")
 async def auth_check():
-    """Checks whether USER and PASSWORD environment variables are set."""
-    if os.environ.get("USER") is None or os.environ.get("PASSWORD") is None:
+    """Checks whether USERNAME and PASSWORD environment variables are set."""
+    if (
+        os.environ.get("USERNAME") is None
+        or os.environ.get("PASSWORD") is None
+    ):
         raise RuntimeError(
-            "The application was launched but could not find the USER and / or PASSWORD environment variables."
+            "The application was launched but could not find the USERNAME and / or PASSWORD environment variables."
         )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: 3.8
 services:
   api:
     image: "neurobagel/api:${API_TAG:-latest}"
-    command: |
-      uvicorn app.main:app --proxy-headers --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       USERNAME: ${USERNAME}
       PASSWORD: ${PASSWORD}
-      DOG_ROOT: ${DOG_ROOT:-graph}
+      GRAPH_ADDRESS: ${GRAPH_ADDRESS:-graph}
   graph:
     image: "stardog/stardog:${STARDOG_TAG:-7.7.3-java11-preview}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 3.8
+version: "3.8"
 
 services:
   api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - USER="${USER}"
-      - PASSWORD="${PASSWORD}"
-      - DOG_ROOT="${DOG_ROOT:-graph}"
+      USERNAME: ${USERNAME}
+      PASSWORD: ${PASSWORD}
+      DOG_ROOT: ${DOG_ROOT:-graph}
   graph:
     image: "stardog/stardog:${STARDOG_TAG:-7.7.3-java11-preview}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: 3.8
+
+services:
+  api:
+    image: "neurobagel/api:${API_TAG:-latest}"
+    command: |
+      uvicorn app.main:app --proxy-headers --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    environment:
+      - USER="${USER}"
+      - PASSWORD="${PASSWORD}"
+      - DOG_ROOT="${DOG_ROOT:-graph}"
+  graph:
+    image: "stardog/stardog:${STARDOG_TAG:-7.7.3-java11-preview}"
+    volumes:
+      - "${STARDOG_ROOT:-~/stardog-home}:/var/opt/stardog"
+    ports:
+      - "5820:5820"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -85,22 +85,22 @@ def mock_invalid_get():
 
 
 def test_start_app_without_environment_vars_fails(test_app, monkeypatch):
-    """Given non-existing USER and PASSWORD environment variables, raises an informative RuntimeError."""
-    monkeypatch.delenv("USER", raising=False)
+    """Given non-existing USERNAME and PASSWORD environment variables, raises an informative RuntimeError."""
+    monkeypatch.delenv("USERNAME", raising=False)
     monkeypatch.delenv("PASSWORD", raising=False)
 
     with pytest.raises(RuntimeError) as e_info:
         with test_app:
             pass
     assert (
-        "could not find the USER and / or PASSWORD environment variables"
+        "could not find the USERNAME and / or PASSWORD environment variables"
         in str(e_info.value)
     )
 
 
 def test_app_with_invalid_environment_vars(test_app, monkeypatch):
     """Given invalid environment variables, returns a 401 status code."""
-    monkeypatch.setenv("USER", "something")
+    monkeypatch.setenv("USERNAME", "something")
     monkeypatch.setenv("PASSWORD", "cool")
 
     def mock_httpx_post(**kwargs):


### PR DESCRIPTION
Other changes:
The `USER` variable has been renamed everywhere to `USERNAME` to try to avoid name conflicts on Linux systems where `USER` is automatically set in the shell. This is more of a precaution; a note has also been added in the README which recommends that the user verifies that the values of the credentials pair is correct.

Closes #86 
Closes #78