### PR TITLE
Update controlled terms to conform to new naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The Neurobagel API is a REST API, developed in [Python](https://www.python.org/)
 
 
 ## Quickstart
-The API is hosted at https://api.neurobagel.org/ and interfaces with Neurobagel's graph database. Queries of the graph can be run using the `/query` route (e.g., the URL for a query for only female participants would be https://api.neurobagel.org/query/?sex=nb:Female).
+The API is hosted at https://api.neurobagel.org/ and interfaces with Neurobagel's graph database. Queries of the graph can be run using the `/query` route.
+
+Example: **I want to query for only female participants in the graph.** The URL for such a query would be https://api.neurobagel.org/query/?sex=snomed:248152002, where `snomed:248152002` is a [controlled term from the SNOMED CT database](https://bioportal.bioontology.org/ontologies/SNOMEDCT?p=classes&conceptid=248152002) corresponding to female sex.
 
 Interactive documentation for the API is available at https://api.neurobagel.org/docs.
 
@@ -104,8 +106,8 @@ NOTE: In case you're connecting to the McGill network via VPN and you started th
 #### Send a test query to the API
 By default, after running the above steps, the API should be served at localhost, http://127.0.0.1:8000/query, on the machine where you launched the Dockerized app. To check that the API is running and can access the knowledge graph as expected, you can navigate to the interactive API docs in your local browser (http://127.0.0.1:8000/docs) and enter a sample query, or send an HTTP request in your terminal using `curl`:
 ``` bash
-# example: query for female subjects in graph 
-curl -L http://127.0.0.1:8000/query/?sex=nb:Female
+# example: query for female subjects in graph
+curl -L http://127.0.0.1:8000/query/?sex=snomed:248152002 
 ```
 The response should be a list of dictionaries containing info about datasets with participants matching the query.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Neurobagel API is a REST API, developed in [Python](https://www.python.org/)
 
 
 ## Quickstart
-The API is hosted at https://api.neurobagel.org/ and interfaces with Neurobagel's graph database. Queries of the graph can be run using the `/query` route (e.g., the URL for a query for only female participants would be https://api.neurobagel.org/query/?sex=female).
+The API is hosted at https://api.neurobagel.org/ and interfaces with Neurobagel's graph database. Queries of the graph can be run using the `/query` route (e.g., the URL for a query for only female participants would be https://api.neurobagel.org/query/?sex=nb:Female).
 
 Interactive documentation for the API is available at https://api.neurobagel.org/docs.
 
@@ -105,7 +105,7 @@ NOTE: In case you're connecting to the McGill network via VPN and you started th
 By default, after running the above steps, the API should be served at localhost, http://127.0.0.1:8000/query, on the machine where you launched the Dockerized app. To check that the API is running and can access the knowledge graph as expected, you can navigate to the interactive API docs in your local browser (http://127.0.0.1:8000/docs) and enter a sample query, or send an HTTP request in your terminal using `curl`:
 ``` bash
 # example: query for female subjects in graph 
-curl -L http://127.0.0.1:8000/query/?sex=female
+curl -L http://127.0.0.1:8000/query/?sex=nb:Female
 ```
 The response should be a list of dictionaries containing info about datasets with participants matching the query.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Neurobagel API is a REST API, developed in [Python](https://www.python.org/)
 ## Quickstart
 The API is hosted at https://api.neurobagel.org/ and interfaces with Neurobagel's graph database. Queries of the graph can be run using the `/query` route.
 
-Example: **I want to query for only female participants in the graph.** The URL for such a query would be https://api.neurobagel.org/query/?sex=snomed:248152002, where `snomed:248152002` is a [controlled term from the SNOMED CT database](https://bioportal.bioontology.org/ontologies/SNOMEDCT?p=classes&conceptid=248152002) corresponding to female sex.
+Example: **I want to query for only female participants in the graph.** The URL for such a query would be https://api.neurobagel.org/query/?sex=snomed:248152002, where `snomed:248152002` is a [controlled term from the SNOMED CT database](http://purl.bioontology.org/ontology/SNOMEDCT/248152002) corresponding to female sex.
 
 Interactive documentation for the API is available at https://api.neurobagel.org/docs.
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ First, [install docker-compose](https://docs.docker.com/compose/install/).
 If needed, update your `.env` file with optional environment variables for the docker-compose configuration:
 - `API_TAG`: Tag for API Docker image (default: `latest`)
 - `GRAPH_ADDRESS`: container name or IP address for the graph database (default: `graph`)
-- `GRAPH_DB`: name of existing graph database to query (default: `test_graph`)
-- `STARDOG_TAG`: Tag for Stardog Docker image (default: `7.7.3-java11-preview`)
+- `GRAPH_DB`: name of existing graph database to query (default: `test_data`)
+- `STARDOG_TAG`: Tag for Stardog Docker image (default: `8.2.2-java11-preview`)
 - `STARDOG_ROOT`: Path to directory on host machine containing a Stardog license file (default: `~/stardog-home`)
 
 NOTE: To avoid conflicts related to [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/), ensure that any variables defined in your `.env` file are not already set in your current shell environment with **different** values.

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -14,7 +14,7 @@ class QueryModel(BaseModel):
 
     min_age: float = Query(default=None, ge=0)
     max_age: float = Query(default=None, ge=0)
-    sex: Literal["male", "female", "other"] = None
+    sex: Literal["nb:Male", "nb:Female", "nb:OtherSex"] = None
     diagnosis: constr(regex=CONTROLLED_TERM_REGEX) = None
     is_control: bool = None
     min_num_sessions: int = Query(default=None, ge=1)

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -1,7 +1,5 @@
 """Data models."""
 
-from typing import Literal
-
 from fastapi import Query
 from fastapi.exceptions import HTTPException
 from pydantic import BaseModel, constr, root_validator
@@ -14,7 +12,7 @@ class QueryModel(BaseModel):
 
     min_age: float = Query(default=None, ge=0)
     max_age: float = Query(default=None, ge=0)
-    sex: Literal["nb:Male", "nb:Female", "nb:OtherSex"] = None
+    sex: constr(regex=CONTROLLED_TERM_REGEX) = None
     diagnosis: constr(regex=CONTROLLED_TERM_REGEX) = None
     is_control: bool = None
     min_num_sessions: int = Query(default=None, ge=1)

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -16,21 +16,23 @@ QUERY_HEADER = {
 
 # SPARQL query context
 DEFAULT_CONTEXT = """
-PREFIX bg: <http://neurobagel.org/vocab/>
-PREFIX snomed: <https://identifiers.org/snomedct:>
+PREFIX cogatlas: <https://www.cognitiveatlas.org/task/id/>
+PREFIX nb: <http://neurobagel.org/vocab/>
+PREFIX nbg: <http://neurobagel.org/graph/>
 PREFIX nidm: <http://purl.org/nidash/nidm#>
+PREFIX snomed: <http://purl.bioontology.org/ontology/SNOMEDCT/>
 """
 
 # Store domains in named tuples
 Domain = namedtuple("Domain", ["var", "pred"])
 # Core domains
-AGE = Domain("age", "bg:age")
-SEX = Domain("sex", "bg:sex")
-DIAGNOSIS = Domain("diagnosis", "bg:diagnosis")
-IS_CONTROL = Domain("subject_group", "bg:isSubjectGroup")
-ASSESSMENT = Domain("assessment", "bg:assessment")
-IMAGE_MODAL = Domain("image_modal", "bg:hasContrastType")
-PROJECT = Domain("project", "bg:hasSamples")
+AGE = Domain("age", "nb:hasAge")
+SEX = Domain("sex", "nb:hasSex")
+DIAGNOSIS = Domain("diagnosis", "nb:hasDiagnosis")
+IS_CONTROL = Domain("subject_group", "nb:isSubjectGroup")
+ASSESSMENT = Domain("assessment", "nb:hasAssessment")
+IMAGE_MODAL = Domain("image_modal", "nb:hasContrastType")
+PROJECT = Domain("project", "nb:hasSamples")
 
 
 CATEGORICAL_DOMAINS = [SEX, DIAGNOSIS, IMAGE_MODAL, ASSESSMENT]
@@ -80,7 +82,7 @@ def create_query(
         subject_level_filters += "\n" + f"FILTER (?{AGE.var} <= {age[1]})."
 
     if sex is not None:
-        subject_level_filters += "\n" + f"FILTER (?{SEX.var} = '{sex}')."
+        subject_level_filters += "\n" + f"FILTER (?{SEX.var} = {sex})."
 
     if diagnosis is not None:
         subject_level_filters += (
@@ -122,40 +124,40 @@ def create_query(
     SELECT DISTINCT ?dataset ?dataset_name ?subject ?sub_id ?age ?sex
     ?diagnosis ?subject_group ?num_sessions ?assessment ?image_modal ?file_path
     WHERE {{
-    ?dataset a bg:Dataset;
-             bg:label ?dataset_name;
-             bg:hasSamples ?subject.
+    ?dataset a nb:Dataset;
+             nb:hasLabel ?dataset_name;
+             nb:hasSamples ?subject.
 
-    ?subject a bg:Subject;
-            bg:label ?sub_id;
-            bg:hasSession ?session;
-            bg:hasSession/bg:hasAcquisition/bg:hasContrastType ?image_modal.
+    ?subject a nb:Subject;
+            nb:hasLabel ?sub_id;
+            nb:hasSession ?session;
+            nb:hasSession/nb:hasAcquisition/nb:hasContrastType ?image_modal.
 
     OPTIONAL {{
-        ?session bg:filePath ?file_path.
+        ?session nb:hasFilePath ?file_path.
     }}
     OPTIONAL {{
-        ?subject bg:age ?age.
+        ?subject nb:hasAge ?age.
     }}
     OPTIONAL {{
-        ?subject bg:sex ?sex.
+        ?subject nb:hasSex ?sex.
     }}
     OPTIONAL {{
-        ?subject bg:diagnosis ?diagnosis.
+        ?subject nb:hasDiagnosis ?diagnosis.
     }}
     OPTIONAL {{
-        ?subject bg:isSubjectGroup ?subject_group.
+        ?subject nb:isSubjectGroup ?subject_group.
     }}
     OPTIONAL {{
-        ?subject bg:assessment ?assessment.
+        ?subject nb:hasAssessment ?assessment.
     }}
 
     {{
     SELECT ?subject (count(distinct ?session) as ?num_sessions)
     WHERE {{
-        ?subject a bg:Subject;
-                 bg:hasSession ?session.
-        ?session bg:hasAcquisition/bg:hasContrastType ?image_modal.
+        ?subject a nb:Subject;
+                 nb:hasSession ?session.
+        ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
         {session_level_filters}
 
     }} GROUP BY ?subject

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -173,13 +173,14 @@ def test_get_invalid_age(
 
 
 @pytest.mark.parametrize(
-    "valid_sex", ["248153007", "248152002", "32570681000036106"]
+    "valid_sex",
+    ["snomed:248153007", "snomed:248152002", "snomed:32570681000036106"],
 )
 def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
     """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
-    response = test_app.get(f"/query/?sex=snomed:{valid_sex}")
+    response = test_app.get(f"/query/?sex={valid_sex}")
     assert response.status_code == 200
     assert response.json() != []
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -172,18 +172,20 @@ def test_get_invalid_age(
     assert response.status_code == 422
 
 
-@pytest.mark.parametrize("valid_sex", ["Male", "Female", "OtherSex"])
+@pytest.mark.parametrize(
+    "valid_sex", ["248153007", "248152002", "32570681000036106"]
+)
 def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
     """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
-    response = test_app.get(f"/query/?sex=nb:{valid_sex}")
+    response = test_app.get(f"/query/?sex=snomed:{valid_sex}")
     assert response.status_code == 200
     assert response.json() != []
 
 
 def test_get_invalid_sex(test_app, mock_invalid_get, monkeypatch):
-    """Given an invalid sex string (i.e., anything other than ["nb:Male", "nb:Female", "nb:OtherSex"]), returns a 422 status code."""
+    """Given an invalid sex string, returns a 422 status code."""
 
     monkeypatch.setattr(crud, "get", mock_invalid_get)
     response = test_app.get("/query/?sex=apple")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -172,18 +172,18 @@ def test_get_invalid_age(
     assert response.status_code == 422
 
 
-@pytest.mark.parametrize("valid_sex", ["male", "female", "other"])
+@pytest.mark.parametrize("valid_sex", ["Male", "Female", "OtherSex"])
 def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
     """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
-    response = test_app.get(f"/query/?sex={valid_sex}")
+    response = test_app.get(f"/query/?sex=nb:{valid_sex}")
     assert response.status_code == 200
     assert response.json() != []
 
 
 def test_get_invalid_sex(test_app, mock_invalid_get, monkeypatch):
-    """Given an invalid sex string (i.e., anything other than ["male", "female", None]), returns a 422 status code."""
+    """Given an invalid sex string (i.e., anything other than ["nb:Male", "nb:Female", "nb:OtherSex"]), returns a 422 status code."""
 
     monkeypatch.setattr(crud, "get", mock_invalid_get)
     response = test_app.get("/query/?sex=apple")
@@ -284,7 +284,7 @@ def test_get_valid_assessment(test_app, mock_successful_get, monkeypatch):
     """Given a valid assessment, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
-    response = test_app.get("/query/?assessment=bg:cogAtlas-1234")
+    response = test_app.get("/query/?assessment=nb:cogAtlas-1234")
     assert response.status_code == 200
     assert response.json() != []
 
@@ -327,7 +327,7 @@ def test_get_valid_available_image_modal(
 
 @pytest.mark.parametrize(
     "valid_unavailable_image_modal",
-    ["nidm:Flair", "owl:sameAs", "bg:FlowWeighted", "snomed:something"],
+    ["nidm:Flair", "owl:sameAs", "nb:FlowWeighted", "snomed:something"],
 )
 def test_get_valid_unavailable_image_modal(
     test_app, valid_unavailable_image_modal, monkeypatch


### PR DESCRIPTION
Notes:
- Fixed options for sex (based on the test graph) were previously string literals (`"male"`, `"female"`, `"other"`) and not URIs. In this PR the options have been changed to a single controlled term regex field
- Minor typos in README also fixed.

Closes #94