### PR TITLE
[ENH] Updated API to return new subject level results 

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -51,8 +51,9 @@ class QueryModel(BaseModel):
 class CohortQueryResponse(BaseModel):
     """Data model for query results for one matching dataset (i.e., a cohort)."""
 
-    dataset: str
     dataset_name: str
+    dataset_portal_uri: str
+    dataset_file_path: str
     num_matching_subjects: int
     subject_data: list
     image_modals: list

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -120,18 +120,21 @@ def create_query(
         )
 
     query_string = f"""
-        SELECT DISTINCT ?dataset ?dataset_name ?subject ?sub_id ?age ?sex
-        ?diagnosis ?subject_group ?num_sessions ?assessment ?image_modal ?file_path
+        SELECT DISTINCT ?dataset_name ?dataset_portal_uri ?dataset_file_path ?sub_id ?age ?sex
+        ?diagnosis ?subject_group ?num_sessions ?session_id ?assessment ?image_modal ?session_file_path
         WHERE {{
             ?dataset a nb:Dataset;
                     nb:hasLabel ?dataset_name;
+                    nb:hasPortalURI ?dataset_portal_uri;
+                    nb:hasFilePath ?dataset_file_path;
                     nb:hasSamples ?subject.
             ?subject a nb:Subject;
                     nb:hasLabel ?sub_id;
                     nb:hasSession ?session;
                     nb:hasSession/nb:hasAcquisition/nb:hasContrastType ?image_modal.
+            ?session nb:hasLabel ?session_id.
             OPTIONAL {{
-                ?session nb:hasFilePath ?file_path.
+                ?session nb:hasFilePath ?session_file_path.
             }}
             OPTIONAL {{
                 ?subject nb:hasAge ?age.
@@ -165,9 +168,9 @@ def create_query(
     # wrap query in an aggregating statement so data returned from graph include only attributes needed for dataset-level aggregate metadata.
     if return_agg:
         query_string = f"""
-            SELECT ?dataset ?dataset_name ?sub_id ?file_path ?image_modal WHERE {{\n
+            SELECT ?dataset_name ?dataset_portal_uri ?dataset_file_path ?sub_id ?session_file_path ?image_modal WHERE {{\n
             {query_string}
-            \n}} GROUP BY ?dataset ?dataset_name ?sub_id ?file_path ?image_modal
+            \n}} GROUP BY ?dataset_name ?dataset_portal_uri ?dataset_file_path ?sub_id ?session_file_path ?image_modal
         """
 
     return "\n".join([DEFAULT_CONTEXT, query_string])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,8 +12,9 @@ def test_data():
     """Create toy data for two datasets for testing."""
     return [
         {
-            "dataset": "http://neurobagel.org/vocab/qpn",
             "dataset_name": "QPN",
+            "dataset_portal_uri": "https://openneuro.org/datasets/ds002725",
+            "dataset_file_path": "https://github.com/OpenNeuroDatasets/ds002725.git",
             "num_matching_subjects": 5,
             "subject_data": [
                 "/my/happy/path/sub-0051/to/session-01",
@@ -28,8 +29,9 @@ def test_data():
             ],
         },
         {
-            "dataset": "http://neurobagel.org/vocab/ppmi",
             "dataset_name": "PPMI",
+            "dataset_portal_uri": "https://openneuro.org/datasets/ds002727",
+            "dataset_file_path": "https://github.com/OpenNeuroDatasets/ds002727.git",
             "num_matching_subjects": 3,
             "subject_data": [
                 "/my/happy/path/sub-719238/to/session-01",


### PR DESCRIPTION
Closes #112 

Changes proposed in this pull request:

- in models.py, add to CohortQueryResponse data model:
  -  `dataset_portal_uri`
  - `dataset_file_path`
- update query string to return from graph, in addition to existing variables:
  - dataset PortalURI (using `hasPortalURI`)
  - dataset FilePath (using `hasFilePath`)
  - SessionID (using `hasLabel`)
  - Renamed `file_path` to `session_file_path`
- remove `dataset` (i.e., unique dataset identifier, `https://iri.nidash...`) and `subject` IRIs from returned variables in query string
- in crud.py, when constructing `subject_data` dataframe from graph-returned data:
  - remove `dataset_name` for each subject entry
  - group acquisitions by subject and session such that each row is a subject-session, and `diagnosis` and `modality` become lists
- Updated the `test_data` fixture
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
