### PR TITLE
[INF] Change graph backend to graphDB

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -68,6 +68,17 @@ async def get(
 
     """
     try:
+        print("Queyr")
+        print(util.create_query(
+                return_agg=util.RETURN_AGG.val,
+                age=(min_age, max_age),
+                sex=sex,
+                diagnosis=diagnosis,
+                is_control=is_control,
+                min_num_sessions=min_num_sessions,
+                assessment=assessment,
+                image_modal=image_modal,
+            ))
         response = httpx.post(
             url=util.QUERY_URL,
             content=util.create_query(
@@ -85,6 +96,7 @@ async def get(
                 os.environ.get(util.GRAPH_USERNAME.name),
                 os.environ.get(util.GRAPH_PASSWORD.name),
             ),
+            timeout=60.0,
         )
     except httpx.ConnectTimeout as exc:
         raise HTTPException(

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -68,17 +68,6 @@ async def get(
 
     """
     try:
-        print("Queyr")
-        print(util.create_query(
-                return_agg=util.RETURN_AGG.val,
-                age=(min_age, max_age),
-                sex=sex,
-                diagnosis=diagnosis,
-                is_control=is_control,
-                min_num_sessions=min_num_sessions,
-                assessment=assessment,
-                image_modal=image_modal,
-            ))
         response = httpx.post(
             url=util.QUERY_URL,
             content=util.create_query(

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -23,8 +23,8 @@ RETURN_AGG = EnvVar(
     "NB_RETURN_AGG", os.environ.get("NB_RETURN_AGG", "True").lower() == "true"
 )
 
-GRAPH_PORT = 5820
-QUERY_URL = f"http://{GRAPH_ADDRESS.val}:{GRAPH_PORT}/{GRAPH_DB.val}/query"
+GRAPH_PORT = 7200
+QUERY_URL = f"http://{GRAPH_ADDRESS.val}:{GRAPH_PORT}/{GRAPH_DB.val}"
 QUERY_HEADER = {
     "Content-Type": "application/sparql-query",
     "Accept": "application/sparql-results+json",

--- a/data-config.ttl
+++ b/data-config.ttl
@@ -1,0 +1,49 @@
+#
+# RDF4J configuration template for a GraphDB repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix graphdb: <http://www.ontotext.com/config/graphdb#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "openneuro" ;
+    rdfs:label "" ;
+    rep:repositoryImpl [
+        rep:repositoryType "graphdb:SailRepository" ;
+        sr:sailImpl [
+            sail:sailType "graphdb:Sail" ;
+
+            graphdb:read-only "false" ;
+
+            # Inference and Validation
+            graphdb:ruleset "rdfsplus-optimized" ;
+            graphdb:disable-sameAs "true" ;
+            graphdb:check-for-inconsistencies "false" ;
+
+            # Indexing
+            graphdb:entity-id-size "32" ;
+            graphdb:enable-context-index "false" ;
+            graphdb:enablePredicateList "true" ;
+            graphdb:enable-fts-index "false" ;
+            graphdb:fts-indexes ("default" "iri") ;
+            graphdb:fts-string-literals-index "default" ;
+            graphdb:fts-iris-index "none" ;
+
+            # Queries and Updates
+            graphdb:query-timeout "0" ;
+            graphdb:throw-QueryEvaluationException-on-timeout "false" ;
+            graphdb:query-limit-results "0" ;
+
+            # Settable in the file but otherwise hidden in the UI and in the RDF4J console
+            graphdb:base-URL "http://example.org/owlim#" ;
+            graphdb:defaultNS "" ;
+            graphdb:imports "" ;
+            graphdb:repository-type "file-repository" ;
+            graphdb:storage-folder "storage" ;
+            graphdb:entity-index-size "10000000" ;
+            graphdb:in-memory-literal-properties "true" ;
+            graphdb:enable-literal-index "true" ;
+        ]
+    ].

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,4 @@ services:
     volumes:
       - "${STARDOG_ROOT:-~/stardog-home}:/opt/graphdb/home"
     ports:
-      - "5820:7200"
+      - "7200:7200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       NB_GRAPH_DB: ${NB_GRAPH_DB:-test_data}
       NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
   graph:
-    image: "stardog/stardog:${STARDOG_TAG:-8.2.2-java11-preview}"
+    image: "ontotext/graphdb:${STARDOG_TAG:-10.2.4}"
     volumes:
-      - "${STARDOG_ROOT:-~/stardog-home}:/var/opt/stardog"
+      - "${STARDOG_ROOT:-~/stardog-home}:/opt/graphdb/home"
     ports:
-      - "5820:5820"
+      - "5820:7200"


### PR DESCRIPTION
Because Stardog pulled a fast one on us with their "FrEe aCaDeMic LIcEnSe" we are now running our neurobagel graph on the free tier of graphDB. GraphDB also exposes a SPARQL interface so the API does not mind talking to it instead. 

The first time setup is a bit different than for Stardog, so we still need to address the docs change!

Fixes #139 
Fixes #140 

Related to https://github.com/neurobagel/project/issues/161

## Changes proposed here:

- change the graph image from Stardog to GraphDB
- change the default graph port in the API from `5820` (Stardog default) to `7200` (graphDB default)
- remove the hardcoded `.../query` suffix from the template URL for queries (graphDB uses a different endpoint route for the SPARQL interface)
- provide a `data-config.ttl` file in the repo - in graphDB you create "resources", not "databases". To do so, you have to provide the specification of the new "resource" as a graph file. See: https://graphdb.ontotext.com/documentation/10.0/devhub/rest-api/location-and-repository-tutorial.html
- change the API request timeout to 60 seconds, from previously default 5 seconds 


For posterity, here are the first time setup commands:

Make a new database aka resource:
```
curl -X PUT http://localhost:7200/repositories/newdata --data-binary "@data-config.ttl" -H "Content-Type: application/x-turtle"
```

!Note that the resource name ("newdata" here) has to match the `rep:repositoryID` field in the data-config.ttl file :shrug: 

Upload a dataset to the new resource

```
curl -i -X POST http://localhost:7200/repositories/<graph-name>/rdf-graphs/default -H "Content-Type: application/ld+json" --data-binary "@./ds001618.jsonld
```

Run a query against the graph via curl:

```
curl http://localhost:7200/repositories/newdata --data-urlencode query="select * where {?s ?p ?o} limit 10" -H "Accept: application/sparql-results+json"
```