### PR TITLE
Add environment variable for allowed origins for CORS

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -4,6 +4,7 @@ NB_GRAPH_PASSWORD=DBPASSWORD  # REPLACE DBPASSWORD WITH YOUR GRAPH DATABASE PASS
 NB_GRAPH_DB=test_data/query
 NB_RETURN_AGG=true
 NB_API_TAG=latest
+NB_API_ALLOWED_ORIGINS="https://localhost:3000 http://localhost:3000"
 NB_GRAPH_IMG=stardog/stardog:8.2.2-java11-preview
 ## ADDITIONAL CONFIGURABLE PARAMETERS: Uncomment and modify values of the below variables as needed to use non-default values.
 # NB_API_PORT_HOST=8000

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The Neurobagel API is a REST API, developed in [Python](https://www.python.org/)
 - [Quickstart](#quickstart)
 - [Local installation](#local-installation)
     - [Environment variables](#set-the-environment-variables)
+    - [Using a graphical query tool](#using-a-graphical-query-tool-to-send-api-requests)
     - [Docker](#docker)
     - [Python](#python)
 - [Testing](#testing)
@@ -49,26 +50,27 @@ git clone https://github.com/neurobagel/api.git
 ### Set the environment variables
 Create a file called `.env` in the root of the repository will house the environment variables used by the app. 
 
-To run API requests against a graph, at least two environment variables must be set, `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD`.  
+To run API requests against a graph, at least two environment variables must be set, `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD`.
 
 This repository contains a [template `.env` file](/.template-env) that you can copy and edit.
 
 Below are explanations of all the possible Neurobagel environment variables that you can set in `.env`, depending on your mode of installation of the API and graph server software.
-| Environment variable | Required in .env? | Description                                                                                                                              | Default value if not set               | Relevant installation mode(s) |
-| -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------- |
-| `NB_GRAPH_USERNAME`  | Yes               | Username to access Stardog graph database that API will communicate with                                                                 | -                                      | Docker, Python                |
-| `NB_GRAPH_PASSWORD`  | Yes               | Password to access Stardog graph database that API will communicate with                                                                 | -                                      | Docker, Python                |
-| `NB_GRAPH_ADDRESS`   | No                | IP address for the graph database (or container name, if graph is hosted locally)                                                        | `206.12.99.17` (`graph`) **               | Docker, Python                |
-| `NB_GRAPH_DB`        | No                | Name of graph database endpoint to query (e.g., for a Stardog database, this will take the format of `{database_name}/query`)            | `test_data/query`                      | Docker, Python                |
-| `NB_RETURN_AGG`      | No                | Whether to return only dataset-level query results (including data locations) and exclude subject-level attributes. One of [true, false] | `true`                                 | Docker, Python                |
-| `NB_API_TAG`         | No                | Tag for API Docker image                                                                                                                 | `latest`                               | Docker                        |
-| `NB_API_PORT_HOST`   | No                | Port number on the _host machine_ to map the API container port to                                                                       | `8000`                                 | Docker                        |
-| `NB_API_PORT`        | No                | Port number on which to run the API                                                                                                      | `8000`                                 | Docker, Python                |
-| `NB_GRAPH_IMG`       | No                | Graph server Docker image                                                                                                                | `stardog/stardog:8.2.2-java11-preview` | Docker                        |
-| `NB_GRAPH_ROOT_HOST` | No                | Path to directory containing a Stardog license file on the _host machine_                                                                | `~/stardog-home`                       | Docker                        |
-| `NB_GRAPH_ROOT_CONT` | No                | Path to directory for graph databases in the _graph server container_                                                                    | `/var/opt/stardog` *                   | Docker                        |
-| `NB_GRAPH_PORT_HOST` | No                | Port number on the _host machine_ to map the graph server container port to                                                              | `5820`                                 | Docker                        |
-| `NB_GRAPH_PORT`      | No                | Port number used by the _graph server container_                                                                                         | `5820` *                               | Docker, Python                |
+| Environment variable     | Required in .env? | Description                                                                                                                              | Default value if not set               | Relevant installation mode(s) |
+| ------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------- |
+| `NB_GRAPH_USERNAME`      | Yes               | Username to access Stardog graph database that API will communicate with                                                                 | -                                      | Docker, Python                |
+| `NB_GRAPH_PASSWORD`      | Yes               | Password to access Stardog graph database that API will communicate with                                                                 | -                                      | Docker, Python                |
+| `NB_GRAPH_ADDRESS`       | No                | IP address for the graph database (or container name, if graph is hosted locally)                                                        | `206.12.99.17` (`graph`) **            | Docker, Python                |
+| `NB_GRAPH_DB`            | No                | Name of graph database endpoint to query (e.g., for a Stardog database, this will take the format of `{database_name}/query`)            | `test_data/query`                      | Docker, Python                |
+| `NB_RETURN_AGG`          | No                | Whether to return only dataset-level query results (including data locations) and exclude subject-level attributes. One of [true, false] | `true`                                 | Docker, Python                |
+| `NB_API_TAG`             | No                | Tag for API Docker image                                                                                                                 | `latest`                               | Docker                        |
+| `NB_API_PORT_HOST`       | No                | Port number on the _host machine_ to map the API container port to                                                                       | `8000`                                 | Docker                        |
+| `NB_API_PORT`            | No                | Port number on which to run the API                                                                                                      | `8000`                                 | Docker, Python                |
+| `NB_API_ALLOWED_ORIGINS` | Yes, if using a query tool               | Origins allowed to make [cross-origin resource sharing](https://fastapi.tiangolo.com/tutorial/cors/) requests. _At least one origin must be specified to make the API accessible from a frontend query tool._ Multiple origins should be separated with spaces in a single string enclosed in quotes.                                                                                                                                   | `""`                                      | Docker, Python                |
+| `NB_GRAPH_IMG`           | No                | Graph server Docker image                                                                                                                | `stardog/stardog:8.2.2-java11-preview` | Docker                        |
+| `NB_GRAPH_ROOT_HOST`     | No                | Path to directory containing a Stardog license file on the _host machine_                                                                | `~/stardog-home`                       | Docker                        |
+| `NB_GRAPH_ROOT_CONT`     | No                | Path to directory for graph databases in the _graph server container_                                                                    | `/var/opt/stardog` *                   | Docker                        |
+| `NB_GRAPH_PORT_HOST`     | No                | Port number on the _host machine_ to map the graph server container port to                                                              | `5820`                                 | Docker                        |
+| `NB_GRAPH_PORT`          | No                | Port number used by the _graph server container_                                                                                         | `5820` *                               | Docker, Python                |
 
 _* These defaults are configured for a Stardog backend - you should not have to change them if you are running a Stardog backend._
 
@@ -83,6 +85,26 @@ also ensure that any variables defined in your `.env` are not already set in you
 ---
 
 The below instructions for Docker and Python assume that you have at least set `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD` in your `.env`.
+
+### Using a graphical query tool to send API requests
+To make the API accessible by a frontend tool such as our [browser query tool](https://github.com/neurobagel/query-tool), you must explicitly specify the origin(s) for the frontend using `NB_API_ALLOWED_ORIGINS` in `.env` (see also above table). 
+This variable defaults to an empty string (`""`) when unset, meaning that your deployed API will only accessible via direct `curl` requests to the URL where the API is hosted (see [this section](#send-a-test-query-to-the-api) for an example `curl` request).
+
+Note: The `.template-env` file in this repo assumes you want to allow API requests from a query tool hosted at a specific port on `localhost`.
+
+Other examples:
+```bash
+# ---- .env file ----
+
+# do not allow requests from any frontend origins
+NB_API_ALLOWED_ORIGINS=""  # or, exclude variable from .env
+
+# allow requests from only one origin
+NB_API_ALLOWED_ORIGINS="https://query.neurobagel.org"
+
+# allow requests from 3 different origins
+NB_API_ALLOWED_ORIGINS="https://query.neurobagel.org https://localhost:3000 http://localhost:3000"
+```
 
 ### Docker
 First, [install docker](https://docs.docker.com/get-docker/).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ NB_API_ALLOWED_ORIGINS="https://query.neurobagel.org"
 
 # allow requests from 3 different origins
 NB_API_ALLOWED_ORIGINS="https://query.neurobagel.org https://localhost:3000 http://localhost:3000"
+
+# allow requests from any origin - use with caution
+NB_API_ALLOWED_ORIGINS="*"
 ```
 
 ### Docker

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -6,6 +6,11 @@ from typing import Optional
 
 # Request constants
 EnvVar = namedtuple("EnvVar", ["name", "val"])
+
+ALLOWED_ORIGINS = EnvVar(
+    "NB_API_ALLOWED_ORIGINS", os.environ.get("NB_API_ALLOWED_ORIGINS", "")
+)
+
 GRAPH_USERNAME = EnvVar(
     "NB_GRAPH_USERNAME", os.environ.get("NB_GRAPH_USERNAME")
 )
@@ -27,6 +32,7 @@ RETURN_AGG = EnvVar(
 )
 
 QUERY_URL = f"http://{GRAPH_ADDRESS.val}:{GRAPH_PORT.val}/{GRAPH_DB.val}"
+print(QUERY_URL)
 QUERY_HEADER = {
     "Content-Type": "application/sparql-query",
     "Accept": "application/sparql-results+json",
@@ -56,6 +62,11 @@ PROJECT = Domain("project", "nb:hasSamples")
 CATEGORICAL_DOMAINS = [SEX, DIAGNOSIS, IMAGE_MODAL, ASSESSMENT]
 
 IS_CONTROL_TERM = "purl:NCIT_C94342"  # TODO: Remove once https://github.com/neurobagel/bagel-cli/issues/139 is resolved.
+
+
+def parse_origins_as_list(allowed_origins: str) -> list:
+    """Returns user-defined allowed origins as a list."""
+    return list(allowed_origins.split(" "))
 
 
 def create_query(

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ app = FastAPI(default_response_class=ORJSONResponse)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=util.parse_origins_as_list(util.ALLOWED_ORIGINS.val),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 """Main app."""
 
 import os
+import warnings
 
 import uvicorn
 from fastapi import FastAPI
@@ -25,11 +26,23 @@ app.add_middleware(
 async def auth_check():
     """Checks whether username and password environment variables are set."""
     if (
+        # TODO: Check if this error is still raised when variables are empty strings
         os.environ.get(util.GRAPH_USERNAME.name) is None
         or os.environ.get(util.GRAPH_PASSWORD.name) is None
     ):
         raise RuntimeError(
             f"The application was launched but could not find the {util.GRAPH_USERNAME.name} and / or {util.GRAPH_PASSWORD.name} environment variables."
+        )
+
+
+@app.on_event("startup")
+async def allowed_origins_check():
+    """Raises warning if allowed origins environment variable has not been set or is an empty string."""
+    if os.environ.get(util.ALLOWED_ORIGINS.name, "") == "":
+        warnings.warn(
+            f"The API was launched without providing any values for the {util.ALLOWED_ORIGINS.name} environment variable. "
+            f"This means that the API will not be accessible from any origin. To fix this, explicitly set the value of {util.ALLOWED_ORIGINS.name} to at least one origin (e.g. http://localhost:3000). "
+            "Multiple allowed origins should be separated with spaces in a single string enclosed in quotes. "
         )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       NB_GRAPH_DB: ${NB_GRAPH_DB:-test_data/query}
       NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
       NB_API_PORT: ${NB_API_PORT:-8000}
+      NB_API_ALLOWED_ORIGINS: ${NB_API_ALLOWED_ORIGINS}
   graph:
     image: "${NB_GRAPH_IMG:-stardog/stardog:8.2.2-java11-preview}"
     volumes:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,8 @@
 """Test API to query subjects from the Stardog graph who match user-specified criteria."""
 
+import os
+import warnings
+
 import httpx
 import pytest
 from fastapi import HTTPException
@@ -112,6 +115,66 @@ def test_app_with_invalid_environment_vars(test_app, monkeypatch):
     monkeypatch.setattr(httpx, "post", mock_httpx_post)
     response = test_app.get("/query/")
     assert response.status_code == 401
+
+
+def test_app_with_unset_allowed_origins(test_app, monkeypatch):
+    """Tests that when the environment variable for allowed origins has not been set, a warning is raised and the app uses a default value."""
+    monkeypatch.delenv(util.ALLOWED_ORIGINS.name, raising=False)
+
+    with pytest.warns(
+        UserWarning,
+        match=f"API was launched without providing any values for the {util.ALLOWED_ORIGINS.name} environment variable",
+    ):
+        with test_app:
+            pass
+
+    assert util.parse_origins_as_list(
+        os.environ.get(util.ALLOWED_ORIGINS.name, "")
+    ) == [""]
+
+
+@pytest.mark.parametrize(
+    "allowed_origins, parsed_origins, expectation",
+    [
+        (
+            "",
+            [""],
+            pytest.warns(
+                UserWarning,
+                match=f"API was launched without providing any values for the {util.ALLOWED_ORIGINS.name} environment variable",
+            ),
+        ),
+        (
+            "http://localhost:3000",
+            ["http://localhost:3000"],
+            warnings.catch_warnings(),
+        ),
+        (
+            "http://localhost:3000 https://localhost:3000",
+            ["http://localhost:3000", "https://localhost:3000"],
+            warnings.catch_warnings(),
+        ),
+    ],
+)
+def test_app_with_set_allowed_origins(
+    test_app, monkeypatch, allowed_origins, parsed_origins, expectation
+):
+    """
+    Test that when the environment variable for allowed origins has been explicitly set, the app correctly parses it into a list
+    and raises a warning if the value is an empty string.
+    """
+    monkeypatch.setenv(util.ALLOWED_ORIGINS.name, allowed_origins)
+
+    with expectation:
+        with test_app:
+            pass
+
+    assert (
+        util.parse_origins_as_list(
+            os.environ.get(util.ALLOWED_ORIGINS.name, "")
+        )
+        == parsed_origins
+    )
 
 
 def test_get_all(test_app, mock_successful_get, monkeypatch):


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #150

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- New environment variable `NB_API_ALLOWED_ORIGINS` replaces hard-coded wildcard allowing all origins for CORS
  - default value is an empty string
- Add utility function to parse origins into a list
- Raise warning if no allowed origins are specified
- Tests added that specified origins are parsed correctly + warning raised appropriately

<!-- To be checked off by reviewers -->
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
