### PR TITLE
[ENH] Add endpoint returning queryable attributes + refine existing endpoint for attribute instances

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -235,11 +235,9 @@ async def get_controlled_term_attributes():
         )
 
     results = response.json()
-    results_dict = {
-        "nb:ControlledTerm": [
-            result["attribute"]["value"]
-            for result in results["results"]["bindings"]
-        ]
-    }
+    results_list = [
+        result["attribute"]["value"]
+        for result in results["results"]["bindings"]
+    ]
 
-    return results_dict
+    return results_list

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -192,7 +192,7 @@ async def get_terms(data_element_URI: str):
 
     results_dict = {
         data_element_URI: [
-            result["termURL"]["value"]
+            util.replace_namespace_uri(result["termURL"]["value"])
             for result in results["results"]["bindings"]
         ]
     }
@@ -236,7 +236,7 @@ async def get_controlled_term_attributes():
 
     results = response.json()
     results_list = [
-        result["attribute"]["value"]
+        util.replace_namespace_uri(result["attribute"]["value"])
         for result in results["results"]["bindings"]
     ]
 

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -1,8 +1,18 @@
 from fastapi import APIRouter
+from pydantic import constr
 
 from .. import crud
+from ..models import CONTROLLED_TERM_REGEX
 
 router = APIRouter(prefix="/attributes", tags=["attributes"])
+
+
+@router.get("/{data_element_URI}")
+async def get_terms(data_element_URI: constr(regex=CONTROLLED_TERM_REGEX)):
+    """When a GET request is sent, return a dict with the only key corresponding to controlled term of a neurobagel class and value corresponding to all the available terms."""
+    response = await crud.get_terms(data_element_URI)
+
+    return response
 
 
 @router.get("/", response_model=dict)

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -15,9 +15,9 @@ async def get_terms(data_element_URI: constr(regex=CONTROLLED_TERM_REGEX)):
     return response
 
 
-@router.get("/", response_model=dict)
+@router.get("/", response_model=list)
 async def get_attributes():
-    """When a GET request is sent, return a dict containing a list of the harmonized controlled term attributes."""
+    """When a GET request is sent, return a list of the harmonized controlled term attributes."""
     response = await crud.get_controlled_term_attributes()
 
     return response

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from .. import crud
+
+router = APIRouter(prefix="/attributes", tags=["attributes"])
+
+
+@router.get("/", response_model=dict)
+async def get_attributes():
+    """When a GET request is sent, return a dict containing a list of the harmonized controlled term attributes."""
+    response = await crud.get_controlled_term_attributes()
+
+    return response

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -3,10 +3,9 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
-from pydantic import constr
 
 from .. import crud
-from ..models import CONTROLLED_TERM_REGEX, CohortQueryResponse, QueryModel
+from ..models import CohortQueryResponse, QueryModel
 
 router = APIRouter(prefix="/query", tags=["query"])
 
@@ -24,13 +23,5 @@ async def get_query(query: QueryModel = Depends(QueryModel)):
         query.assessment,
         query.image_modal,
     )
-
-    return response
-
-
-@router.get("/attributes/{data_element_URI}")
-async def get_terms(data_element_URI: constr(regex=CONTROLLED_TERM_REGEX)):
-    """When a GET request is sent, return a dict with the only key corresponding to controlled term of a neurobagel class and value corresponding to all the available terms."""
-    response = await crud.get_terms(data_element_URI)
 
     return response

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -38,6 +38,7 @@ QUERY_HEADER = {
 }
 
 # SPARQL query context
+# TODO: Refactor into a function.
 DEFAULT_CONTEXT = """
 PREFIX cogatlas: <https://www.cognitiveatlas.org/task/id/>
 PREFIX nb: <http://neurobagel.org/vocab/>
@@ -46,6 +47,15 @@ PREFIX ncit: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
 PREFIX nidm: <http://purl.org/nidash/nidm#>
 PREFIX snomed: <http://purl.bioontology.org/ontology/SNOMEDCT/>
 """
+
+CONTEXT = {
+    "cogatlas": "https://www.cognitiveatlas.org/task/id/",
+    "nb": "http://neurobagel.org/vocab/",
+    "nbg": "http://neurobagel.org/graph/",  # TODO: Check if we still need this namespace.
+    "ncit": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#",
+    "nidm": "http://purl.org/nidash/nidm#",
+    "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+}
 
 # Store domains in named tuples
 Domain = namedtuple("Domain", ["var", "pred"])
@@ -234,3 +244,25 @@ def create_terms_query(data_element_URI: str) -> str:
     """
 
     return "\n".join([DEFAULT_CONTEXT, query_string])
+
+
+def replace_namespace_uri(url: str) -> str:
+    """
+    Replaces namespace URIs in term URLs with corresponding prefixes from the context.
+
+    Parameters
+    ----------
+    url : str
+        A controlled term URL.
+
+    Returns
+    -------
+    str
+        The term with namespace URIs replaced with prefixes if found in the context, or the original URL.
+    """
+    for prefix, uri in CONTEXT.items():
+        if uri in url:
+            return url.replace(uri, f"{prefix}:")
+
+    # If no match found within the context, return original URL
+    return url

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -219,6 +219,7 @@ def create_terms_query(data_element_URI: str) -> str:
     -------
     str
         The SPARQL query.
+
     Examples
     --------
     get_terms_query("nb:Assessment")
@@ -227,7 +228,8 @@ def create_terms_query(data_element_URI: str) -> str:
     query_string = f"""
     SELECT DISTINCT ?termURL
     WHERE {{
-        ?termURL a {data_element_URI}.
+        ?termURL a {data_element_URI} .
+        {data_element_URI} rdfs:subClassOf nb:ControlledTerm .
     }}
     """
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 
 from .api import utility as util
-from .api.routers import query
+from .api.routers import attributes, query
 
 app = FastAPI(default_response_class=ORJSONResponse)
 
@@ -48,6 +48,7 @@ async def allowed_origins_check():
 
 
 app.include_router(query.router)
+app.include_router(attributes.router)
 
 # Automatically start uvicorn server on execution of main.py
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,11 +106,11 @@ def terms_test_data():
     """Create toy data for terms for testing."""
     return {
         "nb:NeurobagelClass": [
-            "http://neurobagel.org/vocab/term1",
-            "http://neurobagel.org/vocab/term2",
-            "http://neurobagel.org/vocab/term3",
-            "http://neurobagel.org/vocab/term4",
-            "http://neurobagel.org/vocab/term5",
+            "nb:term1",
+            "nb:term2",
+            "nb:term3",
+            "nb:term4",
+            "nb:term5",
         ]
     }
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -429,7 +429,7 @@ def test_get_attributes(
     test_app,
     monkeypatch,
 ):
-    """Tests that a GET request to the /attributes/ endpoint successfully returns controlled term attributes as a list."""
+    """Given a GET request to the /attributes/ endpoint, successfully returns controlled term attributes with namespaces abbrieviated and as a list."""
 
     monkeypatch.setenv(util.GRAPH_USERNAME.name, "SomeUser")
     monkeypatch.setenv(util.GRAPH_PASSWORD.name, "SomePassword")
@@ -438,9 +438,24 @@ def test_get_attributes(
         "head": {"vars": ["attribute"]},
         "results": {
             "bindings": [
-                {"attribute": {"type": "uri", "value": "nb:ControlledTerm1"}},
-                {"attribute": {"type": "uri", "value": "nb:ControlledTerm2"}},
-                {"attribute": {"type": "uri", "value": "nb:ControlledTerm3"}},
+                {
+                    "attribute": {
+                        "type": "uri",
+                        "value": "http://neurobagel.org/vocab/ControlledTerm1",
+                    }
+                },
+                {
+                    "attribute": {
+                        "type": "uri",
+                        "value": "http://neurobagel.org/vocab/ControlledTerm2",
+                    }
+                },
+                {
+                    "attribute": {
+                        "type": "uri",
+                        "value": "http://neurobagel.org/vocab/ControlledTerm3",
+                    }
+                },
             ]
         },
     }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -406,7 +406,7 @@ def test_get_terms_valid_data_element_URI(
     """Given a valid data element URI, returns a 200 status code and a non-empty list of terms for that data element."""
 
     monkeypatch.setattr(crud, "get_terms", mock_successful_get_terms)
-    response = test_app.get(f"/query/attributes/{valid_data_element_URI}")
+    response = test_app.get(f"/attributes/{valid_data_element_URI}")
     assert response.status_code == 200
     first_key = next(iter(response.json()))
     assert response.json()[first_key] != []
@@ -417,9 +417,9 @@ def test_get_terms_valid_data_element_URI(
     ["apple", "some_thing:cool"],
 )
 def test_get_terms_invalid_data_element_URI(
-    test_app, invalid_data_element_URI, monkeypatch
+    test_app, invalid_data_element_URI
 ):
     """Given an invalid data element URI, returns a 422 status code as the validation of the data element URI fails."""
 
-    response = test_app.get(f"/query/attributes/{invalid_data_element_URI}")
+    response = test_app.get(f"/attributes/{invalid_data_element_URI}")
     assert response.status_code == 422


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #176 
Closes #186 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- New router created for paths under the `/attributes` prefix
  - Existing endpoint for terms discovery: also moved under this prefix, i.e. `/attributes/{data_element_URI}`
- New endpoint created that returns all subclasses of `nb:ControlledTerm`
- Query string for existing terms discovery endpoint updated to return URIs for only instances of controlled term subclasses
- Helper function added to abbreviate namespaces in term URLs from the graph (e.g., `"http://neurobagel.org/vocab/Diagnosis"` -> `"nb:Diagnosis"`)

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
