### PR TITLE
[ENH] Add support for endpoint that will return `nb:Diagnosis` options from SNOMED

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,10 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+      - id: pretty-format-json
+        args: 
+          - "--autofix"
+          - "--no-sort-keys"
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -275,11 +275,11 @@ async def get_controlled_term_attributes() -> list:
     return results_list
 
 
-async def get_term_labels_for_cogatlas(
-    term_labels_path: Path,
+async def get_term_labels_for_vocab(
+    term_labels_path: Path, vocabulary_name: str, namespace_prefix: str
 ) -> VocabLabelsResponse:
     """
-    Returns the term-label mappings along with the vocabulary namespace details for the Cognitive Atlas Task vocabulary.
+    Returns the term-label mappings along with the vocabulary namespace details for the specified vocabulary.
 
     Returns
     -------
@@ -288,8 +288,8 @@ async def get_term_labels_for_cogatlas(
     term_labels = util.load_json(term_labels_path)
 
     return VocabLabelsResponse(
-        vocabulary_name="Cognitive Atlas Tasks",
-        namespace_url=util.CONTEXT["cogatlas"],
-        namespace_prefix="cogatlas",
+        vocabulary_name=vocabulary_name,
+        namespace_url=util.CONTEXT[namespace_prefix],
+        namespace_prefix=namespace_prefix,
         term_labels=term_labels,
     )

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -69,6 +69,7 @@ class DataElementURI(str, Enum):
     """Data model for data element URIs that have available vocabulary lookups."""
 
     assessment = "nb:Assessment"
+    diagnosis = "nb:Diagnosis"
 
 
 class VocabLabelsResponse(BaseModel):

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -13,9 +13,18 @@ async def get_term_labels_for_vocab(
 ):
     """When a GET request is sent, return a dict containing the name, namespace info, and all term ID-label mappings for the vocabulary of the specified variable."""
     if data_element_URI is DataElementURI.assessment:
-        return await crud.get_term_labels_for_cogatlas(
-            term_labels_path=request.app.state.cogatlas_term_lookup_path
+        return await crud.get_term_labels_for_vocab(
+            term_labels_path=request.app.state.cogatlas_term_lookup_path,
+            vocabulary_name="Cognitive Atlas Tasks",
+            namespace_prefix="cogatlas",
         )
+    else:
+        if data_element_URI is DataElementURI.diagnosis:
+            return await crud.get_term_labels_for_vocab(
+                term_labels_path=request.app.state.snomed_term_lookup_path,
+                vocabulary_name="SNOMED CT",
+                namespace_prefix="snomed",
+            )
 
 
 @router.get("/{data_element_URI}")

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -12,14 +12,14 @@ async def get_term_labels_for_vocab(
     data_element_URI: DataElementURI, request: Request
 ):
     """When a GET request is sent, return a dict containing the name, namespace info, and all term ID-label mappings for the vocabulary of the specified variable."""
-    if data_element_URI is DataElementURI.assessment:
+    if data_element_URI == DataElementURI.assessment:
         return await crud.get_term_labels_for_vocab(
             term_labels_path=request.app.state.cogatlas_term_lookup_path,
             vocabulary_name="Cognitive Atlas Tasks",
             namespace_prefix="cogatlas",
         )
     else:
-        if data_element_URI is DataElementURI.diagnosis:
+        if data_element_URI == DataElementURI.diagnosis:
             return await crud.get_term_labels_for_vocab(
                 term_labels_path=request.app.state.snomed_term_lookup_path,
                 vocabulary_name="SNOMED CT",
@@ -39,6 +39,9 @@ async def get_terms(
 
     if data_element_URI == DataElementURI.assessment:
         term_labels_path = request.app.state.cogatlas_term_lookup_path
+    else:
+        if data_element_URI == DataElementURI.diagnosis:
+            term_labels_path = request.app.state.snomed_term_lookup_path
 
     return await crud.get_terms(data_element_URI, term_labels_path)
 

--- a/app/api/routers/attributes.py
+++ b/app/api/routers/attributes.py
@@ -12,19 +12,19 @@ async def get_term_labels_for_vocab(
     data_element_URI: DataElementURI, request: Request
 ):
     """When a GET request is sent, return a dict containing the name, namespace info, and all term ID-label mappings for the vocabulary of the specified variable."""
+    # TODO: If/when more attribute options are supported, consider refactoring to use match/case (see https://peps.python.org/pep-0634/#the-match-statement)
     if data_element_URI == DataElementURI.assessment:
         return await crud.get_term_labels_for_vocab(
             term_labels_path=request.app.state.cogatlas_term_lookup_path,
             vocabulary_name="Cognitive Atlas Tasks",
             namespace_prefix="cogatlas",
         )
-    else:
-        if data_element_URI == DataElementURI.diagnosis:
-            return await crud.get_term_labels_for_vocab(
-                term_labels_path=request.app.state.snomed_term_lookup_path,
-                vocabulary_name="SNOMED CT",
-                namespace_prefix="snomed",
-            )
+    if data_element_URI == DataElementURI.diagnosis:
+        return await crud.get_term_labels_for_vocab(
+            term_labels_path=request.app.state.snomed_term_lookup_path,
+            vocabulary_name="SNOMED CT",
+            namespace_prefix="snomed",
+        )
 
 
 @router.get("/{data_element_URI}")
@@ -37,11 +37,11 @@ async def get_terms(
     """
     term_labels_path = None
 
+    # TODO: If/when more attribute options are supported, consider refactoring to use match/case (see https://peps.python.org/pep-0634/#the-match-statement)
     if data_element_URI == DataElementURI.assessment:
         term_labels_path = request.app.state.cogatlas_term_lookup_path
-    else:
-        if data_element_URI == DataElementURI.diagnosis:
-            term_labels_path = request.app.state.snomed_term_lookup_path
+    if data_element_URI == DataElementURI.diagnosis:
+        term_labels_path = request.app.state.snomed_term_lookup_path
 
     return await crud.get_terms(data_element_URI, term_labels_path)
 

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -369,7 +369,7 @@ def fetch_and_save_cogatlas(output_path: Path):
     Fetches the Cognitive Atlas vocabulary using its native Task API and writes term ID-label mappings to a temporary lookup file.
     If the API request fails, a backup copy of the vocabulary is used instead.
 
-    Saves a JSON with keys corresponding to Cognitive Atlas task IDs and values corresponding to human-readable task names).
+    Saves a JSON with keys corresponding to Cognitive Atlas task IDs and values corresponding to human-readable task names.
 
     Parameters
     ----------
@@ -403,7 +403,7 @@ def create_snomed_term_lookup(output_path: Path):
     """
     Reads in a file of disorder terms from the SNOMED CT vocabulary and writes term ID-label mappings to a temporary lookup file.
 
-    Saves a JSON with keys corresponding to Cognitive Atlas task IDs and values corresponding to human-readable task names).
+    Saves a JSON with keys corresponding to SNOMED CT IDs and values corresponding to human-readable term names.
 
     Parameters
     ----------

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -397,3 +397,21 @@ def fetch_and_save_cogatlas(output_path: Path):
     term_labels = {term["id"]: term["name"] for term in vocab}
     with open(output_path, "w") as f:
         f.write(json.dumps(term_labels, indent=2))
+
+
+def create_snomed_term_lookup(output_path: Path):
+    """
+    Reads in a file of disorder terms from the SNOMED CT vocabulary and writes term ID-label mappings to a temporary lookup file.
+
+    Saves a JSON with keys corresponding to Cognitive Atlas task IDs and values corresponding to human-readable task names).
+
+    Parameters
+    ----------
+    output_path : Path
+        File path to store output vocabulary lookup file.
+    """
+    vocab = load_json(BACKUP_VOCAB_DIR / "snomedct_disorder.json")
+
+    term_labels = {term["sctid"]: term["preferred_name"] for term in vocab}
+    with open(output_path, "w") as f:
+        f.write(json.dumps(term_labels, indent=2))

--- a/app/main.py
+++ b/app/main.py
@@ -97,11 +97,16 @@ async def fetch_vocabularies_to_temp_dir():
     app.state.vocab_dir = TemporaryDirectory()
     app.state.vocab_dir_path = Path(app.state.vocab_dir.name)
 
+    # TODO: Maybe store these paths in a dictionary instead?
     app.state.cogatlas_term_lookup_path = (
         app.state.vocab_dir_path / "cogatlas_task_term_labels.json"
     )
+    app.state.snomed_term_lookup_path = (
+        app.state.vocab_dir_path / "snomedct_disorder_term_labels.json"
+    )
 
     util.fetch_and_save_cogatlas(app.state.cogatlas_term_lookup_path)
+    util.create_snomed_term_lookup(app.state.snomed_term_lookup_path)
 
 
 @app.on_event("shutdown")

--- a/app/main.py
+++ b/app/main.py
@@ -97,7 +97,7 @@ async def fetch_vocabularies_to_temp_dir():
     app.state.vocab_dir = TemporaryDirectory()
     app.state.vocab_dir_path = Path(app.state.vocab_dir.name)
 
-    # TODO: Maybe store these paths in a dictionary instead?
+    # TODO: Maybe store these paths in one dictionary on the app instance instead of separate variables?
     app.state.cogatlas_term_lookup_path = (
         app.state.vocab_dir_path / "cogatlas_task_term_labels.json"
     )

--- a/tests/test_app_events.py
+++ b/tests/test_app_events.py
@@ -164,7 +164,7 @@ def test_failed_vocab_fetching_on_startup_raises_warning(
     test_app, monkeypatch, set_test_credentials
 ):
     """
-    Tests that when a GET request to the Cognitive Atlas API fails (e.g., due to service being unavailable),
+    Tests that when a GET request to the Cognitive Atlas API has a non-success response code (e.g., due to service being unavailable),
     a warning is raised and that a term label lookup file is still created using a backup copy of the vocab.
     """
 
@@ -183,4 +183,26 @@ def test_failed_vocab_fetching_on_startup_raises_warning(
         "unable to fetch the Cognitive Atlas task vocabulary (https://www.cognitiveatlas.org/tasks/a/) from the source and will default to using a local backup copy"
         in str(warn.message)
         for warn in w
+    )
+
+
+def test_network_error_on_startup_raises_warning(
+    test_app, monkeypatch, set_test_credentials
+):
+    """
+    Tests that when a GET request to the Cognitive Atlas API fails due to a network error (i.e., while issuing the request),
+    a warning is raised and that a term label lookup file is still created using a backup copy of the vocab.
+    """
+
+    def mock_httpx_get(**kwargs):
+        raise httpx.ConnectError("Some network error")
+
+    monkeypatch.setattr(httpx, "get", mock_httpx_get)
+
+    with pytest.warns(UserWarning) as w:
+        with test_app:
+            assert test_app.app.state.cogatlas_term_lookup_path.exists()
+
+    assert any(
+        "failed due to a network error" in str(warn.message) for warn in w
     )

--- a/tests/test_app_events.py
+++ b/tests/test_app_events.py
@@ -108,6 +108,16 @@ def test_app_with_set_allowed_origins(
     )
 
 
+def test_stored_vocab_lookup_file_created_on_startup(
+    test_app, set_test_credentials
+):
+    """Test that on startup, a non-empty temporary lookup file is created for term ID-label mappings for the locally stored SNOMED CT vocabulary."""
+    with test_app:
+        term_labels_path = test_app.app.state.snomed_term_lookup_path
+        assert term_labels_path.exists()
+        assert term_labels_path.stat().st_size > 0
+
+
 def test_external_vocab_is_fetched_on_startup(
     test_app, monkeypatch, set_test_credentials
 ):

--- a/vocab/backup_external/snomedct_disorder.json
+++ b/vocab/backup_external/snomedct_disorder.json
@@ -1,0 +1,27210 @@
+[
+  {
+    "sctid": "10007009",
+    "preferred_name": "Coffin-Siris syndrome"
+  },
+  {
+    "sctid": "1003374009",
+    "preferred_name": "Microlissencephaly"
+  },
+  {
+    "sctid": "1003378007",
+    "preferred_name": "Optic nerve hypoplasia due to endocrine deficiency"
+  },
+  {
+    "sctid": "1003380001",
+    "preferred_name": "6q16 microdeletion syndrome"
+  },
+  {
+    "sctid": "1003422005",
+    "preferred_name": "Hypoplasia of optic nerve due to central nervous system malformation"
+  },
+  {
+    "sctid": "1003429001",
+    "preferred_name": "Focal cortical dysplasia type IIa"
+  },
+  {
+    "sctid": "1003430006",
+    "preferred_name": "Focal cortical dysplasia type IIb"
+  },
+  {
+    "sctid": "1003434002",
+    "preferred_name": "Lipoma due to neurospinal dysraphism"
+  },
+  {
+    "sctid": "1003444000",
+    "preferred_name": "Type 3 lissencephaly"
+  },
+  {
+    "sctid": "1003445004",
+    "preferred_name": "Lumbosacral spina bifida aperta with hydrocephalus"
+  },
+  {
+    "sctid": "1003447007",
+    "preferred_name": "Pelizaeus-Merzbacher disease null syndrome"
+  },
+  {
+    "sctid": "1003448002",
+    "preferred_name": "Lumbosacral spina bifida aperta"
+  },
+  {
+    "sctid": "1003461002",
+    "preferred_name": "Focal cortical dysplasia type II"
+  },
+  {
+    "sctid": "1003462009",
+    "preferred_name": "Focal cortical dysplasia type Ib"
+  },
+  {
+    "sctid": "1003463004",
+    "preferred_name": "Focal cortical dysplasia type I"
+  },
+  {
+    "sctid": "1003464005",
+    "preferred_name": "Focal cortical dysplasia type Ia"
+  },
+  {
+    "sctid": "1003465006",
+    "preferred_name": "Familial spinal neurofibromatosis"
+  },
+  {
+    "sctid": "1003584006",
+    "preferred_name": "Hind brain laceration with open intracranial wound and loss of consciousness"
+  },
+  {
+    "sctid": "1003881009",
+    "preferred_name": "Pelizaeus-Merzbacher disease in female carrier"
+  },
+  {
+    "sctid": "100491000119103",
+    "preferred_name": "Myelopathy due to spinal stenosis of lumbar region"
+  },
+  {
+    "sctid": "100511000119108",
+    "preferred_name": "Myelopathy co-occurrent and due to spinal stenosis of thoracic region"
+  },
+  {
+    "sctid": "10068001",
+    "preferred_name": "Sensory somatic cortical disorder"
+  },
+  {
+    "sctid": "100721000119109",
+    "preferred_name": "High grade astrocytoma of brain"
+  },
+  {
+    "sctid": "100731000119107",
+    "preferred_name": "Low grade astrocytoma of brain"
+  },
+  {
+    "sctid": "10082001",
+    "preferred_name": "Progressive rubella panencephalitis"
+  },
+  {
+    "sctid": "100941000119100",
+    "preferred_name": "Epilepsy in mother complicating pregnancy"
+  },
+  {
+    "sctid": "1010464002",
+    "preferred_name": "Agenesis of right hemisphere of cerebellum"
+  },
+  {
+    "sctid": "1010465001",
+    "preferred_name": "Agenesis of left hemisphere of cerebellum"
+  },
+  {
+    "sctid": "1010604007",
+    "preferred_name": "Ventriculomegaly due to developmental anomaly"
+  },
+  {
+    "sctid": "1010630006",
+    "preferred_name": "X-linked complicated corpus callosum dysgenesis"
+  },
+  {
+    "sctid": "1010642001",
+    "preferred_name": "Sporadic infantile bilateral striatal necrosis"
+  },
+  {
+    "sctid": "1010643006",
+    "preferred_name": "Thoracolumbosacral spina bifida aperta"
+  },
+  {
+    "sctid": "1010644000",
+    "preferred_name": "Spina bifida aperta of upper thoracic spine"
+  },
+  {
+    "sctid": "1010663004",
+    "preferred_name": "Subcortical nodular heterotopia"
+  },
+  {
+    "sctid": "101421000119107",
+    "preferred_name": "Dementia due to Parkinson's disease"
+  },
+  {
+    "sctid": "101571000119107",
+    "preferred_name": "Ependymoma of cerebrum"
+  },
+  {
+    "sctid": "10211000132109",
+    "preferred_name": "Perinatal depression"
+  },
+  {
+    "sctid": "10277002",
+    "preferred_name": "Cerebellopontine angle syndrome"
+  },
+  {
+    "sctid": "10278007",
+    "preferred_name": "Factitious purpura"
+  },
+  {
+    "sctid": "10310006",
+    "preferred_name": "Open fracture of C1-C4 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "10327003",
+    "preferred_name": "Cocaine-induced mood disorder"
+  },
+  {
+    "sctid": "1032761000000105",
+    "preferred_name": "Intraventricular (nontraumatic) haemorrhage, grade 4, of fetus and newborn"
+  },
+  {
+    "sctid": "10340008",
+    "preferred_name": "Isolated gonadotropin deficiency"
+  },
+  {
+    "sctid": "10349009",
+    "preferred_name": "Multi-infarct dementia with delirium"
+  },
+  {
+    "sctid": "103931000119102",
+    "preferred_name": "Hepatic coma due to hepatitis"
+  },
+  {
+    "sctid": "10394003",
+    "preferred_name": "Friedreich's ataxia"
+  },
+  {
+    "sctid": "104431000119107",
+    "preferred_name": "Lipomyelomeningocele"
+  },
+  {
+    "sctid": "10481000119108",
+    "preferred_name": "Colloid brain cyst"
+  },
+  {
+    "sctid": "104851000119103",
+    "preferred_name": "Postpartum major depression in remission"
+  },
+  {
+    "sctid": "10491005",
+    "preferred_name": "Herpes zoster with meningitis"
+  },
+  {
+    "sctid": "104981000119104",
+    "preferred_name": "Oligodendroglioma of cerebrum"
+  },
+  {
+    "sctid": "1052243006",
+    "preferred_name": "Hemiparesis of left side of face"
+  },
+  {
+    "sctid": "1052244000",
+    "preferred_name": "Hemiparesis of right side of face"
+  },
+  {
+    "sctid": "1052326006",
+    "preferred_name": "Rachischisis partialis"
+  },
+  {
+    "sctid": "10532003",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset, with depression"
+  },
+  {
+    "sctid": "105421000119105",
+    "preferred_name": "Early onset Alzheimer's disease with behavioral disturbance"
+  },
+  {
+    "sctid": "105451000119102",
+    "preferred_name": "Amnestic disorder associated with general medical condition"
+  },
+  {
+    "sctid": "10575009",
+    "preferred_name": "Open fracture of vertebral column with spinal cord injury"
+  },
+  {
+    "sctid": "10586006",
+    "preferred_name": "Occupation-related stress disorder"
+  },
+  {
+    "sctid": "106015009",
+    "preferred_name": "Mental disorder AND/OR culture bound syndrome"
+  },
+  {
+    "sctid": "106018006",
+    "preferred_name": "Hereditary degenerative disease of central nervous system"
+  },
+  {
+    "sctid": "106021000119105",
+    "preferred_name": "Multi-infarct dementia due to atherosclerosis"
+  },
+  {
+    "sctid": "106071000119106",
+    "preferred_name": "Secondary hypothalamic insufficiency"
+  },
+  {
+    "sctid": "10649000",
+    "preferred_name": "Hyperpituitarism"
+  },
+  {
+    "sctid": "10651001",
+    "preferred_name": "Temporal lobectomy behavior syndrome"
+  },
+  {
+    "sctid": "1067201000000106",
+    "preferred_name": "Eating disorder co-occurrent with diabetes mellitus type 1"
+  },
+  {
+    "sctid": "10677711000119101",
+    "preferred_name": "Encephalopathy due to Influenza A virus"
+  },
+  {
+    "sctid": "10701000119109",
+    "preferred_name": "Refractory complex partial seizure with impairment of consciousness"
+  },
+  {
+    "sctid": "10706006",
+    "preferred_name": "Tuberculosis of central nervous system"
+  },
+  {
+    "sctid": "10736002",
+    "preferred_name": "Isolated thyroliberin deficiency"
+  },
+  {
+    "sctid": "10741871000119101",
+    "preferred_name": "Alcohol dependence in pregnancy"
+  },
+  {
+    "sctid": "10743001000119103",
+    "preferred_name": "Anxiety disorder in mother complicating childbirth"
+  },
+  {
+    "sctid": "10749811000119108",
+    "preferred_name": "Obstetric anesthesia with central nervous system complication in childbirth"
+  },
+  {
+    "sctid": "10750951000119106",
+    "preferred_name": "Epilepsy in mother complicating childbirth"
+  },
+  {
+    "sctid": "10752641000119102",
+    "preferred_name": "Eclampsia with pre-existing hypertension in childbirth"
+  },
+  {
+    "sctid": "10755041000119100",
+    "preferred_name": "Alcohol dependence in childbirth"
+  },
+  {
+    "sctid": "107557061000119108",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral anterior cerebral arteries"
+  },
+  {
+    "sctid": "107561000119107",
+    "preferred_name": "Ependymoma of brain stem"
+  },
+  {
+    "sctid": "107571000119101",
+    "preferred_name": "Oligodendroglioma of brain stem"
+  },
+  {
+    "sctid": "107581000119103",
+    "preferred_name": "Astrocytoma of brain stem"
+  },
+  {
+    "sctid": "10760421000119102",
+    "preferred_name": "Psychotic disorder in mother complicating childbirth"
+  },
+  {
+    "sctid": "10760461000119107",
+    "preferred_name": "Psychotic disorder in mother complicating pregnancy"
+  },
+  {
+    "sctid": "1078001000000105",
+    "preferred_name": "Haemorrhagic stroke"
+  },
+  {
+    "sctid": "10783000",
+    "preferred_name": "Symptomatic pedophilia"
+  },
+  {
+    "sctid": "10811121000119102",
+    "preferred_name": "Major depressive disorder in mother complicating childbirth"
+  },
+  {
+    "sctid": "10811161000119107",
+    "preferred_name": "Major depressive disorder in mother complicating pregnancy"
+  },
+  {
+    "sctid": "10811201000119102",
+    "preferred_name": "Mental disorder in mother complicating childbirth"
+  },
+  {
+    "sctid": "1082451000119102",
+    "preferred_name": "Encephalitis due to Actinomyces"
+  },
+  {
+    "sctid": "1082511000119102",
+    "preferred_name": "Hepatic coma due to acute hepatic failure"
+  },
+  {
+    "sctid": "1082621000119108",
+    "preferred_name": "Hepatic coma due to alcoholic liver failure"
+  },
+  {
+    "sctid": "10835871000119104",
+    "preferred_name": "Depressive disorder in mother complicating childbirth"
+  },
+  {
+    "sctid": "1084061000000106",
+    "preferred_name": "Depressive personality disorder"
+  },
+  {
+    "sctid": "1084741000119103",
+    "preferred_name": "Meningoencephalitis due to Blastomyces dermatitidis"
+  },
+  {
+    "sctid": "1084801000119107",
+    "preferred_name": "Meningitis due to Sporothrix schenkii"
+  },
+  {
+    "sctid": "1085091000119108",
+    "preferred_name": "Hepatic coma due to chronic hepatic failure"
+  },
+  {
+    "sctid": "1085361000119104",
+    "preferred_name": "Meningitis due to Cytomegaloviral Mononucleosis"
+  },
+  {
+    "sctid": "1086061000119109",
+    "preferred_name": "Diphtheria radiculomyelitis"
+  },
+  {
+    "sctid": "1086471000000103",
+    "preferred_name": "Recurrent reactive depressive episodes, severe, with psychosis"
+  },
+  {
+    "sctid": "1086661000000108",
+    "preferred_name": "Reactive depression, prolonged single episode"
+  },
+  {
+    "sctid": "1086671000000101",
+    "preferred_name": "Reactive depression, single episode"
+  },
+  {
+    "sctid": "1086681000000104",
+    "preferred_name": "Reactive depression, recurrent"
+  },
+  {
+    "sctid": "1086691000000102",
+    "preferred_name": "Reactive depression, first episode"
+  },
+  {
+    "sctid": "1086991000119103",
+    "preferred_name": "Gonococcal abscess of brain"
+  },
+  {
+    "sctid": "1087451000000109",
+    "preferred_name": "Late onset alcohol-induced psychosis"
+  },
+  {
+    "sctid": "1087461000000107",
+    "preferred_name": "Late onset substance-induced psychosis"
+  },
+  {
+    "sctid": "1087471000000100",
+    "preferred_name": "Late onset substance-induced psychiatric disorder"
+  },
+  {
+    "sctid": "1087481000000103",
+    "preferred_name": "Late onset cocaine-induced psychosis"
+  },
+  {
+    "sctid": "1087491000000101",
+    "preferred_name": "Late onset LSD (lysergic acid diethylamide)-induced psychosis"
+  },
+  {
+    "sctid": "10875004",
+    "preferred_name": "Severe mixed bipolar I disorder with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "1087501000000107",
+    "preferred_name": "Late onset cannabinoid-induced psychosis"
+  },
+  {
+    "sctid": "1087511000000109",
+    "preferred_name": "Late onset amphetamine-induced psychosis"
+  },
+  {
+    "sctid": "1089411000000104",
+    "preferred_name": "Cerebral infarction due to occlusion of cerebral artery"
+  },
+  {
+    "sctid": "1089421000000105",
+    "preferred_name": "Cerebral infarction due to stenosis of cerebral artery"
+  },
+  {
+    "sctid": "1089481000000106",
+    "preferred_name": "Cataleptic schizophrenia"
+  },
+  {
+    "sctid": "1089501000000102",
+    "preferred_name": "Presenile dementia with psychosis"
+  },
+  {
+    "sctid": "1089511000000100",
+    "preferred_name": "Recurrent depression with current severe episode and psychotic features"
+  },
+  {
+    "sctid": "1089521000000106",
+    "preferred_name": "Predominantly cortical dementia"
+  },
+  {
+    "sctid": "1089531000000108",
+    "preferred_name": "Predominantly cortical vascular dementia"
+  },
+  {
+    "sctid": "1089631000000109",
+    "preferred_name": "Recurrent depression with current severe episode without psychotic features"
+  },
+  {
+    "sctid": "1089641000000100",
+    "preferred_name": "Recurrent depression with current moderate episode"
+  },
+  {
+    "sctid": "1089661000000104",
+    "preferred_name": "Mania with mood-congruent psychotic features"
+  },
+  {
+    "sctid": "1089671000000106",
+    "preferred_name": "Mania with mood-incongruent psychotic features"
+  },
+  {
+    "sctid": "1089681000000108",
+    "preferred_name": "Mania with psychotic features"
+  },
+  {
+    "sctid": "1089691000000105",
+    "preferred_name": "Acute predominantly delusional psychotic disorder"
+  },
+  {
+    "sctid": "1089701000000105",
+    "preferred_name": "Profound intellectual development disorder without impairment of behaviour"
+  },
+  {
+    "sctid": "1089711000000107",
+    "preferred_name": "Profound intellectual development disorder with significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089721000000101",
+    "preferred_name": "Profound intellectual development disorder with minimal impairment of behaviour"
+  },
+  {
+    "sctid": "1089731000000104",
+    "preferred_name": "Profound intellectual development disorder with impairment of behaviour"
+  },
+  {
+    "sctid": "1089741000000108",
+    "preferred_name": "Severe intellectual development disorder without significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089751000000106",
+    "preferred_name": "Severe intellectual development disorder with significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089761000000109",
+    "preferred_name": "Severe intellectual development disorder with minimal impairment of behaviour"
+  },
+  {
+    "sctid": "1089771000000102",
+    "preferred_name": "Severe intellectual development disorder with impairment of behaviour"
+  },
+  {
+    "sctid": "1089781000000100",
+    "preferred_name": "Moderate intellectual development disorder without significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089781000119109",
+    "preferred_name": "Meningitis due to Chagas disease"
+  },
+  {
+    "sctid": "1089791000000103",
+    "preferred_name": "Moderate intellectual development disorder with significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089791000119107",
+    "preferred_name": "Meningitis due to infectious mononucleosis"
+  },
+  {
+    "sctid": "1089801000119108",
+    "preferred_name": "Meningococcal retrobulbar neuritis"
+  },
+  {
+    "sctid": "1089811000000102",
+    "preferred_name": "Moderate intellectual development disorder with minimal impairment of behaviour"
+  },
+  {
+    "sctid": "1089811000119106",
+    "preferred_name": "Meningoencephalitis due to Acanthamoeba"
+  },
+  {
+    "sctid": "1089821000000108",
+    "preferred_name": "Moderate intellectual development disorder with impairment of behaviour"
+  },
+  {
+    "sctid": "1089821000119104",
+    "preferred_name": "Meningoencephalitis due to Chagas disease"
+  },
+  {
+    "sctid": "1089831000000105",
+    "preferred_name": "Mild intellectual development disorder without significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089841000000101",
+    "preferred_name": "Mild intellectual development disorder with significant impairment of behaviour"
+  },
+  {
+    "sctid": "1089851000000103",
+    "preferred_name": "Mild intellectual development disorder with minimal impairment of behaviour"
+  },
+  {
+    "sctid": "109006",
+    "preferred_name": "Anxiety disorder of childhood OR adolescence"
+  },
+  {
+    "sctid": "1092351000119107",
+    "preferred_name": "Meningitis caused by Rubella virus"
+  },
+  {
+    "sctid": "1092491000000102",
+    "preferred_name": "Otosyphilis"
+  },
+  {
+    "sctid": "1092691000119109",
+    "preferred_name": "Hepatic coma due to subacute liver failure"
+  },
+  {
+    "sctid": "10938941000119103",
+    "preferred_name": "Injury of conus medullaris"
+  },
+  {
+    "sctid": "1093991000000101",
+    "preferred_name": "Mild intellectual development disorder with impairment of behaviour"
+  },
+  {
+    "sctid": "1094001000000106",
+    "preferred_name": "Intellectual development disorder without significant impairment of behaviour"
+  },
+  {
+    "sctid": "1094011000000108",
+    "preferred_name": "Intellectual development disorder with significant impairment of behaviour"
+  },
+  {
+    "sctid": "1094021000000102",
+    "preferred_name": "Intellectual development disorder with minimal impairment of behaviour"
+  },
+  {
+    "sctid": "1094031000000100",
+    "preferred_name": "Intellectual development disorder with impairment of behaviour"
+  },
+  {
+    "sctid": "10943311000119108",
+    "preferred_name": "Contusion of right cerebrum"
+  },
+  {
+    "sctid": "10943471000119107",
+    "preferred_name": "Contusion of left cerebrum"
+  },
+  {
+    "sctid": "109478007",
+    "preferred_name": "Kohlschutter's syndrome"
+  },
+  {
+    "sctid": "10948005",
+    "preferred_name": "Thoracic spondylosis with myelopathy"
+  },
+  {
+    "sctid": "109561000",
+    "preferred_name": "Cerebrofacial dysplasia"
+  },
+  {
+    "sctid": "10976711000119104",
+    "preferred_name": "Primary primitive neuroectodermal neoplasm of central nervous system"
+  },
+  {
+    "sctid": "109805003",
+    "preferred_name": "Factitious cheilitis"
+  },
+  {
+    "sctid": "10981006",
+    "preferred_name": "Severe mixed bipolar I disorder with psychotic features"
+  },
+  {
+    "sctid": "109896009",
+    "preferred_name": "Indication for modification of patient status"
+  },
+  {
+    "sctid": "109897000",
+    "preferred_name": "Indication for modification of patient behavior status"
+  },
+  {
+    "sctid": "109898005",
+    "preferred_name": "Indication for modification of patient cognitive status"
+  },
+  {
+    "sctid": "109899002",
+    "preferred_name": "Indication for modification of patient emotional status"
+  },
+  {
+    "sctid": "109900007",
+    "preferred_name": "Indication for modification of patient physical status"
+  },
+  {
+    "sctid": "109901006",
+    "preferred_name": "Indication for modification of patient psychological status"
+  },
+  {
+    "sctid": "109902004",
+    "preferred_name": "Acute purulent meningitis"
+  },
+  {
+    "sctid": "109904003",
+    "preferred_name": "Acquired meningocele"
+  },
+  {
+    "sctid": "109905002",
+    "preferred_name": "Acquired myelocele"
+  },
+  {
+    "sctid": "109911004",
+    "preferred_name": "Overlapping malignant neoplasm of brain and other parts of the central nervous system"
+  },
+  {
+    "sctid": "109912006",
+    "preferred_name": "Overlapping malignant neoplasm of brain"
+  },
+  {
+    "sctid": "109913001",
+    "preferred_name": "Benign neoplasm of meninges"
+  },
+  {
+    "sctid": "109914007",
+    "preferred_name": "Neoplasm of uncertain behavior of meninges"
+  },
+  {
+    "sctid": "109915008",
+    "preferred_name": "Primary malignant neoplasm of meninges"
+  },
+  {
+    "sctid": "109956006",
+    "preferred_name": "Psychogenic purpura"
+  },
+  {
+    "sctid": "110030002",
+    "preferred_name": "Concussion injury of brain"
+  },
+  {
+    "sctid": "110150000",
+    "preferred_name": "Spinal cord concussion"
+  },
+  {
+    "sctid": "110270004",
+    "preferred_name": "Late effects of poliomyelitis"
+  },
+  {
+    "sctid": "110359009",
+    "preferred_name": "Intellectual disability"
+  },
+  {
+    "sctid": "11045000",
+    "preferred_name": "Supranuclear facial nerve paralysis"
+  },
+  {
+    "sctid": "1105051000000102",
+    "preferred_name": "Subacute combined degeneration of spinal cord due to use of nitrous oxide"
+  },
+  {
+    "sctid": "11061003",
+    "preferred_name": "Psychoactive substance use disorder"
+  },
+  {
+    "sctid": "110997000",
+    "preferred_name": "Fahr's syndrome"
+  },
+  {
+    "sctid": "111028009",
+    "preferred_name": "Arteriopathic granular atrophy of cerebral cortex"
+  },
+  {
+    "sctid": "111033008",
+    "preferred_name": "Circumscribed atrophy of brain"
+  },
+  {
+    "sctid": "111297002",
+    "preferred_name": "Nonparalytic stroke"
+  },
+  {
+    "sctid": "111337001",
+    "preferred_name": "Dyke-Davidoff-Masson syndrome"
+  },
+  {
+    "sctid": "111395007",
+    "preferred_name": "Nephrogenic diabetes insipidus"
+  },
+  {
+    "sctid": "111475002",
+    "preferred_name": "Neurosis"
+  },
+  {
+    "sctid": "111477005",
+    "preferred_name": "Reactive attachment disorder of infancy OR early childhood, disinhibited type"
+  },
+  {
+    "sctid": "111479008",
+    "preferred_name": "Organic mental disorder"
+  },
+  {
+    "sctid": "111480006",
+    "preferred_name": "Psychoactive substance-induced organic dementia"
+  },
+  {
+    "sctid": "111482003",
+    "preferred_name": "Subchronic schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "111483008",
+    "preferred_name": "Catatonic schizophrenia in remission"
+  },
+  {
+    "sctid": "111484002",
+    "preferred_name": "Undifferentiated schizophrenia"
+  },
+  {
+    "sctid": "111485001",
+    "preferred_name": "Mixed bipolar I disorder in full remission"
+  },
+  {
+    "sctid": "111486000",
+    "preferred_name": "Symptomatic sexual sadism"
+  },
+  {
+    "sctid": "111487009",
+    "preferred_name": "Dream anxiety disorder"
+  },
+  {
+    "sctid": "111488004",
+    "preferred_name": "Kleine-Levin syndrome"
+  },
+  {
+    "sctid": "111490003",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in partial remission AND severe panic attacks"
+  },
+  {
+    "sctid": "111491004",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in full remission AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "111492006",
+    "preferred_name": "Conversion disorder, single episode"
+  },
+  {
+    "sctid": "111496009",
+    "preferred_name": "Syringomyelia"
+  },
+  {
+    "sctid": "111497000",
+    "preferred_name": "Arterial thrombosis of spinal cord"
+  },
+  {
+    "sctid": "111498005",
+    "preferred_name": "Extratemporal epilepsy"
+  },
+  {
+    "sctid": "111504002",
+    "preferred_name": "Walker-Warburg congenital muscular dystrophy"
+  },
+  {
+    "sctid": "111505001",
+    "preferred_name": "Muscle-eye-brain disease, congenital muscular dystrophy"
+  },
+  {
+    "sctid": "111527005",
+    "preferred_name": "Partial optic atrophy"
+  },
+  {
+    "sctid": "111548007",
+    "preferred_name": "Syndrome of diencephalo-hypophyseal origin"
+  },
+  {
+    "sctid": "111558006",
+    "preferred_name": "Insulin coma"
+  },
+  {
+    "sctid": "111568001",
+    "preferred_name": "Hypothalamic syndrome"
+  },
+  {
+    "sctid": "111569009",
+    "preferred_name": "Hyperthermia-hyperphagia-hypothyroidism syndrome"
+  },
+  {
+    "sctid": "111633007",
+    "preferred_name": "Open fracture of sacrum AND/OR coccyx with complete cauda equina lesion"
+  },
+  {
+    "sctid": "111641000119102",
+    "preferred_name": "Congenital choroid plexus cyst"
+  },
+  {
+    "sctid": "111681000",
+    "preferred_name": "Extradural hemorrhage following injury with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "111850006",
+    "preferred_name": "Adenoviral meningitis"
+  },
+  {
+    "sctid": "111851005",
+    "preferred_name": "Subacute adenoviral encephalitis"
+  },
+  {
+    "sctid": "111868009",
+    "preferred_name": "Rubella infection of central nervous system"
+  },
+  {
+    "sctid": "111872008",
+    "preferred_name": "Post measles encephalitis"
+  },
+  {
+    "sctid": "111878007",
+    "preferred_name": "Coxsackie meningitis"
+  },
+  {
+    "sctid": "111897007",
+    "preferred_name": "Acute necrotizing encephalitis"
+  },
+  {
+    "sctid": "1119281000",
+    "preferred_name": "Diffuse unilateral subacute neuroretinitis"
+  },
+  {
+    "sctid": "111936002",
+    "preferred_name": "Cerebral sarcoidosis"
+  },
+  {
+    "sctid": "11197005",
+    "preferred_name": "Hydromyelia"
+  },
+  {
+    "sctid": "11265003",
+    "preferred_name": "Hemichorea"
+  },
+  {
+    "sctid": "1137357005",
+    "preferred_name": "Hepatic coma due to viral hepatitis D"
+  },
+  {
+    "sctid": "11387009",
+    "preferred_name": "Psychoactive substance-induced organic mental disorder"
+  },
+  {
+    "sctid": "11413003",
+    "preferred_name": "Incomplete spinal cord lesion at T1-T6 level without bone injury"
+  },
+  {
+    "sctid": "1141661004",
+    "preferred_name": "Neurocutaneous melanosis"
+  },
+  {
+    "sctid": "1142031005",
+    "preferred_name": "Late congenital syphilitic optic atrophy"
+  },
+  {
+    "sctid": "1142047007",
+    "preferred_name": "Possession trance disorder"
+  },
+  {
+    "sctid": "1142050005",
+    "preferred_name": "Uncomplicated opioid withdrawal"
+  },
+  {
+    "sctid": "1142056004",
+    "preferred_name": "Neonatal ischemic stroke"
+  },
+  {
+    "sctid": "1144223007",
+    "preferred_name": "Hypoxic ischemic encephalopathy of newborn"
+  },
+  {
+    "sctid": "1144893005",
+    "preferred_name": "Epidermoid cyst of pituitary gland"
+  },
+  {
+    "sctid": "1144895003",
+    "preferred_name": "Postoperative pseudomeningocele"
+  },
+  {
+    "sctid": "1144942002",
+    "preferred_name": "Neuropsychiatric disorder due to systemic lupus erythematosus"
+  },
+  {
+    "sctid": "1144966008",
+    "preferred_name": "Herpes simplex type 1 encephalitis"
+  },
+  {
+    "sctid": "1144968009",
+    "preferred_name": "Herpes simplex type 2 encephalitis"
+  },
+  {
+    "sctid": "1145003",
+    "preferred_name": "Developmental speech disorder"
+  },
+  {
+    "sctid": "11471000224106",
+    "preferred_name": "Diffuse intrinsic pontine glioma"
+  },
+  {
+    "sctid": "1148694009",
+    "preferred_name": "Postoperative central diabetes insipidus"
+  },
+  {
+    "sctid": "1148738004",
+    "preferred_name": "Entrapment of inferior horn of lateral ventricle"
+  },
+  {
+    "sctid": "1148739007",
+    "preferred_name": "Obstructive hydrocephalus due to entrapment of inferior horn of lateral ventricle"
+  },
+  {
+    "sctid": "1148741008",
+    "preferred_name": "Necrosis of brain caused by exposure to ionizing radiation"
+  },
+  {
+    "sctid": "1148924004",
+    "preferred_name": "Dementia due to deficiency of folic acid"
+  },
+  {
+    "sctid": "1149087003",
+    "preferred_name": "Congenital microencephaly"
+  },
+  {
+    "sctid": "1149095004",
+    "preferred_name": "Meningitis caused by Streptococcus suis"
+  },
+  {
+    "sctid": "1153337000",
+    "preferred_name": "Neoplasm of extradural space"
+  },
+  {
+    "sctid": "1153340000",
+    "preferred_name": "Myelopathy due to folate deficiency"
+  },
+  {
+    "sctid": "1153570009",
+    "preferred_name": "Treatment resistant depression"
+  },
+  {
+    "sctid": "1153575004",
+    "preferred_name": "Persistent depressive disorder"
+  },
+  {
+    "sctid": "1155991005",
+    "preferred_name": "Secondary malignant neoplasm of leptomeninges"
+  },
+  {
+    "sctid": "1156018007",
+    "preferred_name": "Left cerebellar artery thrombosis"
+  },
+  {
+    "sctid": "1156019004",
+    "preferred_name": "Right cerebellar artery thrombosis"
+  },
+  {
+    "sctid": "1156035006",
+    "preferred_name": "Nontraumatic injury of brain"
+  },
+  {
+    "sctid": "1156266006",
+    "preferred_name": "Compression of cervical spinal cord"
+  },
+  {
+    "sctid": "1156340006",
+    "preferred_name": "Toxic encephalopathy caused by monomethyl mercury"
+  },
+  {
+    "sctid": "1156406005",
+    "preferred_name": "Anaplastic oligodendroglioma of central nervous system"
+  },
+  {
+    "sctid": "1156407001",
+    "preferred_name": "Myxopapillary ependymoma of spinal cord"
+  },
+  {
+    "sctid": "1156409003",
+    "preferred_name": "Anaplastic ependymoma of central nervous system"
+  },
+  {
+    "sctid": "1156410008",
+    "preferred_name": "Anaplastic oligoastrocytoma of central nervous system"
+  },
+  {
+    "sctid": "1156412000",
+    "preferred_name": "Angiocentric glioma of central nervous system"
+  },
+  {
+    "sctid": "1156413005",
+    "preferred_name": "Gliomatosis cerebri"
+  },
+  {
+    "sctid": "1156414004",
+    "preferred_name": "Giant cell glioblastoma of brain"
+  },
+  {
+    "sctid": "1156415003",
+    "preferred_name": "Protoplasmic astrocytoma of brain"
+  },
+  {
+    "sctid": "1156416002",
+    "preferred_name": "Gemistocytic astrocytoma of brain"
+  },
+  {
+    "sctid": "1156417006",
+    "preferred_name": "Fibrillary astrocytoma of brain"
+  },
+  {
+    "sctid": "1156455001",
+    "preferred_name": "Pleomorphic xanthoastrocytoma of brain"
+  },
+  {
+    "sctid": "1156456000",
+    "preferred_name": "Pilomyxoid astrocytoma of brain"
+  },
+  {
+    "sctid": "1156457009",
+    "preferred_name": "Papillary glioneuronal tumor of brain"
+  },
+  {
+    "sctid": "1156459007",
+    "preferred_name": "Anaplastic ganglioglioma of central nervous system"
+  },
+  {
+    "sctid": "1156460002",
+    "preferred_name": "Desmoplastic nodular medulloblastoma of brain"
+  },
+  {
+    "sctid": "1156461003",
+    "preferred_name": "Gliosarcoma of brain"
+  },
+  {
+    "sctid": "1156469001",
+    "preferred_name": "Large cell medulloblastoma of brain"
+  },
+  {
+    "sctid": "1156470000",
+    "preferred_name": "Atypical papilloma of choroid plexus"
+  },
+  {
+    "sctid": "1156471001",
+    "preferred_name": "Choroid plexus carcinoma"
+  },
+  {
+    "sctid": "1156472008",
+    "preferred_name": "Papillary tumor of pineal region"
+  },
+  {
+    "sctid": "1156473003",
+    "preferred_name": "Pineocytoma"
+  },
+  {
+    "sctid": "1156584007",
+    "preferred_name": "X-linked intellectual disability hypotonic face syndrome"
+  },
+  {
+    "sctid": "1156761002",
+    "preferred_name": "Progressive supranuclear palsy progressive non fluent aphasia"
+  },
+  {
+    "sctid": "1156763004",
+    "preferred_name": "Progressive supranuclear palsy corticobasal syndrome"
+  },
+  {
+    "sctid": "1156764005",
+    "preferred_name": "Progressive supranuclear palsy parkinsonism syndrome"
+  },
+  {
+    "sctid": "1156768008",
+    "preferred_name": "Ovarioleukodystrophy"
+  },
+  {
+    "sctid": "1156789004",
+    "preferred_name": "Autosomal dominant Alzheimer disease due to mutation of amyloid precursor protein"
+  },
+  {
+    "sctid": "1156790008",
+    "preferred_name": "Atypical progressive supranuclear palsy syndrome"
+  },
+  {
+    "sctid": "1156796002",
+    "preferred_name": "Autosomal dominant cerebellar ataxia type 2"
+  },
+  {
+    "sctid": "1156798001",
+    "preferred_name": "Autosomal dominant Alzheimer disease due to mutation of presenilin 2"
+  },
+  {
+    "sctid": "1156800008",
+    "preferred_name": "Autosomal dominant Alzheimer disease due to mutation of presenilin 1"
+  },
+  {
+    "sctid": "1156822001",
+    "preferred_name": "Autosomal recessive familial Parkinson disease"
+  },
+  {
+    "sctid": "1156823006",
+    "preferred_name": "Autosomal recessive bilateral optic atrophy"
+  },
+  {
+    "sctid": "1156833003",
+    "preferred_name": "Germinoma of central nervous system"
+  },
+  {
+    "sctid": "1156841003",
+    "preferred_name": "X-linked complex hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "1156842005",
+    "preferred_name": "X-linked pure hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "1156963006",
+    "preferred_name": "Myelopathy due to cervical spondylosis"
+  },
+  {
+    "sctid": "1156965004",
+    "preferred_name": "Myelopathy due to single-level cervical spondylosis"
+  },
+  {
+    "sctid": "1156967007",
+    "preferred_name": "Myelopathy due to multiple-level cervical spondylosis"
+  },
+  {
+    "sctid": "1156969005",
+    "preferred_name": "Myelopathy due to two-level cervical spondylosis"
+  },
+  {
+    "sctid": "1157060001",
+    "preferred_name": "Diffuse astrocytoma of brain"
+  },
+  {
+    "sctid": "1157061002",
+    "preferred_name": "Gliosarcoma of central nervous system"
+  },
+  {
+    "sctid": "1157062009",
+    "preferred_name": "Giant cell glioblastoma of central nervous system"
+  },
+  {
+    "sctid": "1157064005",
+    "preferred_name": "Gemistocytic astrocytoma of central nervous system"
+  },
+  {
+    "sctid": "1157068008",
+    "preferred_name": "Fibrillary astrocytoma of central nervous system"
+  },
+  {
+    "sctid": "1157072007",
+    "preferred_name": "Gliosarcoma of spinal cord"
+  },
+  {
+    "sctid": "1157141006",
+    "preferred_name": "Astroblastoma of central nervous system"
+  },
+  {
+    "sctid": "1157161000",
+    "preferred_name": "Meningioma of uncertain behavior"
+  },
+  {
+    "sctid": "1157249003",
+    "preferred_name": "Invasive benign pituitary adenoma"
+  },
+  {
+    "sctid": "116288000",
+    "preferred_name": "Paralytic stroke"
+  },
+  {
+    "sctid": "116401000119105",
+    "preferred_name": "Recurrent complex partial epilepsy"
+  },
+  {
+    "sctid": "11676005",
+    "preferred_name": "Tuberculous leptomeningitis"
+  },
+  {
+    "sctid": "116811000119106",
+    "preferred_name": "Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of lower limb"
+  },
+  {
+    "sctid": "116821000119104",
+    "preferred_name": "Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of upper limb"
+  },
+  {
+    "sctid": "11701009",
+    "preferred_name": "Hemicephaly"
+  },
+  {
+    "sctid": "117776611000119102",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left posterior communicating artery"
+  },
+  {
+    "sctid": "117891000119100",
+    "preferred_name": "Simple partial seizure"
+  },
+  {
+    "sctid": "11806006",
+    "preferred_name": "Separation anxiety disorder of childhood"
+  },
+  {
+    "sctid": "11807002",
+    "preferred_name": "Injury at C5-C7 level with spinal cord injury AND without bone injury"
+  },
+  {
+    "sctid": "11862006",
+    "preferred_name": "Drug-induced myelopathy"
+  },
+  {
+    "sctid": "118951003",
+    "preferred_name": "Drug-induced nephrogenic diabetes insipidus"
+  },
+  {
+    "sctid": "119001000119108",
+    "preferred_name": "Intractable simple partial epilepsy"
+  },
+  {
+    "sctid": "11941006",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in full remission AND panic attacks in full remission"
+  },
+  {
+    "sctid": "1196001",
+    "preferred_name": "Chronic bipolar II disorder, most recent episode major depressive"
+  },
+  {
+    "sctid": "12050001000004101",
+    "preferred_name": "Mass of left frontal lobe of brain"
+  },
+  {
+    "sctid": "1207009",
+    "preferred_name": "Glaucomatous atrophy of optic disc"
+  },
+  {
+    "sctid": "12166008",
+    "preferred_name": "Staphylococcal meningitis"
+  },
+  {
+    "sctid": "122021000119104",
+    "preferred_name": "Ophthalmic status migrainosus"
+  },
+  {
+    "sctid": "122051000119107",
+    "preferred_name": "Retinal status migrainosus"
+  },
+  {
+    "sctid": "122061000119109",
+    "preferred_name": "Intractable retinal migraine"
+  },
+  {
+    "sctid": "122141000119109",
+    "preferred_name": "Refractory abdominal migraine"
+  },
+  {
+    "sctid": "12237911000119109",
+    "preferred_name": "Amaurosis fugax of left eye"
+  },
+  {
+    "sctid": "12237951000119105",
+    "preferred_name": "Amaurosis fugax of right eye"
+  },
+  {
+    "sctid": "12265261000119102",
+    "preferred_name": "Benign extra-axial hygroma"
+  },
+  {
+    "sctid": "122731000119104",
+    "preferred_name": "Primary thunderclap headache"
+  },
+  {
+    "sctid": "12275031000119106",
+    "preferred_name": "Congenital cerebral ventriculomegaly"
+  },
+  {
+    "sctid": "12277671000119109",
+    "preferred_name": "Gender dysphoria in childhood"
+  },
+  {
+    "sctid": "12277711000119108",
+    "preferred_name": "Gender dysphoria in adolescence and adulthood"
+  },
+  {
+    "sctid": "12331003",
+    "preferred_name": "Gigantism due to somatostatin deficiency"
+  },
+  {
+    "sctid": "12348006",
+    "preferred_name": "Presenile dementia"
+  },
+  {
+    "sctid": "123615007",
+    "preferred_name": "Secondary optic atrophy"
+  },
+  {
+    "sctid": "123758004",
+    "preferred_name": "Complex pituitary endocrine disorder"
+  },
+  {
+    "sctid": "123759007",
+    "preferred_name": "Prepuberal hyperpituitarism"
+  },
+  {
+    "sctid": "123760002",
+    "preferred_name": "Prepuberal panhypopituitarism"
+  },
+  {
+    "sctid": "123763000",
+    "preferred_name": "Houssay's syndrome"
+  },
+  {
+    "sctid": "1239331000000100",
+    "preferred_name": "Significant learning disability"
+  },
+  {
+    "sctid": "12394009",
+    "preferred_name": "Miscarriage with cerebral anoxia"
+  },
+  {
+    "sctid": "123953004",
+    "preferred_name": "Idiopathic hypogonadotropic hypogonadism"
+  },
+  {
+    "sctid": "12398201000119102",
+    "preferred_name": "Anxiety disorder caused by methamphetamine"
+  },
+  {
+    "sctid": "12398281000119105",
+    "preferred_name": "Methamphetamine withdrawal"
+  },
+  {
+    "sctid": "12398321000119100",
+    "preferred_name": "Mood disorder caused by methamphetamine"
+  },
+  {
+    "sctid": "12398361000119105",
+    "preferred_name": "Mental disorder caused by methamphetamine"
+  },
+  {
+    "sctid": "124001000119104",
+    "preferred_name": "Common migraine with status migrainosus"
+  },
+  {
+    "sctid": "124041000119102",
+    "preferred_name": "Intractable hemiplegic migraine"
+  },
+  {
+    "sctid": "124051000119100",
+    "preferred_name": "Hemiplegic status migrainosus"
+  },
+  {
+    "sctid": "1240561000000108",
+    "preferred_name": "Encephalopathy due to disease caused by Severe acute respiratory syndrome coronavirus 2"
+  },
+  {
+    "sctid": "124061000119103",
+    "preferred_name": "Intractable hemiplegic status migrainosus"
+  },
+  {
+    "sctid": "124071000119109",
+    "preferred_name": "Intractable menstrual migraine"
+  },
+  {
+    "sctid": "124081000119107",
+    "preferred_name": "Menstrual status migrainosus"
+  },
+  {
+    "sctid": "124091000119105",
+    "preferred_name": "Intractable menstrual status migrainosus"
+  },
+  {
+    "sctid": "124171000119105",
+    "preferred_name": "Chronic intractable migraine without aura"
+  },
+  {
+    "sctid": "124391000119108",
+    "preferred_name": "Status migrainosus with aura"
+  },
+  {
+    "sctid": "125081000119106",
+    "preferred_name": "Cerebral infarction due to occlusion of precerebral artery"
+  },
+  {
+    "sctid": "125609005",
+    "preferred_name": "Open fracture of cervical region with spinal cord injury"
+  },
+  {
+    "sctid": "12589008",
+    "preferred_name": "Brain stem laceration with open intracranial wound"
+  },
+  {
+    "sctid": "125921000119106",
+    "preferred_name": "Hepatic coma due to acute hepatitis C"
+  },
+  {
+    "sctid": "12677003",
+    "preferred_name": "Tuberculosis of brain"
+  },
+  {
+    "sctid": "126941005",
+    "preferred_name": "Subdural hemorrhage due to birth trauma"
+  },
+  {
+    "sctid": "126943008",
+    "preferred_name": "Separation anxiety"
+  },
+  {
+    "sctid": "126944002",
+    "preferred_name": "Brain damage due to hypoxia"
+  },
+  {
+    "sctid": "126945001",
+    "preferred_name": "Perinatal anoxic-ischemic brain injury"
+  },
+  {
+    "sctid": "126947009",
+    "preferred_name": "Cerebellopontine angle tumor"
+  },
+  {
+    "sctid": "126948004",
+    "preferred_name": "Cerebellopontine angle meningioma"
+  },
+  {
+    "sctid": "126951006",
+    "preferred_name": "Neoplasm of central nervous system"
+  },
+  {
+    "sctid": "126952004",
+    "preferred_name": "Neoplasm of brain"
+  },
+  {
+    "sctid": "126953009",
+    "preferred_name": "Neoplasm of cerebrum"
+  },
+  {
+    "sctid": "126954003",
+    "preferred_name": "Neoplasm of frontal lobe"
+  },
+  {
+    "sctid": "126955002",
+    "preferred_name": "Neoplasm of temporal lobe"
+  },
+  {
+    "sctid": "126956001",
+    "preferred_name": "Neoplasm of parietal lobe"
+  },
+  {
+    "sctid": "126957005",
+    "preferred_name": "Neoplasm of occipital lobe"
+  },
+  {
+    "sctid": "126958000",
+    "preferred_name": "Neoplasm of cerebral ventricle"
+  },
+  {
+    "sctid": "126959008",
+    "preferred_name": "Neoplasm of cerebral meninges"
+  },
+  {
+    "sctid": "126960003",
+    "preferred_name": "Neoplasm of cerebellum"
+  },
+  {
+    "sctid": "126961004",
+    "preferred_name": "Neoplasm of brain stem"
+  },
+  {
+    "sctid": "126962006",
+    "preferred_name": "Neoplasm of spinal cord"
+  },
+  {
+    "sctid": "126964007",
+    "preferred_name": "Neoplasm of spinal meninges"
+  },
+  {
+    "sctid": "126965008",
+    "preferred_name": "Neoplasm of meninges"
+  },
+  {
+    "sctid": "127024001",
+    "preferred_name": "Neoplasm of pituitary gland"
+  },
+  {
+    "sctid": "127025000",
+    "preferred_name": "Neoplasm of craniopharyngeal duct"
+  },
+  {
+    "sctid": "127026004",
+    "preferred_name": "Neoplasm of pineal gland"
+  },
+  {
+    "sctid": "127294003",
+    "preferred_name": "Traumatic or nontraumatic brain injury"
+  },
+  {
+    "sctid": "127295002",
+    "preferred_name": "Traumatic brain injury"
+  },
+  {
+    "sctid": "127298000",
+    "preferred_name": "Traumatic brain injury with loss of consciousness"
+  },
+  {
+    "sctid": "127299008",
+    "preferred_name": "Traumatic brain injury with brief loss of consciousness"
+  },
+  {
+    "sctid": "127300000",
+    "preferred_name": "Traumatic brain injury with moderate loss of consciousness"
+  },
+  {
+    "sctid": "127301001",
+    "preferred_name": "Traumatic brain injury with prolonged loss of consciousness"
+  },
+  {
+    "sctid": "127302008",
+    "preferred_name": "Traumatic brain injury with no loss of consciousness"
+  },
+  {
+    "sctid": "127303003",
+    "preferred_name": "Cortex laceration"
+  },
+  {
+    "sctid": "127304009",
+    "preferred_name": "Cerebellar contusion"
+  },
+  {
+    "sctid": "127305005",
+    "preferred_name": "Brain stem contusion"
+  },
+  {
+    "sctid": "127306006",
+    "preferred_name": "Cerebellar laceration"
+  },
+  {
+    "sctid": "127307002",
+    "preferred_name": "Brain stem laceration"
+  },
+  {
+    "sctid": "127309004",
+    "preferred_name": "Intracranial hemorrhage following injury with brief loss of consciousness"
+  },
+  {
+    "sctid": "127310009",
+    "preferred_name": "Intracranial hemorrhage following injury with moderate loss of consciousness"
+  },
+  {
+    "sctid": "127311008",
+    "preferred_name": "Intracranial hemorrhage following injury with prolonged loss of consciousness AND return to pre-existing conscious level"
+  },
+  {
+    "sctid": "127312001",
+    "preferred_name": "Intracranial hemorrhage following injury with prolonged loss of consciousness without return to pre-existing conscious level"
+  },
+  {
+    "sctid": "127551000119100",
+    "preferred_name": "Congenital hypoplasia of brain"
+  },
+  {
+    "sctid": "128117002",
+    "preferred_name": "Infectious disease of central nervous system"
+  },
+  {
+    "sctid": "128119004",
+    "preferred_name": "Bacterial infection of central nervous system"
+  },
+  {
+    "sctid": "128120005",
+    "preferred_name": "Fungal infection of central nervous system"
+  },
+  {
+    "sctid": "128124001",
+    "preferred_name": "Congenital anomaly of central nervous system"
+  },
+  {
+    "sctid": "128126004",
+    "preferred_name": "Injury of central nervous system"
+  },
+  {
+    "sctid": "128128003",
+    "preferred_name": "Disorder of cerebral cortex"
+  },
+  {
+    "sctid": "128188000",
+    "preferred_name": "Cerebral palsy"
+  },
+  {
+    "sctid": "128191000",
+    "preferred_name": "Encephalomyelitis due to rubella"
+  },
+  {
+    "sctid": "128203003",
+    "preferred_name": "Hereditary motor and sensory neuropathy with optic atrophy"
+  },
+  {
+    "sctid": "128211000119102",
+    "preferred_name": "Meningoencephalitis due to free-living ameba"
+  },
+  {
+    "sctid": "128293007",
+    "preferred_name": "Chronic mental disorder"
+  },
+  {
+    "sctid": "128328009",
+    "preferred_name": "Suprasellar syndrome"
+  },
+  {
+    "sctid": "128329001",
+    "preferred_name": "Disorder of visual cortex"
+  },
+  {
+    "sctid": "128331005",
+    "preferred_name": "Optic disc disorder"
+  },
+  {
+    "sctid": "128431009",
+    "preferred_name": "Internal hydrocephalus"
+  },
+  {
+    "sctid": "128470003",
+    "preferred_name": "Pineal gland disorder"
+  },
+  {
+    "sctid": "128485009",
+    "preferred_name": "Retrobulbar neuropathy"
+  },
+  {
+    "sctid": "12853006",
+    "preferred_name": "Embolism of torcular Herophili"
+  },
+  {
+    "sctid": "128533009",
+    "preferred_name": "Micropapilla"
+  },
+  {
+    "sctid": "128612007",
+    "preferred_name": "Focal motor seizure"
+  },
+  {
+    "sctid": "128613002",
+    "preferred_name": "Seizure disorder"
+  },
+  {
+    "sctid": "128614008",
+    "preferred_name": "Infectious disease of brain"
+  },
+  {
+    "sctid": "129104009",
+    "preferred_name": "Developmental mental disorder"
+  },
+  {
+    "sctid": "129132000",
+    "preferred_name": "Bacterial infectious disease of brain"
+  },
+  {
+    "sctid": "12939007",
+    "preferred_name": "Chronic disorganized schizophrenia"
+  },
+  {
+    "sctid": "129562004",
+    "preferred_name": "Psychogenic skin disease"
+  },
+  {
+    "sctid": "129602009",
+    "preferred_name": "Symbiotic infantile psychosis"
+  },
+  {
+    "sctid": "129604005",
+    "preferred_name": "Delusion of heart disease syndrome"
+  },
+  {
+    "sctid": "129605006",
+    "preferred_name": "Postgastrectomy neurosis"
+  },
+  {
+    "sctid": "129606007",
+    "preferred_name": "Frontal lobe syndrome"
+  },
+  {
+    "sctid": "129607003",
+    "preferred_name": "Mother-daughter symbiotic syndrome"
+  },
+  {
+    "sctid": "129608008",
+    "preferred_name": "Progressive pyramidopallidal degeneration"
+  },
+  {
+    "sctid": "129609000",
+    "preferred_name": "Spinocerebellar ataxia"
+  },
+  {
+    "sctid": "129615000",
+    "preferred_name": "Nucleus ambiguus-hypoglossal nerve syndrome"
+  },
+  {
+    "sctid": "129633006",
+    "preferred_name": "Induced female hypogonadism syndrome"
+  },
+  {
+    "sctid": "12969000",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive, in full remission"
+  },
+  {
+    "sctid": "130121000119104",
+    "preferred_name": "Dementia due to Rett's syndrome"
+  },
+  {
+    "sctid": "131411000119107",
+    "preferred_name": "Meningitis caused by arbovirus infection"
+  },
+  {
+    "sctid": "13194006",
+    "preferred_name": "Closed fracture of T7-T12 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "13196008",
+    "preferred_name": "Secondary diabetes insipidus"
+  },
+  {
+    "sctid": "13225007",
+    "preferred_name": "Rubella meningoencephalitis"
+  },
+  {
+    "sctid": "133091000119105",
+    "preferred_name": "Rapid cycling bipolar I disorder"
+  },
+  {
+    "sctid": "13310005",
+    "preferred_name": "Taboparesis"
+  },
+  {
+    "sctid": "133121000119109",
+    "preferred_name": "Severe seasonal affective disorder"
+  },
+  {
+    "sctid": "13313007",
+    "preferred_name": "Mild bipolar disorder"
+  },
+  {
+    "sctid": "133301000119102",
+    "preferred_name": "Degenerative brain disorder caused by alcohol"
+  },
+  {
+    "sctid": "13386009",
+    "preferred_name": "Intraspinal embolic abscess"
+  },
+  {
+    "sctid": "133951000119104",
+    "preferred_name": "Temporal lobe sclerosis"
+  },
+  {
+    "sctid": "134209002",
+    "preferred_name": "Prolactinoma"
+  },
+  {
+    "sctid": "13438001",
+    "preferred_name": "Overanxious disorder of childhood"
+  },
+  {
+    "sctid": "13456001",
+    "preferred_name": "Closed fracture of T1-T6 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "134811000119108",
+    "preferred_name": "Severe hypoxic ischemic encephalopathy of newborn"
+  },
+  {
+    "sctid": "134821000119101",
+    "preferred_name": "Moderate hypoxic ischemic encephalopathy of newborn"
+  },
+  {
+    "sctid": "134831000119103",
+    "preferred_name": "Mild hypoxic ischemic encephalopathy of newborn"
+  },
+  {
+    "sctid": "135491000119100",
+    "preferred_name": "Myelopathy due to benign neoplastic disease"
+  },
+  {
+    "sctid": "135511000119105",
+    "preferred_name": "Myelopathy due to malignant neoplastic disease"
+  },
+  {
+    "sctid": "135761000119101",
+    "preferred_name": "Cerebral degeneration due to alcoholism"
+  },
+  {
+    "sctid": "135781000119105",
+    "preferred_name": "Cerebral degeneration due to hypothyroidism"
+  },
+  {
+    "sctid": "135801000119109",
+    "preferred_name": "Compression of brain due to focal lesion"
+  },
+  {
+    "sctid": "13581000",
+    "preferred_name": "Severe bipolar I disorder, single manic episode with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "135811000119107",
+    "preferred_name": "Lewy body dementia with behavioral disturbance"
+  },
+  {
+    "sctid": "135884009",
+    "preferred_name": "Benign neoplasm of pons"
+  },
+  {
+    "sctid": "13601000119109",
+    "preferred_name": "Necrosis of central nervous system due to exposure to ionizing radiation"
+  },
+  {
+    "sctid": "13601005",
+    "preferred_name": "Paranoid personality disorder"
+  },
+  {
+    "sctid": "13670005",
+    "preferred_name": "Gender identity disorder of adulthood, previously heterosexual"
+  },
+  {
+    "sctid": "13691000119103",
+    "preferred_name": "Epidural empyema"
+  },
+  {
+    "sctid": "13746004",
+    "preferred_name": "Bipolar disorder"
+  },
+  {
+    "sctid": "13752003",
+    "preferred_name": "Brain injury with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "1376001",
+    "preferred_name": "Obsessive compulsive personality disorder"
+  },
+  {
+    "sctid": "137991000119103",
+    "preferred_name": "Seizure disorder as sequela of stroke"
+  },
+  {
+    "sctid": "1380006",
+    "preferred_name": "Agoraphobia without history of panic disorder with limited symptom attacks"
+  },
+  {
+    "sctid": "1383008",
+    "preferred_name": "Hallucinogen mood disorder"
+  },
+  {
+    "sctid": "138371000119104",
+    "preferred_name": "Paresis as late effect of poliomyelitis"
+  },
+  {
+    "sctid": "13847000",
+    "preferred_name": "Partial seizure with impaired consciousness"
+  },
+  {
+    "sctid": "13920009",
+    "preferred_name": "Hepatic encephalopathy"
+  },
+  {
+    "sctid": "13950001",
+    "preferred_name": "Bergeron's chorea"
+  },
+  {
+    "sctid": "13973009",
+    "preferred_name": "Grand mal status"
+  },
+  {
+    "sctid": "13980006",
+    "preferred_name": "Adhesive arachnoiditis"
+  },
+  {
+    "sctid": "140281000119108",
+    "preferred_name": "Hemiparesis as late effect of cerebrovascular disease"
+  },
+  {
+    "sctid": "14055002",
+    "preferred_name": "Hydrocephalus ex vacuo"
+  },
+  {
+    "sctid": "140621000119106",
+    "preferred_name": "Memory disorder co-occurrent and due to organic brain damage"
+  },
+  {
+    "sctid": "14070001",
+    "preferred_name": "Multi-infarct dementia with depression"
+  },
+  {
+    "sctid": "14077003",
+    "preferred_name": "Pica"
+  },
+  {
+    "sctid": "140881000119109",
+    "preferred_name": "Spontaneous cerebral hemorrhage with compression of brain"
+  },
+  {
+    "sctid": "140911000119109",
+    "preferred_name": "Ischemic stroke with coma"
+  },
+  {
+    "sctid": "140921000119102",
+    "preferred_name": "Ischemic stroke without coma"
+  },
+  {
+    "sctid": "141091000119105",
+    "preferred_name": "Nontraumatic subarachnoid hemorrhage with brain compression"
+  },
+  {
+    "sctid": "141151000119101",
+    "preferred_name": "Nontraumatic subdural hematoma with brain compression"
+  },
+  {
+    "sctid": "14144000",
+    "preferred_name": "Erotomanic delusion disorder"
+  },
+  {
+    "sctid": "14168008",
+    "preferred_name": "Rabies"
+  },
+  {
+    "sctid": "14183003",
+    "preferred_name": "Chronic major depressive disorder, single episode"
+  },
+  {
+    "sctid": "141991000119109",
+    "preferred_name": "Delusions in Alzheimer's disease"
+  },
+  {
+    "sctid": "142001000119106",
+    "preferred_name": "Depressed mood in Alzheimer's disease"
+  },
+  {
+    "sctid": "142011000119109",
+    "preferred_name": "Alzheimer's disease co-occurrent with delirium"
+  },
+  {
+    "sctid": "14232007",
+    "preferred_name": "Cryptococcal meningitis"
+  },
+  {
+    "sctid": "142851000119103",
+    "preferred_name": "Spontaneous cerebellar hemorrhage"
+  },
+  {
+    "sctid": "14289006",
+    "preferred_name": "Myopathy in hypopituitarism"
+  },
+  {
+    "sctid": "14291003",
+    "preferred_name": "Subchronic disorganized schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "142971000119102",
+    "preferred_name": "Encephalopathy due to H1N1 influenza"
+  },
+  {
+    "sctid": "14309005",
+    "preferred_name": "Anterior choroidal artery syndrome"
+  },
+  {
+    "sctid": "143521000119103",
+    "preferred_name": "Nontraumatic intraparenchymal cerebral hemorrhage"
+  },
+  {
+    "sctid": "14357004",
+    "preferred_name": "Ischemic optic neuropathy"
+  },
+  {
+    "sctid": "14401000119109",
+    "preferred_name": "Partial frontal lobe epilepsy"
+  },
+  {
+    "sctid": "14405000",
+    "preferred_name": "Spinal subdural abscess"
+  },
+  {
+    "sctid": "14415006",
+    "preferred_name": "Pneumocephalus"
+  },
+  {
+    "sctid": "14434006",
+    "preferred_name": "Cerebellar laceration with open intracranial wound AND no loss of consciousness"
+  },
+  {
+    "sctid": "14447001",
+    "preferred_name": "Dandy-Walker syndrome"
+  },
+  {
+    "sctid": "144581000000105",
+    "preferred_name": "Fetal open spina bifida"
+  },
+  {
+    "sctid": "14460007",
+    "preferred_name": "Hemorrhage in optic nerve sheaths"
+  },
+  {
+    "sctid": "14493003",
+    "preferred_name": "Closed fracture of T1-T6 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "14495005",
+    "preferred_name": "Severe bipolar I disorder, single manic episode without psychotic features"
+  },
+  {
+    "sctid": "14521008",
+    "preferred_name": "Visual seizure"
+  },
+  {
+    "sctid": "14535005",
+    "preferred_name": "Acute nonparalytic poliomyelitis"
+  },
+  {
+    "sctid": "146251000146109",
+    "preferred_name": "Traumatic spinal cord injury"
+  },
+  {
+    "sctid": "146371000119104",
+    "preferred_name": "Hepatic coma due to chronic hepatitis C"
+  },
+  {
+    "sctid": "147101000119108",
+    "preferred_name": "Primary malignant astrocytoma of central nervous system"
+  },
+  {
+    "sctid": "147121000119104",
+    "preferred_name": "Ependymoma of central nervous system"
+  },
+  {
+    "sctid": "147131000119101",
+    "preferred_name": "Glioblastoma multiforme of central nervous system"
+  },
+  {
+    "sctid": "14784000",
+    "preferred_name": "Opioid-induced organic mental disorder"
+  },
+  {
+    "sctid": "14900002",
+    "preferred_name": "Hypopituitarism due to radiotherapy"
+  },
+  {
+    "sctid": "149821000119103",
+    "preferred_name": "Cerebral infarction due to carotid artery occlusion"
+  },
+  {
+    "sctid": "1499003",
+    "preferred_name": "Bipolar I disorder, single manic episode with postpartum onset"
+  },
+  {
+    "sctid": "151004",
+    "preferred_name": "Gonococcal meningitis"
+  },
+  {
+    "sctid": "151161000119102",
+    "preferred_name": "Bilateral cerebral infarction due to precererbral arterial occlusion"
+  },
+  {
+    "sctid": "15139001",
+    "preferred_name": "Chronic brain-hydrocephalus syndrome"
+  },
+  {
+    "sctid": "15167005",
+    "preferred_name": "Alcohol abuse"
+  },
+  {
+    "sctid": "15182000",
+    "preferred_name": "Coffin-Lowry syndrome"
+  },
+  {
+    "sctid": "15193003",
+    "preferred_name": "Severe recurrent major depression with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "152148641000119104",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral carotid arteries"
+  },
+  {
+    "sctid": "15244003",
+    "preferred_name": "Neuroleptic malignant syndrome"
+  },
+  {
+    "sctid": "15277004",
+    "preferred_name": "Hallucinogen-induced anxiety disorder"
+  },
+  {
+    "sctid": "153071000119108",
+    "preferred_name": "Recurrent manic episodes in partial remission"
+  },
+  {
+    "sctid": "153091000119109",
+    "preferred_name": "Hepatic coma due to chronic hepatitis B with delta agent"
+  },
+  {
+    "sctid": "15316002",
+    "preferred_name": "Simian B encephalomyelitis"
+  },
+  {
+    "sctid": "1538006",
+    "preferred_name": "Central nervous system malformation in fetus affecting obstetrical care"
+  },
+  {
+    "sctid": "15523002",
+    "preferred_name": "Benign focal epilepsy of childhood"
+  },
+  {
+    "sctid": "15552004",
+    "preferred_name": "Osteogenesis imperfecta, recessive perinatal lethal, with microcephaly AND cataracts"
+  },
+  {
+    "sctid": "15629411000119106",
+    "preferred_name": "Subependymoma of brain"
+  },
+  {
+    "sctid": "15631011000119102",
+    "preferred_name": "Neuritis of right optic nerve"
+  },
+  {
+    "sctid": "15631051000119101",
+    "preferred_name": "Neuritis of left optic nerve"
+  },
+  {
+    "sctid": "15631251000119109",
+    "preferred_name": "Blepharospasm of right eyelid"
+  },
+  {
+    "sctid": "15631291000119104",
+    "preferred_name": "Blepharospasm of left eyelid"
+  },
+  {
+    "sctid": "15631331000119105",
+    "preferred_name": "Bilateral blepharospasm"
+  },
+  {
+    "sctid": "15632811000119100",
+    "preferred_name": "Optic atrophy of right eye"
+  },
+  {
+    "sctid": "15632851000119104",
+    "preferred_name": "Optic atrophy of left eye"
+  },
+  {
+    "sctid": "15632891000119109",
+    "preferred_name": "Bilateral optic atrophy of eyes"
+  },
+  {
+    "sctid": "15639000",
+    "preferred_name": "Moderate major depression, single episode"
+  },
+  {
+    "sctid": "15662003",
+    "preferred_name": "Senile dementia"
+  },
+  {
+    "sctid": "15671007",
+    "preferred_name": "Encephalocele of orbit"
+  },
+  {
+    "sctid": "15699081000119101",
+    "preferred_name": "Hereditary bilateral optic atrophy"
+  },
+  {
+    "sctid": "15699121000119104",
+    "preferred_name": "Hereditary right optic atrophy"
+  },
+  {
+    "sctid": "15699161000119109",
+    "preferred_name": "Hereditary left optic atrophy"
+  },
+  {
+    "sctid": "15705007",
+    "preferred_name": "Phlebitis of basilar sinus"
+  },
+  {
+    "sctid": "15731281000119106",
+    "preferred_name": "Papilledema of bilateral eyes due to raised intracranial pressure"
+  },
+  {
+    "sctid": "15731521000119105",
+    "preferred_name": "Papilledema of right eye"
+  },
+  {
+    "sctid": "15731561000119100",
+    "preferred_name": "Papilledema of left eye"
+  },
+  {
+    "sctid": "15731601000119100",
+    "preferred_name": "Anterior ischemic optic neuropathy of left eye"
+  },
+  {
+    "sctid": "15731641000119103",
+    "preferred_name": "Anterior ischemic optic neuropathy of right eye"
+  },
+  {
+    "sctid": "15731801000119104",
+    "preferred_name": "Disorder of left optic nerve"
+  },
+  {
+    "sctid": "15731841000119102",
+    "preferred_name": "Disorder of right optic nerve"
+  },
+  {
+    "sctid": "15731881000119107",
+    "preferred_name": "Disorder of bilateral optic nerves"
+  },
+  {
+    "sctid": "15739801000119100",
+    "preferred_name": "Cupping of left optic disc due to open-angle glaucoma of left eye"
+  },
+  {
+    "sctid": "15739881000119108",
+    "preferred_name": "Cupping of right optic disc due to open-angle glaucoma of right eye"
+  },
+  {
+    "sctid": "15742000",
+    "preferred_name": "Thrombosis of inferior sagittal sinus"
+  },
+  {
+    "sctid": "15758002",
+    "preferred_name": "Disorder of meninges"
+  },
+  {
+    "sctid": "15771004",
+    "preferred_name": "Diabetes insipidus"
+  },
+  {
+    "sctid": "15782007",
+    "preferred_name": "MPTP-induced parkinsonism"
+  },
+  {
+    "sctid": "15802004",
+    "preferred_name": "Dystonia"
+  },
+  {
+    "sctid": "1581000119101",
+    "preferred_name": "Dementia of the Alzheimer type with behavioral disturbance"
+  },
+  {
+    "sctid": "15840001",
+    "preferred_name": "Symptomatic fetishism"
+  },
+  {
+    "sctid": "15863451000119107",
+    "preferred_name": "Lipoma of brain"
+  },
+  {
+    "sctid": "1591000119103",
+    "preferred_name": "Dementia with behavioral disturbance"
+  },
+  {
+    "sctid": "15913031000119100",
+    "preferred_name": "Bilateral cortical blindness of brain"
+  },
+  {
+    "sctid": "15921731000119106",
+    "preferred_name": "Psychotic disorder caused by methamphetamine"
+  },
+  {
+    "sctid": "1593000",
+    "preferred_name": "Infantile hemiplegia"
+  },
+  {
+    "sctid": "15930301000119107",
+    "preferred_name": "Edema of optic disc of right eye"
+  },
+  {
+    "sctid": "15930341000119109",
+    "preferred_name": "Edema of optic disc of left eye"
+  },
+  {
+    "sctid": "15930381000119104",
+    "preferred_name": "Edema of optic disc of bilateral eyes"
+  },
+  {
+    "sctid": "15938005",
+    "preferred_name": "Eclampsia"
+  },
+  {
+    "sctid": "15945005",
+    "preferred_name": "Psychogenic polydipsia"
+  },
+  {
+    "sctid": "15977008",
+    "preferred_name": "Adjustment disorder with academic inhibition"
+  },
+  {
+    "sctid": "15978551000119104",
+    "preferred_name": "Myelopathy of thoracolumbar spine due to disc disorder"
+  },
+  {
+    "sctid": "15984951000119108",
+    "preferred_name": "Neonatal spontaneous cerebellar hemorrhage"
+  },
+  {
+    "sctid": "15984991000119103",
+    "preferred_name": "Spontaneous intracerebral hemorrhage in neonate"
+  },
+  {
+    "sctid": "15985031000119102",
+    "preferred_name": "Neonatal non-traumatic intraventricular hemorrhage"
+  },
+  {
+    "sctid": "15985111000119106",
+    "preferred_name": "Neonatal nontraumatic subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "15985351000119105",
+    "preferred_name": "Intractable juvenile myoclonic status epilepticus"
+  },
+  {
+    "sctid": "15985791000119101",
+    "preferred_name": "Dystonia of right hand"
+  },
+  {
+    "sctid": "15985831000119107",
+    "preferred_name": "Dystonia of left hand"
+  },
+  {
+    "sctid": "15986111000119101",
+    "preferred_name": "Bilateral congenital coloboma of optic discs"
+  },
+  {
+    "sctid": "15986151000119100",
+    "preferred_name": "Congenital coloboma of right optic disc"
+  },
+  {
+    "sctid": "15986191000119105",
+    "preferred_name": "Congenital coloboma of left optic disc"
+  },
+  {
+    "sctid": "15986231000119101",
+    "preferred_name": "Congenital anomaly of right optic disc"
+  },
+  {
+    "sctid": "15986271000119103",
+    "preferred_name": "Bilateral congenital anomaly of optic disc"
+  },
+  {
+    "sctid": "15986311000119103",
+    "preferred_name": "Congenital anomaly of left optic disc"
+  },
+  {
+    "sctid": "15992631000119101",
+    "preferred_name": "Neuroretinitis of right eye"
+  },
+  {
+    "sctid": "15992671000119103",
+    "preferred_name": "Neuroretinitis of left eye"
+  },
+  {
+    "sctid": "15992711000119104",
+    "preferred_name": "Bilateral neuroretinitis of eyes"
+  },
+  {
+    "sctid": "15997591000119103",
+    "preferred_name": "Central serous choroidopathy of right eye"
+  },
+  {
+    "sctid": "15997631000119103",
+    "preferred_name": "Central serous choroidopathy of bilateral eyes"
+  },
+  {
+    "sctid": "15997671000119100",
+    "preferred_name": "Central serous choroidopathy of left eye"
+  },
+  {
+    "sctid": "16000351000119109",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left posterior cerebral artery"
+  },
+  {
+    "sctid": "16000391000119104",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right posterior cerebral artery"
+  },
+  {
+    "sctid": "16000431000119109",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right middle cerebral artery"
+  },
+  {
+    "sctid": "16000511000119103",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left middle cerebral artery"
+  },
+  {
+    "sctid": "16002031000119102",
+    "preferred_name": "Cerebrovascular accident due to thrombus of right middle cerebral artery"
+  },
+  {
+    "sctid": "16002071000119104",
+    "preferred_name": "Cerebrovascular accident due to thrombus of right cerebellar artery"
+  },
+  {
+    "sctid": "16002111000119106",
+    "preferred_name": "Cerebrovascular accident due to thrombus of left middle cerebral artery"
+  },
+  {
+    "sctid": "16002151000119107",
+    "preferred_name": "Nonpyogenic cerebral venous thrombosis with stroke"
+  },
+  {
+    "sctid": "16002191000119102",
+    "preferred_name": "Left cerebellar artery thrombosis with stroke"
+  },
+  {
+    "sctid": "16002231000119106",
+    "preferred_name": "Cerebrovascular accident due to thrombus of right posterior cerebral artery"
+  },
+  {
+    "sctid": "16002271000119109",
+    "preferred_name": "Left posterior cerebral artery thrombosis with stroke"
+  },
+  {
+    "sctid": "16002351000119105",
+    "preferred_name": "Right vertebral artery embolism with stroke"
+  },
+  {
+    "sctid": "16002391000119100",
+    "preferred_name": "Left vertebral artery embolism with stroke"
+  },
+  {
+    "sctid": "16002431000119105",
+    "preferred_name": "Right carotid artery embolism with stroke"
+  },
+  {
+    "sctid": "16002471000119108",
+    "preferred_name": "Left carotid artery embolism with stroke"
+  },
+  {
+    "sctid": "16002511000119104",
+    "preferred_name": "Basilar artery embolism with stroke"
+  },
+  {
+    "sctid": "16023911000119108",
+    "preferred_name": "Cerebrovascular accident due to right carotid artery occlusion"
+  },
+  {
+    "sctid": "16023991000119104",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left pontine artery"
+  },
+  {
+    "sctid": "16024031000119100",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right pontine artery"
+  },
+  {
+    "sctid": "16024111000119109",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left carotid artery"
+  },
+  {
+    "sctid": "16024151000119105",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left cerebellar artery"
+  },
+  {
+    "sctid": "16024271000119107",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right cerebellar artery"
+  },
+  {
+    "sctid": "16026008",
+    "preferred_name": "Congenital cerebellar hypoplasia"
+  },
+  {
+    "sctid": "16026951000119102",
+    "preferred_name": "Cerebrovascular accident due to right carotid artery stenosis"
+  },
+  {
+    "sctid": "16026991000119107",
+    "preferred_name": "Cerebrovascular accident due to left carotid artery stenosis"
+  },
+  {
+    "sctid": "16053991000119103",
+    "preferred_name": "Injury of neonatal central nervous system due to birth trauma"
+  },
+  {
+    "sctid": "16054391000119102",
+    "preferred_name": "Congenital hypoplasia of right optic nerve"
+  },
+  {
+    "sctid": "16054431000119107",
+    "preferred_name": "Congenital hypoplasia of left optic nerve"
+  },
+  {
+    "sctid": "16054471000119105",
+    "preferred_name": "Bilateral congenital hypoplasia of optic nerves"
+  },
+  {
+    "sctid": "16058431000119104",
+    "preferred_name": "White matter disease"
+  },
+  {
+    "sctid": "16060001",
+    "preferred_name": "Hepatic coma due to viral hepatitis A"
+  },
+  {
+    "sctid": "16061002",
+    "preferred_name": "Endophlebitis of lateral venous sinus"
+  },
+  {
+    "sctid": "16171003",
+    "preferred_name": "Double athetosis"
+  },
+  {
+    "sctid": "162004",
+    "preferred_name": "Severe manic bipolar I disorder without psychotic features"
+  },
+  {
+    "sctid": "16207161000119102",
+    "preferred_name": "Cavernous hemangioma of spinal cord"
+  },
+  {
+    "sctid": "16219201000119101",
+    "preferred_name": "Behavioral disturbance co-occurrent and due to late onset Alzheimer dementia"
+  },
+  {
+    "sctid": "16219341000119105",
+    "preferred_name": "Myelopathy due to spinal cord compression"
+  },
+  {
+    "sctid": "162218007",
+    "preferred_name": "Stress-related problem"
+  },
+  {
+    "sctid": "162313000",
+    "preferred_name": "Morbid jealousy"
+  },
+  {
+    "sctid": "16236661000119100",
+    "preferred_name": "Delirium due to methamphetamine intoxication"
+  },
+  {
+    "sctid": "16236701000119107",
+    "preferred_name": "Delirium due to drug withdrawal"
+  },
+  {
+    "sctid": "16238181000119101",
+    "preferred_name": "Depressive disorder caused by amphetamine"
+  },
+  {
+    "sctid": "16238221000119109",
+    "preferred_name": "Depressive disorder caused by methamphetamine"
+  },
+  {
+    "sctid": "16238741000119105",
+    "preferred_name": "Bipolar disorder caused by drug"
+  },
+  {
+    "sctid": "16264621000119109",
+    "preferred_name": "Recurrent mild major depressive disorder co-occurrent with anxiety"
+  },
+  {
+    "sctid": "16264821000119108",
+    "preferred_name": "Recurrent severe major depressive disorder co-occurrent with anxiety"
+  },
+  {
+    "sctid": "16264901000119109",
+    "preferred_name": "Recurrent moderate major depressive disorder co-occurrent with anxiety"
+  },
+  {
+    "sctid": "16265061000119105",
+    "preferred_name": "Recurrent major depressive disorder co-occurrent with anxiety in full remission"
+  },
+  {
+    "sctid": "16265301000119106",
+    "preferred_name": "Recurrent major depressive disorder in partial remission co-occurrent with anxiety"
+  },
+  {
+    "sctid": "16265701000119107",
+    "preferred_name": "Illness anxiety disorder"
+  },
+  {
+    "sctid": "16265951000119109",
+    "preferred_name": "Mild major depressive disorder co-occurrent with anxiety single episode"
+  },
+  {
+    "sctid": "16266831000119100",
+    "preferred_name": "Moderate major depressive disorder co-occurrent with anxiety single episode"
+  },
+  {
+    "sctid": "16266991000119108",
+    "preferred_name": "Severe major depressive disorder co-occurrent with anxiety single episode"
+  },
+  {
+    "sctid": "16270831000119107",
+    "preferred_name": "Bulimia nervosa in partial remission"
+  },
+  {
+    "sctid": "16270871000119105",
+    "preferred_name": "Bulimia nervosa in full remission"
+  },
+  {
+    "sctid": "16276361000119109",
+    "preferred_name": "Vascular dementia without behavioral disturbance"
+  },
+  {
+    "sctid": "16279005",
+    "preferred_name": "Disorder of neurometabolic regulation"
+  },
+  {
+    "sctid": "16279021000119106",
+    "preferred_name": "Delirium due to opioid withdrawal"
+  },
+  {
+    "sctid": "16295005",
+    "preferred_name": "Bipolar II disorder, most recent episode major depressive"
+  },
+  {
+    "sctid": "16300007",
+    "preferred_name": "Spinal cord abscess"
+  },
+  {
+    "sctid": "16319002",
+    "preferred_name": "Cortex contusion without open intracranial wound AND with concussion"
+  },
+  {
+    "sctid": "16371781000119100",
+    "preferred_name": "Cerebellar stroke"
+  },
+  {
+    "sctid": "16376191000119109",
+    "preferred_name": "Bilateral arteritic anterior ischemic optic neuropathy of eyes"
+  },
+  {
+    "sctid": "16376241000119109",
+    "preferred_name": "Arteritic anterior ischemic optic neuropathy of left eye"
+  },
+  {
+    "sctid": "16376391000119106",
+    "preferred_name": "Arteritic anterior ischemic optic neuropathy of right eye"
+  },
+  {
+    "sctid": "16415361000119105",
+    "preferred_name": "Radiologically isolated syndrome"
+  },
+  {
+    "sctid": "16418006",
+    "preferred_name": "Embolism of basilar sinus"
+  },
+  {
+    "sctid": "16476641000119100",
+    "preferred_name": "Acquired arteriovenous fistula of dura of cerebrum"
+  },
+  {
+    "sctid": "16476681000119105",
+    "preferred_name": "Spontaneous intracranial hypotension"
+  },
+  {
+    "sctid": "16506000",
+    "preferred_name": "Mixed bipolar I disorder"
+  },
+  {
+    "sctid": "16517004",
+    "preferred_name": "Cerebral lipidosis"
+  },
+  {
+    "sctid": "16561007",
+    "preferred_name": "Acute anoxic encephalopathy"
+  },
+  {
+    "sctid": "166071000000101",
+    "preferred_name": "Congenital dilated lateral ventricles of brain"
+  },
+  {
+    "sctid": "16631009",
+    "preferred_name": "Transverse myelopathy syndrome"
+  },
+  {
+    "sctid": "16644681000119102",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral pontine arteries"
+  },
+  {
+    "sctid": "16661931000119102",
+    "preferred_name": "Cerebrovascular accident due to stenosis of bilateral vertebral arteries"
+  },
+  {
+    "sctid": "16661971000119104",
+    "preferred_name": "Cerebrovascular accident due to stenosis of bilateral carotid arteries"
+  },
+  {
+    "sctid": "16695002",
+    "preferred_name": "Open fracture of T1-T6 level with spinal cord injury"
+  },
+  {
+    "sctid": "1670004",
+    "preferred_name": "Cerebral hemiparesis"
+  },
+  {
+    "sctid": "16709811000119106",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from anterior communicating artery"
+  },
+  {
+    "sctid": "16805009",
+    "preferred_name": "Cluster A personality disorder"
+  },
+  {
+    "sctid": "16818591000119108",
+    "preferred_name": "Calcification of basal ganglia"
+  },
+  {
+    "sctid": "16845301000119108",
+    "preferred_name": "Primary glioblastoma multiforme of cerebellum"
+  },
+  {
+    "sctid": "16845341000119105",
+    "preferred_name": "Primary glioblastoma multiforme of brainstem"
+  },
+  {
+    "sctid": "1686006",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced anxiety disorder"
+  },
+  {
+    "sctid": "168747591000119109",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral posterior cerebral arteries"
+  },
+  {
+    "sctid": "16891111000119104",
+    "preferred_name": "Cryptogenic stroke"
+  },
+  {
+    "sctid": "16901001",
+    "preferred_name": "Encephalitis due to European subtype of tick-borne encephalitis virus"
+  },
+  {
+    "sctid": "16903531000119107",
+    "preferred_name": "Atypical meningioma of cerebral meninges"
+  },
+  {
+    "sctid": "16966009",
+    "preferred_name": "Factitious hypoglycemia"
+  },
+  {
+    "sctid": "16990005",
+    "preferred_name": "Subchronic schizophrenia"
+  },
+  {
+    "sctid": "16997008",
+    "preferred_name": "Neonatal agitation"
+  },
+  {
+    "sctid": "171131006",
+    "preferred_name": "Meningocele"
+  },
+  {
+    "sctid": "17151000119108",
+    "preferred_name": "Partial growth hormone deficiency"
+  },
+  {
+    "sctid": "17155009",
+    "preferred_name": "Trichotillomania"
+  },
+  {
+    "sctid": "17169009",
+    "preferred_name": "Cerebellar contusion without open intracranial wound AND with loss of consciousness"
+  },
+  {
+    "sctid": "172069000",
+    "preferred_name": "Congenital meningocele"
+  },
+  {
+    "sctid": "17226007",
+    "preferred_name": "Adjustment disorder"
+  },
+  {
+    "sctid": "17258002",
+    "preferred_name": "Chronic anoxic encephalopathy"
+  },
+  {
+    "sctid": "17262008",
+    "preferred_name": "Non-alcoholic Korsakoff's psychosis"
+  },
+  {
+    "sctid": "1734006",
+    "preferred_name": "Fracture of vertebral column with spinal cord injury"
+  },
+  {
+    "sctid": "1740001000004102",
+    "preferred_name": "Iatrogenic thyrotoxicosis factitia"
+  },
+  {
+    "sctid": "17409003",
+    "preferred_name": "Facial hemiparesis"
+  },
+  {
+    "sctid": "17496003",
+    "preferred_name": "Organic anxiety disorder"
+  },
+  {
+    "sctid": "17498002",
+    "preferred_name": "Cortex contusion without open intracranial wound AND with loss of consciousness"
+  },
+  {
+    "sctid": "17570001000004102",
+    "preferred_name": "Mass of right temporal lobe"
+  },
+  {
+    "sctid": "1767005",
+    "preferred_name": "Fisher's syndrome"
+  },
+  {
+    "sctid": "17761000119109",
+    "preferred_name": "High lumbar myelomeningocele"
+  },
+  {
+    "sctid": "17771000119103",
+    "preferred_name": "Low lumbar myelomeningocele"
+  },
+  {
+    "sctid": "17782008",
+    "preferred_name": "Bipolar I disorder, most recent episode manic with catatonic features"
+  },
+  {
+    "sctid": "17827007",
+    "preferred_name": "Cross syndrome"
+  },
+  {
+    "sctid": "17944005",
+    "preferred_name": "Cerebral calcification"
+  },
+  {
+    "sctid": "17949000",
+    "preferred_name": "Meningoencephalitis due to acquired toxoplasmosis"
+  },
+  {
+    "sctid": "17961008",
+    "preferred_name": "Conduct disorder, childhood-onset type"
+  },
+  {
+    "sctid": "18003009",
+    "preferred_name": "Gender identity disorder of adulthood"
+  },
+  {
+    "sctid": "18058007",
+    "preferred_name": "Phlebitis of intracranial venous sinus"
+  },
+  {
+    "sctid": "18071005",
+    "preferred_name": "Meningococcal encephalitis"
+  },
+  {
+    "sctid": "18085000",
+    "preferred_name": "Compulsive gambling"
+  },
+  {
+    "sctid": "1816003",
+    "preferred_name": "Panic disorder with agoraphobia, severe agoraphobic avoidance AND mild panic attacks"
+  },
+  {
+    "sctid": "18186001",
+    "preferred_name": "True compulsive fetishism"
+  },
+  {
+    "sctid": "18193002",
+    "preferred_name": "Hypochondriasis"
+  },
+  {
+    "sctid": "18200000",
+    "preferred_name": "Autosomal recessive isolated somatotropin deficiency"
+  },
+  {
+    "sctid": "18260003",
+    "preferred_name": "Postpartum psychosis"
+  },
+  {
+    "sctid": "182960891000119101",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left anterior cerebral artery"
+  },
+  {
+    "sctid": "182961000119101",
+    "preferred_name": "Acute disseminated encephalomyelitis following infectious disease"
+  },
+  {
+    "sctid": "18311006",
+    "preferred_name": "Aseptic meningitis due to drug"
+  },
+  {
+    "sctid": "18393005",
+    "preferred_name": "Undifferentiated somatoform disorder"
+  },
+  {
+    "sctid": "18478005",
+    "preferred_name": "Adjustment disorder with physical complaints"
+  },
+  {
+    "sctid": "18491000119109",
+    "preferred_name": "Psychological disorder during pregnancy"
+  },
+  {
+    "sctid": "18541000119100",
+    "preferred_name": "Borderline cognitive developmental delay"
+  },
+  {
+    "sctid": "1855002",
+    "preferred_name": "Developmental academic disorder"
+  },
+  {
+    "sctid": "18573003",
+    "preferred_name": "Obsessional erotomania"
+  },
+  {
+    "sctid": "18615009",
+    "preferred_name": "Sunstroke"
+  },
+  {
+    "sctid": "186217006",
+    "preferred_name": "Tuberculous abscess of brain"
+  },
+  {
+    "sctid": "186284005",
+    "preferred_name": "Plague meningitis"
+  },
+  {
+    "sctid": "186476008",
+    "preferred_name": "Acute paralytic non-bulbar poliomyelitis"
+  },
+  {
+    "sctid": "186478009",
+    "preferred_name": "Acute paralytic poliomyelitis, vaccine-associated"
+  },
+  {
+    "sctid": "186479001",
+    "preferred_name": "Acute paralytic poliomyelitis, wild virus, imported"
+  },
+  {
+    "sctid": "186480003",
+    "preferred_name": "Acute paralytic poliomyelitis, wild virus, indigenous"
+  },
+  {
+    "sctid": "186482006",
+    "preferred_name": "Slow viral central nervous system infection"
+  },
+  {
+    "sctid": "186498004",
+    "preferred_name": "Epidemic encephalitis"
+  },
+  {
+    "sctid": "186499007",
+    "preferred_name": "Encephalitis lethargica"
+  },
+  {
+    "sctid": "186509002",
+    "preferred_name": "Postvaricella encephalitis"
+  },
+  {
+    "sctid": "18653004",
+    "preferred_name": "Alcohol intoxication delirium"
+  },
+  {
+    "sctid": "186561002",
+    "preferred_name": "Measles complicated by meningitis"
+  },
+  {
+    "sctid": "186591007",
+    "preferred_name": "Encephalitis due to Far Eastern tick-borne encephalitis virus"
+  },
+  {
+    "sctid": "186624004",
+    "preferred_name": "Hepatic coma due to acute hepatitis B with delta agent"
+  },
+  {
+    "sctid": "186628001",
+    "preferred_name": "Hepatic coma due to viral hepatitis C"
+  },
+  {
+    "sctid": "186791009",
+    "preferred_name": "Plasmodium falciparum malaria with cerebral complications"
+  },
+  {
+    "sctid": "186863009",
+    "preferred_name": "Acute secondary syphilitic meningitis"
+  },
+  {
+    "sctid": "18689007",
+    "preferred_name": "Inhalant intoxication delirium"
+  },
+  {
+    "sctid": "186956008",
+    "preferred_name": "Leptospiral meningitis"
+  },
+  {
+    "sctid": "187080002",
+    "preferred_name": "Pheohyphomycotic brain abscess"
+  },
+  {
+    "sctid": "187094001",
+    "preferred_name": "Cerebral cryptococcosis"
+  },
+  {
+    "sctid": "187100003",
+    "preferred_name": "Rhinocerebral mucormycosis"
+  },
+  {
+    "sctid": "187148002",
+    "preferred_name": "Cysticercosis of central nervous system"
+  },
+  {
+    "sctid": "187253003",
+    "preferred_name": "Late effects of central nervous system tuberculosis"
+  },
+  {
+    "sctid": "187921002",
+    "preferred_name": "Developmental receptive language disorder"
+  },
+  {
+    "sctid": "187931000119106",
+    "preferred_name": "Atypical absence epilepsy"
+  },
+  {
+    "sctid": "188174841000119103",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral middle cerebral arteries"
+  },
+  {
+    "sctid": "18818009",
+    "preferred_name": "Moderate recurrent major depression"
+  },
+  {
+    "sctid": "188280007",
+    "preferred_name": "Malignant neoplasm of cerebrum (excluding lobes and ventricles)"
+  },
+  {
+    "sctid": "188281006",
+    "preferred_name": "Malignant neoplasm of basal ganglia"
+  },
+  {
+    "sctid": "188282004",
+    "preferred_name": "Malignant neoplasm of cerebral cortex"
+  },
+  {
+    "sctid": "188283009",
+    "preferred_name": "Malignant neoplasm of corpus striatum"
+  },
+  {
+    "sctid": "188285002",
+    "preferred_name": "Malignant neoplasm of globus pallidus"
+  },
+  {
+    "sctid": "188286001",
+    "preferred_name": "Malignant tumor of hypothalamus"
+  },
+  {
+    "sctid": "188287005",
+    "preferred_name": "Malignant neoplasm of thalamus"
+  },
+  {
+    "sctid": "188289008",
+    "preferred_name": "Malignant neoplasm of hippocampus"
+  },
+  {
+    "sctid": "188290004",
+    "preferred_name": "Malignant neoplasm of uncus"
+  },
+  {
+    "sctid": "188292007",
+    "preferred_name": "Malignant tumor of choroid plexus"
+  },
+  {
+    "sctid": "188293002",
+    "preferred_name": "Malignant neoplasm of floor of cerebral ventricle"
+  },
+  {
+    "sctid": "188295009",
+    "preferred_name": "Malignant neoplasm of cerebral peduncle"
+  },
+  {
+    "sctid": "188296005",
+    "preferred_name": "Malignant neoplasm of medulla oblongata"
+  },
+  {
+    "sctid": "188297001",
+    "preferred_name": "Malignant neoplasm of midbrain"
+  },
+  {
+    "sctid": "188298006",
+    "preferred_name": "Malignant neoplasm of pons"
+  },
+  {
+    "sctid": "188301005",
+    "preferred_name": "Malignant neoplasm of corpus callosum"
+  },
+  {
+    "sctid": "188302003",
+    "preferred_name": "Malignant neoplasm of tapetum"
+  },
+  {
+    "sctid": "188308004",
+    "preferred_name": "Malignant neoplasm of olfactory bulb"
+  },
+  {
+    "sctid": "188312005",
+    "preferred_name": "Malignant neoplasm of cerebral dura mater"
+  },
+  {
+    "sctid": "188313000",
+    "preferred_name": "Malignant neoplasm of cerebral arachnoid mater"
+  },
+  {
+    "sctid": "188315007",
+    "preferred_name": "Malignant neoplasm of cerebral pia mater"
+  },
+  {
+    "sctid": "188317004",
+    "preferred_name": "Malignant neoplasm of spinal dura mater"
+  },
+  {
+    "sctid": "188318009",
+    "preferred_name": "Malignant neoplasm of spinal arachnoid mater"
+  },
+  {
+    "sctid": "188319001",
+    "preferred_name": "Malignant neoplasm of spinal pia mater"
+  },
+  {
+    "sctid": "188339002",
+    "preferred_name": "Malignant neoplasm of pituitary gland and craniopharyngeal duct"
+  },
+  {
+    "sctid": "188340000",
+    "preferred_name": "Malignant tumor of craniopharyngeal duct"
+  },
+  {
+    "sctid": "18842008",
+    "preferred_name": "Corticobasal degeneration"
+  },
+  {
+    "sctid": "188462001",
+    "preferred_name": "Secondary malignant neoplasm of brain and spinal cord"
+  },
+  {
+    "sctid": "18871009",
+    "preferred_name": "Cerebellar vertigo"
+  },
+  {
+    "sctid": "18894005",
+    "preferred_name": "Legal termination of pregnancy with cerebral anoxia"
+  },
+  {
+    "sctid": "189015008",
+    "preferred_name": "Lipoma of spinal epidural space"
+  },
+  {
+    "sctid": "189016009",
+    "preferred_name": "Lipoma of spinal canal - intradural"
+  },
+  {
+    "sctid": "189017000",
+    "preferred_name": "Lipoma of spinal cord"
+  },
+  {
+    "sctid": "189162003",
+    "preferred_name": "Benign neoplasm of brain, supratentorial"
+  },
+  {
+    "sctid": "189164002",
+    "preferred_name": "Cerebral meningioma"
+  },
+  {
+    "sctid": "189167009",
+    "preferred_name": "Spinal meningioma"
+  },
+  {
+    "sctid": "189179009",
+    "preferred_name": "Craniopharyngioma"
+  },
+  {
+    "sctid": "189198006",
+    "preferred_name": "Epileptic drop attack"
+  },
+  {
+    "sctid": "18941000",
+    "preferred_name": "Oppositional defiant disorder"
+  },
+  {
+    "sctid": "189484008",
+    "preferred_name": "Neoplasm of uncertain behavior of brain and spinal cord"
+  },
+  {
+    "sctid": "189487001",
+    "preferred_name": "Neoplasm of uncertain or unknown behavior of brain, supratentorial"
+  },
+  {
+    "sctid": "189488006",
+    "preferred_name": "Neoplasm of uncertain or unknown behavior of brain, infratentorial"
+  },
+  {
+    "sctid": "18960007",
+    "preferred_name": "Closed fracture of T7-T12 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "190330002",
+    "preferred_name": "Hyperosmolar coma due to type 1 diabetes mellitus"
+  },
+  {
+    "sctid": "190331003",
+    "preferred_name": "Hyperosmolar coma due to type 2 diabetes mellitus"
+  },
+  {
+    "sctid": "190470005",
+    "preferred_name": "Idiopathic panhypopituitarism"
+  },
+  {
+    "sctid": "190471009",
+    "preferred_name": "Post-birth injury panhypopituitarism"
+  },
+  {
+    "sctid": "190472002",
+    "preferred_name": "Post-infarction panhypopituitarism"
+  },
+  {
+    "sctid": "190480009",
+    "preferred_name": "Follicle stimulating hormone deficiency"
+  },
+  {
+    "sctid": "190481008",
+    "preferred_name": "LH - luteinizing hormone deficiency"
+  },
+  {
+    "sctid": "190492009",
+    "preferred_name": "Diencephalic syndrome secondary to tumor"
+  },
+  {
+    "sctid": "190502001",
+    "preferred_name": "Pituitary dependent hypercortisolism"
+  },
+  {
+    "sctid": "190823004",
+    "preferred_name": "Westphal-Strumpell syndrome"
+  },
+  {
+    "sctid": "19090001000004101",
+    "preferred_name": "Metastatic neoplasm of left basal ganglion"
+  },
+  {
+    "sctid": "19091006",
+    "preferred_name": "Pallidoluysian degeneration"
+  },
+  {
+    "sctid": "19109004",
+    "preferred_name": "Syringomyelobulbia"
+  },
+  {
+    "sctid": "191447007",
+    "preferred_name": "Organic psychotic condition"
+  },
+  {
+    "sctid": "191449005",
+    "preferred_name": "Uncomplicated senile dementia"
+  },
+  {
+    "sctid": "191451009",
+    "preferred_name": "Uncomplicated presenile dementia"
+  },
+  {
+    "sctid": "191452002",
+    "preferred_name": "Presenile dementia with delirium"
+  },
+  {
+    "sctid": "191454001",
+    "preferred_name": "Presenile dementia with paranoia"
+  },
+  {
+    "sctid": "191455000",
+    "preferred_name": "Presenile dementia with depression"
+  },
+  {
+    "sctid": "191457008",
+    "preferred_name": "Senile dementia with depressive or paranoid features"
+  },
+  {
+    "sctid": "191458003",
+    "preferred_name": "Senile dementia with paranoia"
+  },
+  {
+    "sctid": "191459006",
+    "preferred_name": "Senile dementia with depression"
+  },
+  {
+    "sctid": "191461002",
+    "preferred_name": "Senile dementia with delirium"
+  },
+  {
+    "sctid": "191463004",
+    "preferred_name": "Uncomplicated arteriosclerotic dementia"
+  },
+  {
+    "sctid": "191464005",
+    "preferred_name": "Arteriosclerotic dementia with delirium"
+  },
+  {
+    "sctid": "191465006",
+    "preferred_name": "Arteriosclerotic dementia with paranoia"
+  },
+  {
+    "sctid": "191466007",
+    "preferred_name": "Arteriosclerotic dementia with depression"
+  },
+  {
+    "sctid": "191471000",
+    "preferred_name": "Korsakov's alcoholic psychosis with peripheral neuritis"
+  },
+  {
+    "sctid": "191475009",
+    "preferred_name": "Chronic alcoholic brain syndrome"
+  },
+  {
+    "sctid": "191476005",
+    "preferred_name": "Alcohol withdrawal hallucinosis"
+  },
+  {
+    "sctid": "191478006",
+    "preferred_name": "Alcoholic paranoia"
+  },
+  {
+    "sctid": "191480000",
+    "preferred_name": "Alcohol withdrawal syndrome"
+  },
+  {
+    "sctid": "191483003",
+    "preferred_name": "Drug-induced psychosis"
+  },
+  {
+    "sctid": "191484009",
+    "preferred_name": "Drug-induced paranoia or hallucinatory states"
+  },
+  {
+    "sctid": "191485005",
+    "preferred_name": "Drug-induced paranoid state"
+  },
+  {
+    "sctid": "191486006",
+    "preferred_name": "Hallucinosis caused by drug"
+  },
+  {
+    "sctid": "191492000",
+    "preferred_name": "Drug-induced delirium"
+  },
+  {
+    "sctid": "191493005",
+    "preferred_name": "Drug-induced dementia"
+  },
+  {
+    "sctid": "191494004",
+    "preferred_name": "Drug-induced amnestic syndrome"
+  },
+  {
+    "sctid": "191495003",
+    "preferred_name": "Drug-induced depressive state"
+  },
+  {
+    "sctid": "191496002",
+    "preferred_name": "Drug-induced personality disorder"
+  },
+  {
+    "sctid": "191499009",
+    "preferred_name": "Transient organic psychoses"
+  },
+  {
+    "sctid": "191501001",
+    "preferred_name": "Acute confusional state, post-traumatic"
+  },
+  {
+    "sctid": "191502008",
+    "preferred_name": "Acute confusional state, of infective origin"
+  },
+  {
+    "sctid": "191503003",
+    "preferred_name": "Acute confusional state, of endocrine origin"
+  },
+  {
+    "sctid": "191504009",
+    "preferred_name": "Acute confusional state, of metabolic origin"
+  },
+  {
+    "sctid": "191505005",
+    "preferred_name": "Acute confusional state, of cerebrovascular origin"
+  },
+  {
+    "sctid": "191507002",
+    "preferred_name": "Subacute delirium"
+  },
+  {
+    "sctid": "191508007",
+    "preferred_name": "Subacute confusional state, post-traumatic"
+  },
+  {
+    "sctid": "191509004",
+    "preferred_name": "Subacute confusional state, of infective origin"
+  },
+  {
+    "sctid": "191510009",
+    "preferred_name": "Subacute confusional state, of endocrine origin"
+  },
+  {
+    "sctid": "191511008",
+    "preferred_name": "Subacute confusional state, of metabolic origin"
+  },
+  {
+    "sctid": "191512001",
+    "preferred_name": "Subacute confusional state, of cerebrovascular origin"
+  },
+  {
+    "sctid": "191519005",
+    "preferred_name": "Dementia associated with another disease"
+  },
+  {
+    "sctid": "191525009",
+    "preferred_name": "Non-organic psychosis"
+  },
+  {
+    "sctid": "191526005",
+    "preferred_name": "Schizophrenic disorders"
+  },
+  {
+    "sctid": "191527001",
+    "preferred_name": "Simple schizophrenia"
+  },
+  {
+    "sctid": "191531007",
+    "preferred_name": "Acute exacerbation of chronic schizophrenia"
+  },
+  {
+    "sctid": "191542003",
+    "preferred_name": "Catatonic schizophrenia"
+  },
+  {
+    "sctid": "191547009",
+    "preferred_name": "Acute exacerbation of subchronic catatonic schizophrenia"
+  },
+  {
+    "sctid": "191548004",
+    "preferred_name": "Acute exacerbation of chronic catatonic schizophrenia"
+  },
+  {
+    "sctid": "191554003",
+    "preferred_name": "Acute exacerbation of subchronic paranoid schizophrenia"
+  },
+  {
+    "sctid": "191555002",
+    "preferred_name": "Acute exacerbation of chronic paranoid schizophrenia"
+  },
+  {
+    "sctid": "191559008",
+    "preferred_name": "Latent schizophrenia"
+  },
+  {
+    "sctid": "191561004",
+    "preferred_name": "Subchronic latent schizophrenia"
+  },
+  {
+    "sctid": "191562006",
+    "preferred_name": "Chronic latent schizophrenia"
+  },
+  {
+    "sctid": "191563001",
+    "preferred_name": "Acute exacerbation of subchronic latent schizophrenia"
+  },
+  {
+    "sctid": "191564007",
+    "preferred_name": "Acute exacerbation of chronic latent schizophrenia"
+  },
+  {
+    "sctid": "191565008",
+    "preferred_name": "Latent schizophrenia in remission"
+  },
+  {
+    "sctid": "191567000",
+    "preferred_name": "Schizoaffective schizophrenia"
+  },
+  {
+    "sctid": "191569002",
+    "preferred_name": "Subchronic schizoaffective schizophrenia"
+  },
+  {
+    "sctid": "191570001",
+    "preferred_name": "Chronic schizoaffective schizophrenia"
+  },
+  {
+    "sctid": "191571002",
+    "preferred_name": "Acute exacerbation of subchronic schizoaffective schizophrenia"
+  },
+  {
+    "sctid": "191572009",
+    "preferred_name": "Acute exacerbation of chronic schizoaffective schizophrenia"
+  },
+  {
+    "sctid": "191574005",
+    "preferred_name": "Schizoaffective schizophrenia in remission"
+  },
+  {
+    "sctid": "191577003",
+    "preferred_name": "Cenesthopathic schizophrenia"
+  },
+  {
+    "sctid": "191583000",
+    "preferred_name": "Single manic episode, mild"
+  },
+  {
+    "sctid": "191584006",
+    "preferred_name": "Single manic episode, moderate"
+  },
+  {
+    "sctid": "191586008",
+    "preferred_name": "Single manic episode, severe, with psychosis"
+  },
+  {
+    "sctid": "191588009",
+    "preferred_name": "Single manic episode in full remission"
+  },
+  {
+    "sctid": "191590005",
+    "preferred_name": "Recurrent manic episodes"
+  },
+  {
+    "sctid": "191592002",
+    "preferred_name": "Recurrent manic episodes, mild"
+  },
+  {
+    "sctid": "191593007",
+    "preferred_name": "Recurrent manic episodes, moderate"
+  },
+  {
+    "sctid": "191595000",
+    "preferred_name": "Recurrent manic episodes, severe, with psychosis"
+  },
+  {
+    "sctid": "191597008",
+    "preferred_name": "Recurrent manic episodes, in full remission"
+  },
+  {
+    "sctid": "191604000",
+    "preferred_name": "Single major depressive episode, severe, with psychosis"
+  },
+  {
+    "sctid": "191610000",
+    "preferred_name": "Recurrent major depressive episodes, mild"
+  },
+  {
+    "sctid": "191611001",
+    "preferred_name": "Recurrent major depressive episodes, moderate"
+  },
+  {
+    "sctid": "191613003",
+    "preferred_name": "Recurrent major depressive episodes, severe, with psychosis"
+  },
+  {
+    "sctid": "191616006",
+    "preferred_name": "Recurrent depression"
+  },
+  {
+    "sctid": "191618007",
+    "preferred_name": "Bipolar affective disorder, current episode manic"
+  },
+  {
+    "sctid": "191620005",
+    "preferred_name": "Bipolar affective disorder, currently manic, mild"
+  },
+  {
+    "sctid": "191621009",
+    "preferred_name": "Bipolar affective disorder, currently manic, moderate"
+  },
+  {
+    "sctid": "191623007",
+    "preferred_name": "Bipolar affective disorder, currently manic, severe, with psychosis"
+  },
+  {
+    "sctid": "191625000",
+    "preferred_name": "Bipolar affective disorder, currently manic, in full remission"
+  },
+  {
+    "sctid": "191627008",
+    "preferred_name": "Bipolar affective disorder, current episode depression"
+  },
+  {
+    "sctid": "191629006",
+    "preferred_name": "Bipolar affective disorder, currently depressed, mild"
+  },
+  {
+    "sctid": "191630001",
+    "preferred_name": "Bipolar affective disorder, currently depressed, moderate"
+  },
+  {
+    "sctid": "191634005",
+    "preferred_name": "Bipolar affective disorder, currently depressed, in full remission"
+  },
+  {
+    "sctid": "191636007",
+    "preferred_name": "Mixed bipolar affective disorder"
+  },
+  {
+    "sctid": "191638008",
+    "preferred_name": "Mixed bipolar affective disorder, mild"
+  },
+  {
+    "sctid": "191639000",
+    "preferred_name": "Mixed bipolar affective disorder, moderate"
+  },
+  {
+    "sctid": "191641004",
+    "preferred_name": "Mixed bipolar affective disorder, severe, with psychosis"
+  },
+  {
+    "sctid": "191643001",
+    "preferred_name": "Mixed bipolar affective disorder, in full remission"
+  },
+  {
+    "sctid": "191658009",
+    "preferred_name": "Atypical manic disorder"
+  },
+  {
+    "sctid": "191659001",
+    "preferred_name": "Atypical depressive disorder"
+  },
+  {
+    "sctid": "191667009",
+    "preferred_name": "Paranoid disorder"
+  },
+  {
+    "sctid": "191668004",
+    "preferred_name": "Simple paranoid state"
+  },
+  {
+    "sctid": "191670008",
+    "preferred_name": "Shared paranoid disorder"
+  },
+  {
+    "sctid": "191672000",
+    "preferred_name": "Paranoia querulans"
+  },
+  {
+    "sctid": "191676002",
+    "preferred_name": "Reactive depressive psychosis"
+  },
+  {
+    "sctid": "191677006",
+    "preferred_name": "Acute hysterical psychosis"
+  },
+  {
+    "sctid": "191678001",
+    "preferred_name": "Reactive confusion"
+  },
+  {
+    "sctid": "191680007",
+    "preferred_name": "Psychogenic paranoid psychosis"
+  },
+  {
+    "sctid": "191683009",
+    "preferred_name": "Psychogenic stupor"
+  },
+  {
+    "sctid": "191687005",
+    "preferred_name": "Psychosis with origin in childhood"
+  },
+  {
+    "sctid": "191689008",
+    "preferred_name": "Active infantile autism"
+  },
+  {
+    "sctid": "191690004",
+    "preferred_name": "Residual infantile autism"
+  },
+  {
+    "sctid": "191692007",
+    "preferred_name": "Active disintegrative psychoses"
+  },
+  {
+    "sctid": "191693002",
+    "preferred_name": "Residual disintegrative psychoses"
+  },
+  {
+    "sctid": "191696005",
+    "preferred_name": "Atypical childhood psychoses"
+  },
+  {
+    "sctid": "191697001",
+    "preferred_name": "Borderline psychosis of childhood"
+  },
+  {
+    "sctid": "191713008",
+    "preferred_name": "Dissociative tremor"
+  },
+  {
+    "sctid": "191714002",
+    "preferred_name": "Dissociative convulsions"
+  },
+  {
+    "sctid": "191722009",
+    "preferred_name": "Agoraphobia with panic attacks"
+  },
+  {
+    "sctid": "191724005",
+    "preferred_name": "Social phobia, fear of eating in public"
+  },
+  {
+    "sctid": "191725006",
+    "preferred_name": "Social phobia, fear of public speaking"
+  },
+  {
+    "sctid": "191726007",
+    "preferred_name": "Social phobia, fear of public washing"
+  },
+  {
+    "sctid": "191736004",
+    "preferred_name": "Obsessive-compulsive disorder"
+  },
+  {
+    "sctid": "191737008",
+    "preferred_name": "Compulsive neurosis"
+  },
+  {
+    "sctid": "191738003",
+    "preferred_name": "Obsessional neurosis"
+  },
+  {
+    "sctid": "191744004",
+    "preferred_name": "Writer's cramp neurosis"
+  },
+  {
+    "sctid": "191746002",
+    "preferred_name": "Psychasthenic neurosis"
+  },
+  {
+    "sctid": "191753006",
+    "preferred_name": "Hypomanic personality disorder"
+  },
+  {
+    "sctid": "191765005",
+    "preferred_name": "Emotionally unstable personality disorder"
+  },
+  {
+    "sctid": "191766006",
+    "preferred_name": "Psychoinfantile personality"
+  },
+  {
+    "sctid": "191772006",
+    "preferred_name": "Eccentric personality disorder"
+  },
+  {
+    "sctid": "191773001",
+    "preferred_name": "Immature personality disorder"
+  },
+  {
+    "sctid": "191774007",
+    "preferred_name": "Masochistic personality disorder"
+  },
+  {
+    "sctid": "191787001",
+    "preferred_name": "Psychosexual identity disorder"
+  },
+  {
+    "sctid": "191811004",
+    "preferred_name": "Continuous chronic alcoholism"
+  },
+  {
+    "sctid": "191812006",
+    "preferred_name": "Episodic chronic alcoholism"
+  },
+  {
+    "sctid": "191813001",
+    "preferred_name": "Chronic alcoholism in remission"
+  },
+  {
+    "sctid": "191882002",
+    "preferred_name": "Nondependent alcohol abuse, continuous"
+  },
+  {
+    "sctid": "191883007",
+    "preferred_name": "Nondependent alcohol abuse, episodic"
+  },
+  {
+    "sctid": "191884001",
+    "preferred_name": "Nondependent alcohol abuse in remission"
+  },
+  {
+    "sctid": "191928000",
+    "preferred_name": "Abuse of antidepressant drug"
+  },
+  {
+    "sctid": "191930003",
+    "preferred_name": "Nondependent antidepressant type drug abuse, continuous"
+  },
+  {
+    "sctid": "191931004",
+    "preferred_name": "Nondependent antidepressant type drug abuse, episodic"
+  },
+  {
+    "sctid": "191932006",
+    "preferred_name": "Nondependent antidepressant type drug abuse in remission"
+  },
+  {
+    "sctid": "191952007",
+    "preferred_name": "Somatoform autonomic dysfunction - respiratory tract"
+  },
+  {
+    "sctid": "191953002",
+    "preferred_name": "Psychogenic air hunger"
+  },
+  {
+    "sctid": "191962000",
+    "preferred_name": "Neurocirculatory asthenia"
+  },
+  {
+    "sctid": "191965003",
+    "preferred_name": "Psychogenic skin symptoms"
+  },
+  {
+    "sctid": "191966002",
+    "preferred_name": "Psychogenic pruritus"
+  },
+  {
+    "sctid": "191972002",
+    "preferred_name": "Psychogenic dyspepsia"
+  },
+  {
+    "sctid": "191973007",
+    "preferred_name": "Psychogenic constipation"
+  },
+  {
+    "sctid": "191980009",
+    "preferred_name": "Psychogenic endocrine malfunction"
+  },
+  {
+    "sctid": "191981008",
+    "preferred_name": "Psychogenic symptom of special sense organ"
+  },
+  {
+    "sctid": "191990001",
+    "preferred_name": "Transient childhood tic"
+  },
+  {
+    "sctid": "192003008",
+    "preferred_name": "Sleep drunkenness"
+  },
+  {
+    "sctid": "192014006",
+    "preferred_name": "Psychogenic rumination"
+  },
+  {
+    "sctid": "192016008",
+    "preferred_name": "Non-organic infant feeding disturbance"
+  },
+  {
+    "sctid": "192017004",
+    "preferred_name": "Non-organic loss of appetite"
+  },
+  {
+    "sctid": "192029008",
+    "preferred_name": "Psychogenic backache"
+  },
+  {
+    "sctid": "192037000",
+    "preferred_name": "Acute panic state due to acute stress reaction"
+  },
+  {
+    "sctid": "192038005",
+    "preferred_name": "Acute fugue state due to acute stress reaction"
+  },
+  {
+    "sctid": "192039002",
+    "preferred_name": "Acute stupor state due to acute stress reaction"
+  },
+  {
+    "sctid": "192041001",
+    "preferred_name": "Acute situational disturbance"
+  },
+  {
+    "sctid": "192042008",
+    "preferred_name": "Acute post-trauma stress state"
+  },
+  {
+    "sctid": "192044009",
+    "preferred_name": "Stress reaction causing mixed disturbance of emotion and conduct"
+  },
+  {
+    "sctid": "192046006",
+    "preferred_name": "Brief depressive adjustment reaction"
+  },
+  {
+    "sctid": "192049004",
+    "preferred_name": "Prolonged depressive adjustment reaction"
+  },
+  {
+    "sctid": "192051000",
+    "preferred_name": "Adolescent emancipation disorder"
+  },
+  {
+    "sctid": "192052007",
+    "preferred_name": "Early adult emancipation disorder"
+  },
+  {
+    "sctid": "192054008",
+    "preferred_name": "Culture shock"
+  },
+  {
+    "sctid": "192056005",
+    "preferred_name": "Adjustment reaction with aggression"
+  },
+  {
+    "sctid": "192057001",
+    "preferred_name": "Adjustment reaction with antisocial behavior"
+  },
+  {
+    "sctid": "192058006",
+    "preferred_name": "Adjustment reaction with destructiveness"
+  },
+  {
+    "sctid": "192061007",
+    "preferred_name": "Concentration camp syndrome"
+  },
+  {
+    "sctid": "192063005",
+    "preferred_name": "Adjustment reaction with physical symptoms"
+  },
+  {
+    "sctid": "192064004",
+    "preferred_name": "Elective mutism due to an adjustment reaction"
+  },
+  {
+    "sctid": "192065003",
+    "preferred_name": "Hospitalism"
+  },
+  {
+    "sctid": "192069009",
+    "preferred_name": "Specific nonpsychotic mental disorders following organic brain damage"
+  },
+  {
+    "sctid": "192072002",
+    "preferred_name": "Organic memory impairment"
+  },
+  {
+    "sctid": "192073007",
+    "preferred_name": "Change in personality"
+  },
+  {
+    "sctid": "192079006",
+    "preferred_name": "Postviral depression"
+  },
+  {
+    "sctid": "192080009",
+    "preferred_name": "Chronic depression"
+  },
+  {
+    "sctid": "192082001",
+    "preferred_name": "Aggressive unsocial conduct disorder"
+  },
+  {
+    "sctid": "192092009",
+    "preferred_name": "Group delinquency"
+  },
+  {
+    "sctid": "192097003",
+    "preferred_name": "Isolated explosive disorder"
+  },
+  {
+    "sctid": "192099000",
+    "preferred_name": "Childhood disorder of conduct and emotion"
+  },
+  {
+    "sctid": "19210000",
+    "preferred_name": "Brain stem laceration with open intracranial wound AND no loss of consciousness"
+  },
+  {
+    "sctid": "192100008",
+    "preferred_name": "Neurotic delinquency"
+  },
+  {
+    "sctid": "192108001",
+    "preferred_name": "Disturbance of anxiety and fearfulness in childhood and adolescence"
+  },
+  {
+    "sctid": "192110004",
+    "preferred_name": "Childhood and adolescent fearfulness disturbance"
+  },
+  {
+    "sctid": "192119003",
+    "preferred_name": "Sibling jealousy"
+  },
+  {
+    "sctid": "192123006",
+    "preferred_name": "Academic underachievement disorder"
+  },
+  {
+    "sctid": "192127007",
+    "preferred_name": "Child attention deficit disorder"
+  },
+  {
+    "sctid": "192131001",
+    "preferred_name": "Hyperkinesis with developmental delay"
+  },
+  {
+    "sctid": "192132008",
+    "preferred_name": "Hyperkinetic conduct disorder"
+  },
+  {
+    "sctid": "192136006",
+    "preferred_name": "Specific reading disorder"
+  },
+  {
+    "sctid": "192147004",
+    "preferred_name": "Mixed disorder of psychological development"
+  },
+  {
+    "sctid": "19233004",
+    "preferred_name": "Cerebellar contusion with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "192362008",
+    "preferred_name": "Bipolar affective disorder, current episode mixed"
+  },
+  {
+    "sctid": "192454004",
+    "preferred_name": "Nonorganic insomnia"
+  },
+  {
+    "sctid": "192527004",
+    "preferred_name": "Elaboration of physical symptoms for psychological reasons"
+  },
+  {
+    "sctid": "192562009",
+    "preferred_name": "Disorder of psychological development"
+  },
+  {
+    "sctid": "192575009",
+    "preferred_name": "Mixed disorder of scholastic skills"
+  },
+  {
+    "sctid": "192611004",
+    "preferred_name": "Childhood phobic anxiety disorder"
+  },
+  {
+    "sctid": "192616009",
+    "preferred_name": "Childhood or adolescent disorder of social functioning"
+  },
+  {
+    "sctid": "192630004",
+    "preferred_name": "Psychogenic feeding disorder of infancy and childhood"
+  },
+  {
+    "sctid": "192631000",
+    "preferred_name": "Pica of infancy and childhood"
+  },
+  {
+    "sctid": "192643004",
+    "preferred_name": "Haemophilus meningitis"
+  },
+  {
+    "sctid": "192644005",
+    "preferred_name": "Meningococcal meningitis"
+  },
+  {
+    "sctid": "192647003",
+    "preferred_name": "Secondary syphilitic meningitis"
+  },
+  {
+    "sctid": "192648008",
+    "preferred_name": "Meningitis due to typhoid fever"
+  },
+  {
+    "sctid": "192649000",
+    "preferred_name": "Actinomycotic meningitis"
+  },
+  {
+    "sctid": "192650000",
+    "preferred_name": "Meningitis due to pertussis"
+  },
+  {
+    "sctid": "192654009",
+    "preferred_name": "Meningitis due to bacillus pyocyaneus"
+  },
+  {
+    "sctid": "192655005",
+    "preferred_name": "Escherichia coli meningitis"
+  },
+  {
+    "sctid": "192656006",
+    "preferred_name": "Meningitis due to Friedlander bacillus"
+  },
+  {
+    "sctid": "192659004",
+    "preferred_name": "Morganella morganii meningitis"
+  },
+  {
+    "sctid": "192660009",
+    "preferred_name": "Pseudomonas meningitis"
+  },
+  {
+    "sctid": "192667007",
+    "preferred_name": "Echovirus meningitis"
+  },
+  {
+    "sctid": "192673008",
+    "preferred_name": "Sarcoid meningitis"
+  },
+  {
+    "sctid": "192679007",
+    "preferred_name": "Non-pyogenic meningitis"
+  },
+  {
+    "sctid": "192685000",
+    "preferred_name": "Subacute sclerosing panencephalitis"
+  },
+  {
+    "sctid": "192686004",
+    "preferred_name": "Polioencephalitis"
+  },
+  {
+    "sctid": "192687008",
+    "preferred_name": "Arbovirus encephalitis"
+  },
+  {
+    "sctid": "192689006",
+    "preferred_name": "Rubella encephalitis"
+  },
+  {
+    "sctid": "192701001",
+    "preferred_name": "Toxoplasma encephalitis"
+  },
+  {
+    "sctid": "192704009",
+    "preferred_name": "Post-immunization encephalitis"
+  },
+  {
+    "sctid": "192705005",
+    "preferred_name": "Post BCG vaccination encephalitis"
+  },
+  {
+    "sctid": "192706006",
+    "preferred_name": "Post typhoid vaccination encephalitis"
+  },
+  {
+    "sctid": "192707002",
+    "preferred_name": "Post paratyphoid vaccination encephalitis"
+  },
+  {
+    "sctid": "192708007",
+    "preferred_name": "Post cholera vaccination encephalitis"
+  },
+  {
+    "sctid": "192709004",
+    "preferred_name": "Post plague vaccination encephalitis"
+  },
+  {
+    "sctid": "192710009",
+    "preferred_name": "Post tetanus vaccination encephalitis"
+  },
+  {
+    "sctid": "192711008",
+    "preferred_name": "Post diphtheria vaccination encephalitis"
+  },
+  {
+    "sctid": "192712001",
+    "preferred_name": "Post pertussis vaccination encephalitis"
+  },
+  {
+    "sctid": "192713006",
+    "preferred_name": "Post smallpox vaccination encephalitis"
+  },
+  {
+    "sctid": "192714000",
+    "preferred_name": "Post rabies vaccination encephalitis"
+  },
+  {
+    "sctid": "192715004",
+    "preferred_name": "Post typhus vaccination encephalitis"
+  },
+  {
+    "sctid": "192716003",
+    "preferred_name": "Post yellow fever vaccination encephalitis"
+  },
+  {
+    "sctid": "192717007",
+    "preferred_name": "Post measles vaccination encephalitis"
+  },
+  {
+    "sctid": "192718002",
+    "preferred_name": "Post polio vaccination encephalitis"
+  },
+  {
+    "sctid": "192719005",
+    "preferred_name": "Post mumps vaccination encephalitis"
+  },
+  {
+    "sctid": "192720004",
+    "preferred_name": "Post rubella vaccination encephalitis"
+  },
+  {
+    "sctid": "192721000",
+    "preferred_name": "Post influenza vaccination encephalitis"
+  },
+  {
+    "sctid": "192722007",
+    "preferred_name": "Post hepatitis A vaccination encephalitis"
+  },
+  {
+    "sctid": "192723002",
+    "preferred_name": "Post hepatitis B vaccination encephalitis"
+  },
+  {
+    "sctid": "192724008",
+    "preferred_name": "Post mixed vaccination encephalitis"
+  },
+  {
+    "sctid": "192727001",
+    "preferred_name": "Post-infectious encephalitis"
+  },
+  {
+    "sctid": "192730008",
+    "preferred_name": "Toxic encephalitis"
+  },
+  {
+    "sctid": "192737006",
+    "preferred_name": "Intracranial and intraspinal abscesses"
+  },
+  {
+    "sctid": "192743008",
+    "preferred_name": "Epidural intracranial abscess"
+  },
+  {
+    "sctid": "192744002",
+    "preferred_name": "Subdural intracranial abscess"
+  },
+  {
+    "sctid": "19276002",
+    "preferred_name": "Congenital cerebral cyst"
+  },
+  {
+    "sctid": "192761004",
+    "preferred_name": "Thrombosis transverse sinus"
+  },
+  {
+    "sctid": "192764007",
+    "preferred_name": "Phlebitis cavernous sinus"
+  },
+  {
+    "sctid": "192765008",
+    "preferred_name": "Phlebitis of superior longitudinal sinus"
+  },
+  {
+    "sctid": "192770001",
+    "preferred_name": "Thrombophlebitis of cavernous sinus"
+  },
+  {
+    "sctid": "192771002",
+    "preferred_name": "Thrombophlebitis of superior longitudinal venous sinus"
+  },
+  {
+    "sctid": "192772009",
+    "preferred_name": "Thrombophlebitis lateral venous sinus"
+  },
+  {
+    "sctid": "192781003",
+    "preferred_name": "Leukodystrophy"
+  },
+  {
+    "sctid": "192782005",
+    "preferred_name": "Galactosylceramide beta-galactosidase deficiency"
+  },
+  {
+    "sctid": "192791009",
+    "preferred_name": "Cerebral degeneration in Gaucher's disease"
+  },
+  {
+    "sctid": "192792002",
+    "preferred_name": "Cerebral degeneration in Niemann-Pick disease"
+  },
+  {
+    "sctid": "192794001",
+    "preferred_name": "Cerebral degeneration associated with another disorder"
+  },
+  {
+    "sctid": "192795000",
+    "preferred_name": "Cerebral degeneration in Hunter's disease"
+  },
+  {
+    "sctid": "192796004",
+    "preferred_name": "Cerebral degeneration in mucopolysaccharidosis"
+  },
+  {
+    "sctid": "192805000",
+    "preferred_name": "Non-obstructive hydrocephalus"
+  },
+  {
+    "sctid": "192811002",
+    "preferred_name": "Alcoholic encephalopathy"
+  },
+  {
+    "sctid": "192812009",
+    "preferred_name": "Cerebral degeneration due to beriberi"
+  },
+  {
+    "sctid": "192813004",
+    "preferred_name": "Cerebral degeneration due to cerebrovascular disease"
+  },
+  {
+    "sctid": "192814005",
+    "preferred_name": "Cerebral degeneration due to congenital hydrocephalus"
+  },
+  {
+    "sctid": "192815006",
+    "preferred_name": "Cerebral degeneration due to neoplastic disease"
+  },
+  {
+    "sctid": "192816007",
+    "preferred_name": "Myxedema encephalopathy"
+  },
+  {
+    "sctid": "192817003",
+    "preferred_name": "Cerebral degeneration due to vitamin B12 deficiency"
+  },
+  {
+    "sctid": "192818008",
+    "preferred_name": "Cerebral degeneration due to Creutzfeldt-Jakob disease"
+  },
+  {
+    "sctid": "192819000",
+    "preferred_name": "Cerebral degeneration due to progressive multifocal leukoencephalopathy"
+  },
+  {
+    "sctid": "192845009",
+    "preferred_name": "Myoclonic encephalopathy"
+  },
+  {
+    "sctid": "192859002",
+    "preferred_name": "Fragments of torsion dystonia"
+  },
+  {
+    "sctid": "192871008",
+    "preferred_name": "Early onset cerebellar ataxia with myoclonus"
+  },
+  {
+    "sctid": "192874000",
+    "preferred_name": "Cerebellar ataxia associated with another disorder"
+  },
+  {
+    "sctid": "192876003",
+    "preferred_name": "Myxedema cerebellar degeneration"
+  },
+  {
+    "sctid": "192877007",
+    "preferred_name": "Paraneoplastic cerebellar degeneration"
+  },
+  {
+    "sctid": "192894009",
+    "preferred_name": "Syringomyelia and syringobulbia"
+  },
+  {
+    "sctid": "192897002",
+    "preferred_name": "Myelopathy due to acute infarction of spinal cord"
+  },
+  {
+    "sctid": "192898007",
+    "preferred_name": "Myelopathy due to arterial thrombosis of spinal cord"
+  },
+  {
+    "sctid": "192899004",
+    "preferred_name": "Myelopathy due to edema of spinal cord"
+  },
+  {
+    "sctid": "192900009",
+    "preferred_name": "Myelopathy due to hematomyelia"
+  },
+  {
+    "sctid": "192904000",
+    "preferred_name": "Myelopathy due to another disorder"
+  },
+  {
+    "sctid": "192905004",
+    "preferred_name": "Myelopathy due to intervertebral disc disease"
+  },
+  {
+    "sctid": "192906003",
+    "preferred_name": "Myelopathy due to neoplastic disease"
+  },
+  {
+    "sctid": "192907007",
+    "preferred_name": "Myelopathy due to spondylosis"
+  },
+  {
+    "sctid": "192926004",
+    "preferred_name": "Multiple sclerosis of the brainstem"
+  },
+  {
+    "sctid": "192927008",
+    "preferred_name": "Multiple sclerosis of the spinal cord"
+  },
+  {
+    "sctid": "192929006",
+    "preferred_name": "Exacerbation of multiple sclerosis"
+  },
+  {
+    "sctid": "192958009",
+    "preferred_name": "Hypotonic cerebral palsy"
+  },
+  {
+    "sctid": "192965001",
+    "preferred_name": "Spastic tetraplegia"
+  },
+  {
+    "sctid": "192967009",
+    "preferred_name": "Spastic paraplegia"
+  },
+  {
+    "sctid": "192976002",
+    "preferred_name": "Progressive supranuclear palsy"
+  },
+  {
+    "sctid": "192979009",
+    "preferred_name": "Generalized non-convulsive epilepsy"
+  },
+  {
+    "sctid": "192990004",
+    "preferred_name": "Benign myoclonic epilepsy in infancy"
+  },
+  {
+    "sctid": "192999003",
+    "preferred_name": "Partial epilepsy with impairment of consciousness"
+  },
+  {
+    "sctid": "193000002",
+    "preferred_name": "Temporal lobe epilepsy"
+  },
+  {
+    "sctid": "19300006",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "193002005",
+    "preferred_name": "Psychosensory epilepsy"
+  },
+  {
+    "sctid": "193003000",
+    "preferred_name": "Mesiobasal limbic epilepsy"
+  },
+  {
+    "sctid": "193004006",
+    "preferred_name": "Epileptic automatism"
+  },
+  {
+    "sctid": "193008009",
+    "preferred_name": "Somatosensory epilepsy"
+  },
+  {
+    "sctid": "193009001",
+    "preferred_name": "Partial epilepsy with autonomic symptoms"
+  },
+  {
+    "sctid": "193010006",
+    "preferred_name": "Visual reflex epilepsy"
+  },
+  {
+    "sctid": "193021002",
+    "preferred_name": "Cursive (running) epilepsy"
+  },
+  {
+    "sctid": "193028008",
+    "preferred_name": "Sick headache"
+  },
+  {
+    "sctid": "193030005",
+    "preferred_name": "Migraine variants"
+  },
+  {
+    "sctid": "193031009",
+    "preferred_name": "Cluster headache"
+  },
+  {
+    "sctid": "193039006",
+    "preferred_name": "Complicated migraine"
+  },
+  {
+    "sctid": "193064009",
+    "preferred_name": "Cerebrospinal fluid leak from spinal puncture"
+  },
+  {
+    "sctid": "193069004",
+    "preferred_name": "Intracranial hypotension following ventricular shunting"
+  },
+  {
+    "sctid": "193071004",
+    "preferred_name": "Cerebral meningeal adhesions"
+  },
+  {
+    "sctid": "193072006",
+    "preferred_name": "Spinal meningeal adhesions"
+  },
+  {
+    "sctid": "193073001",
+    "preferred_name": "Cyst of spinal meninges"
+  },
+  {
+    "sctid": "193074007",
+    "preferred_name": "Chemical meningitis"
+  },
+  {
+    "sctid": "193078005",
+    "preferred_name": "Pseudomeningocele"
+  },
+  {
+    "sctid": "19350004",
+    "preferred_name": "Athetosis with rigidity"
+  },
+  {
+    "sctid": "193756007",
+    "preferred_name": "Charles Bonnet syndrome"
+  },
+  {
+    "sctid": "194043004",
+    "preferred_name": "Optic atrophy secondary to retinal disease"
+  },
+  {
+    "sctid": "194057002",
+    "preferred_name": "Disorder of optic chiasm due to pituitary disorder"
+  },
+  {
+    "sctid": "194058007",
+    "preferred_name": "Disorder of optic chiasm due to non-pituitary neoplasm"
+  },
+  {
+    "sctid": "194059004",
+    "preferred_name": "Disorder of optic chiasm due to vascular disorder"
+  },
+  {
+    "sctid": "194060009",
+    "preferred_name": "Inflammatory disorder of optic chiasm"
+  },
+  {
+    "sctid": "194063006",
+    "preferred_name": "Visual pathway disorder due to neoplasm"
+  },
+  {
+    "sctid": "194064000",
+    "preferred_name": "Visual pathway disorder due to vascular disorder"
+  },
+  {
+    "sctid": "194065004",
+    "preferred_name": "Inflammatory disorder of optic tract"
+  },
+  {
+    "sctid": "194068002",
+    "preferred_name": "Visual cortex disorder due to neoplasm"
+  },
+  {
+    "sctid": "194069005",
+    "preferred_name": "Visual cortex disorder due to vascular disorder"
+  },
+  {
+    "sctid": "194070006",
+    "preferred_name": "Inflammatory disorder of visual cortex"
+  },
+  {
+    "sctid": "194091000119102",
+    "preferred_name": "Neonatal cerebral hematoma due to birth trauma"
+  },
+  {
+    "sctid": "19445006",
+    "preferred_name": "Opioid-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "19448008",
+    "preferred_name": "Optic atrophy associated with retinal dystrophy"
+  },
+  {
+    "sctid": "19480005",
+    "preferred_name": "Axis V diagnosis"
+  },
+  {
+    "sctid": "195155004",
+    "preferred_name": "Subarachnoid hemorrhage from carotid siphon and bifurcation"
+  },
+  {
+    "sctid": "195160000",
+    "preferred_name": "Subarachnoid hemorrhage from vertebral artery"
+  },
+  {
+    "sctid": "195165005",
+    "preferred_name": "Basal ganglia hemorrhage"
+  },
+  {
+    "sctid": "195167002",
+    "preferred_name": "External capsule hemorrhage"
+  },
+  {
+    "sctid": "195168007",
+    "preferred_name": "Intracerebral hemorrhage, intraventricular"
+  },
+  {
+    "sctid": "195169004",
+    "preferred_name": "Intracerebral hemorrhage, multiple localized"
+  },
+  {
+    "sctid": "195176009",
+    "preferred_name": "Non-traumatic subdural hemorrhage"
+  },
+  {
+    "sctid": "195185009",
+    "preferred_name": "Cerebral infarct due to thrombosis of precerebral arteries"
+  },
+  {
+    "sctid": "195186005",
+    "preferred_name": "Cerebral infarction due to embolism of precerebral arteries"
+  },
+  {
+    "sctid": "195189003",
+    "preferred_name": "Cerebral infarction due to thrombosis of cerebral arteries"
+  },
+  {
+    "sctid": "195190007",
+    "preferred_name": "Cerebral infarction due to embolism of cerebral arteries"
+  },
+  {
+    "sctid": "195200006",
+    "preferred_name": "Carotid artery syndrome hemispheric"
+  },
+  {
+    "sctid": "195205001",
+    "preferred_name": "Impending cerebral ischemia"
+  },
+  {
+    "sctid": "195209007",
+    "preferred_name": "Middle cerebral artery syndrome"
+  },
+  {
+    "sctid": "195210002",
+    "preferred_name": "Anterior cerebral artery syndrome"
+  },
+  {
+    "sctid": "195211003",
+    "preferred_name": "Posterior cerebral artery syndrome"
+  },
+  {
+    "sctid": "195212005",
+    "preferred_name": "Brainstem stroke syndrome"
+  },
+  {
+    "sctid": "195213000",
+    "preferred_name": "Cerebellar stroke syndrome"
+  },
+  {
+    "sctid": "195216008",
+    "preferred_name": "Left sided cerebral hemisphere cerebrovascular accident"
+  },
+  {
+    "sctid": "195217004",
+    "preferred_name": "Right sided cerebral hemisphere cerebrovascular accident"
+  },
+  {
+    "sctid": "195230003",
+    "preferred_name": "Cerebral infarction due to cerebral venous thrombosis, non-pyogenic"
+  },
+  {
+    "sctid": "19527009",
+    "preferred_name": "Single episode of major depression in full remission"
+  },
+  {
+    "sctid": "19598007",
+    "preferred_name": "Generalized epilepsy"
+  },
+  {
+    "sctid": "19694002",
+    "preferred_name": "Late onset dysthymia"
+  },
+  {
+    "sctid": "1973000",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced psychotic disorder with delusions"
+  },
+  {
+    "sctid": "19735005",
+    "preferred_name": "Incipient prechiasmal optic nerve compression syndrome"
+  },
+  {
+    "sctid": "197480006",
+    "preferred_name": "Anxiety disorder"
+  },
+  {
+    "sctid": "19766004",
+    "preferred_name": "Panic disorder with agoraphobia, mild agoraphobic avoidance AND severe panic attacks"
+  },
+  {
+    "sctid": "198438009",
+    "preferred_name": "Menopausal headache"
+  },
+  {
+    "sctid": "19886006",
+    "preferred_name": "Sturge-Weber syndrome"
+  },
+  {
+    "sctid": "198990007",
+    "preferred_name": "Eclampsia - delivered"
+  },
+  {
+    "sctid": "198991006",
+    "preferred_name": "Eclampsia - delivered with postnatal complication"
+  },
+  {
+    "sctid": "198992004",
+    "preferred_name": "Eclampsia in pregnancy"
+  },
+  {
+    "sctid": "198993009",
+    "preferred_name": "Eclampsia with postnatal complication"
+  },
+  {
+    "sctid": "19903002",
+    "preferred_name": "Adductor spastic dysphonia"
+  },
+  {
+    "sctid": "19922006",
+    "preferred_name": "Compulsive sexual sadism"
+  },
+  {
+    "sctid": "199257008",
+    "preferred_name": "Mental disorders during pregnancy, childbirth and the puerperium"
+  },
+  {
+    "sctid": "199259006",
+    "preferred_name": "Mental disorder during pregnancy - baby delivered"
+  },
+  {
+    "sctid": "199260001",
+    "preferred_name": "Mental disorder in the puerperium - baby delivered"
+  },
+  {
+    "sctid": "199261002",
+    "preferred_name": "Mental disorder during pregnancy - baby not yet delivered"
+  },
+  {
+    "sctid": "199262009",
+    "preferred_name": "Mental disorder in the puerperium - baby delivered during previous episode of care"
+  },
+  {
+    "sctid": "199451000000106",
+    "preferred_name": "Simple partial epileptic seizure"
+  },
+  {
+    "sctid": "19972008",
+    "preferred_name": "Postencephalitic parkinsonism"
+  },
+  {
+    "sctid": "200021000119109",
+    "preferred_name": "Dysraphism of cervical spine"
+  },
+  {
+    "sctid": "200061003",
+    "preferred_name": "Obstetric anesthesia with central nervous system complications"
+  },
+  {
+    "sctid": "200063000",
+    "preferred_name": "Obstetric anesthesia with central nervous system complications - delivered"
+  },
+  {
+    "sctid": "200064006",
+    "preferred_name": "Obstetric anesthesia with central nervous system complication - delivered with postnatal problem"
+  },
+  {
+    "sctid": "200065007",
+    "preferred_name": "Obstetric anesthesia with central nervous system complication with antenatal problem"
+  },
+  {
+    "sctid": "200066008",
+    "preferred_name": "Obstetric anesthesia with central nervous system complication with postnatal problem"
+  },
+  {
+    "sctid": "200071001",
+    "preferred_name": "Obstetric spinal and epidural anesthesia-induced headache"
+  },
+  {
+    "sctid": "200072008",
+    "preferred_name": "Spinal and epidural anesthesia-induced headache during pregnancy"
+  },
+  {
+    "sctid": "200073003",
+    "preferred_name": "Spinal and epidural anesthesia-induced headache during the puerperium"
+  },
+  {
+    "sctid": "200076006",
+    "preferred_name": "Spinal and epidural anesthesia-induced headache during labor and delivery"
+  },
+  {
+    "sctid": "200078007",
+    "preferred_name": "Central nervous system complications of anesthesia during labor and delivery"
+  },
+  {
+    "sctid": "20010003",
+    "preferred_name": "Borderline personality disorder"
+  },
+  {
+    "sctid": "20022000",
+    "preferred_name": "Hemiparesis"
+  },
+  {
+    "sctid": "20121000119105",
+    "preferred_name": "Partial occipital lobe epilepsy"
+  },
+  {
+    "sctid": "20250007",
+    "preferred_name": "Severe major depression, single episode, with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "202664003",
+    "preferred_name": "Cervical myelopathy"
+  },
+  {
+    "sctid": "202670009",
+    "preferred_name": "Single-level thoracic spondylosis with myelopathy"
+  },
+  {
+    "sctid": "202671008",
+    "preferred_name": "Two-level thoracic spondylosis with myelopathy"
+  },
+  {
+    "sctid": "202672001",
+    "preferred_name": "Multiple-level thoracic spondylosis with myelopathy"
+  },
+  {
+    "sctid": "202689009",
+    "preferred_name": "Single-level thoracic spondylosis with radiculopathy"
+  },
+  {
+    "sctid": "202690000",
+    "preferred_name": "Two-level thoracic spondylosis with radiculopathy"
+  },
+  {
+    "sctid": "202692008",
+    "preferred_name": "Multiple-level thoracic spondylosis with radiculopathy"
+  },
+  {
+    "sctid": "202729001",
+    "preferred_name": "Cervical disc prolapse with myelopathy"
+  },
+  {
+    "sctid": "202730006",
+    "preferred_name": "Thoracic disc prolapse with myelopathy"
+  },
+  {
+    "sctid": "202830000",
+    "preferred_name": "Recurrent atlantoaxial subluxation with myelopathy"
+  },
+  {
+    "sctid": "2032001",
+    "preferred_name": "Cerebral edema"
+  },
+  {
+    "sctid": "20377001",
+    "preferred_name": "Open fracture of C5-C7 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "20385005",
+    "preferred_name": "Opioid-induced psychotic disorder with delusions"
+  },
+  {
+    "sctid": "203928008",
+    "preferred_name": "Iniencephaly - open"
+  },
+  {
+    "sctid": "203934001",
+    "preferred_name": "Cervical spina bifida with hydrocephalus"
+  },
+  {
+    "sctid": "203935000",
+    "preferred_name": "Thoracic spina bifida with hydrocephalus"
+  },
+  {
+    "sctid": "203936004",
+    "preferred_name": "Lumbar spina bifida with hydrocephalus"
+  },
+  {
+    "sctid": "203941007",
+    "preferred_name": "Cervical spina bifida with hydrocephalus - open"
+  },
+  {
+    "sctid": "203942000",
+    "preferred_name": "Thoracic spina bifida with hydrocephalus - open"
+  },
+  {
+    "sctid": "203943005",
+    "preferred_name": "Lumbar spina bifida with hydrocephalus - open"
+  },
+  {
+    "sctid": "203944004",
+    "preferred_name": "Sacral spina bifida with hydrocephalus - open"
+  },
+  {
+    "sctid": "203946002",
+    "preferred_name": "Spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "203948001",
+    "preferred_name": "Cervical spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "203949009",
+    "preferred_name": "Thoracic spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "203950009",
+    "preferred_name": "Lumbar spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "203951008",
+    "preferred_name": "Sacral spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "203954000",
+    "preferred_name": "Spina bifida with hydrocephalus of late onset"
+  },
+  {
+    "sctid": "203955004",
+    "preferred_name": "Spina bifida with stenosis of aqueduct of Sylvius"
+  },
+  {
+    "sctid": "203957007",
+    "preferred_name": "Dandy-Walker syndrome with spina bifida"
+  },
+  {
+    "sctid": "203974007",
+    "preferred_name": "Cervical hydromyelocele"
+  },
+  {
+    "sctid": "203975008",
+    "preferred_name": "Thoracic hydromyelocele"
+  },
+  {
+    "sctid": "203976009",
+    "preferred_name": "Lumbar hydromyelocele"
+  },
+  {
+    "sctid": "203980004",
+    "preferred_name": "Cervical spinal meningocele"
+  },
+  {
+    "sctid": "203981000",
+    "preferred_name": "Thoracic spinal meningocele"
+  },
+  {
+    "sctid": "203982007",
+    "preferred_name": "Lumbar spinal meningocele"
+  },
+  {
+    "sctid": "203985009",
+    "preferred_name": "Cervical meningomyelocele"
+  },
+  {
+    "sctid": "203986005",
+    "preferred_name": "Thoracic meningomyelocele"
+  },
+  {
+    "sctid": "203987001",
+    "preferred_name": "Lumbar meningomyelocele"
+  },
+  {
+    "sctid": "203990007",
+    "preferred_name": "Cervical myelocele"
+  },
+  {
+    "sctid": "203991006",
+    "preferred_name": "Thoracic myelocele"
+  },
+  {
+    "sctid": "203992004",
+    "preferred_name": "Lumbar myelocele"
+  },
+  {
+    "sctid": "203994003",
+    "preferred_name": "Myelocystocele"
+  },
+  {
+    "sctid": "203996001",
+    "preferred_name": "Cervical myelocystocele"
+  },
+  {
+    "sctid": "203997005",
+    "preferred_name": "Thoracic myelocystocele"
+  },
+  {
+    "sctid": "203998000",
+    "preferred_name": "Lumbar myelocystocele"
+  },
+  {
+    "sctid": "204003007",
+    "preferred_name": "Cervical spina bifida without hydrocephalus - open"
+  },
+  {
+    "sctid": "204004001",
+    "preferred_name": "Thoracic spina bifida without hydrocephalus - open"
+  },
+  {
+    "sctid": "204005000",
+    "preferred_name": "Lumbar spina bifida without hydrocephalus - open"
+  },
+  {
+    "sctid": "204006004",
+    "preferred_name": "Sacral spina bifida without hydrocephalus - open"
+  },
+  {
+    "sctid": "204021005",
+    "preferred_name": "Encephalomyelocele"
+  },
+  {
+    "sctid": "204036008",
+    "preferred_name": "Lissencephaly"
+  },
+  {
+    "sctid": "204040004",
+    "preferred_name": "Agenesis of cerebrum"
+  },
+  {
+    "sctid": "204042007",
+    "preferred_name": "Congenital malformation of corpus callosum"
+  },
+  {
+    "sctid": "204043002",
+    "preferred_name": "Hypoplasia of corpus callosum"
+  },
+  {
+    "sctid": "204044008",
+    "preferred_name": "Aplasia of corpus callosum"
+  },
+  {
+    "sctid": "204046005",
+    "preferred_name": "Anomalies of hypothalamus"
+  },
+  {
+    "sctid": "204047001",
+    "preferred_name": "Anomalies of cerebellum"
+  },
+  {
+    "sctid": "204049003",
+    "preferred_name": "Aplasia of cerebellum"
+  },
+  {
+    "sctid": "204061006",
+    "preferred_name": "Congenital atresia of foramen of Magendie"
+  },
+  {
+    "sctid": "204062004",
+    "preferred_name": "Congenital atresia of foramen of Luschka"
+  },
+  {
+    "sctid": "204067005",
+    "preferred_name": "Single congenital cerebral cyst"
+  },
+  {
+    "sctid": "204068000",
+    "preferred_name": "Multiple congenital cerebral cysts"
+  },
+  {
+    "sctid": "204072001",
+    "preferred_name": "Congenital adhesions of cerebral meninges"
+  },
+  {
+    "sctid": "204074000",
+    "preferred_name": "Multiple brain anomalies"
+  },
+  {
+    "sctid": "204081007",
+    "preferred_name": "Spinal cord hypoplasia"
+  },
+  {
+    "sctid": "2041006",
+    "preferred_name": "Eunuchoid gigantism"
+  },
+  {
+    "sctid": "20415001",
+    "preferred_name": "Progressive sclerosing poliodystrophy"
+  },
+  {
+    "sctid": "20484008",
+    "preferred_name": "Prion disease"
+  },
+  {
+    "sctid": "205749001",
+    "preferred_name": "Congenital absence of pituitary gland"
+  },
+  {
+    "sctid": "205750001",
+    "preferred_name": "Accessory pituitary gland"
+  },
+  {
+    "sctid": "206188000",
+    "preferred_name": "Subdural and cerebral hemorrhage due to birth trauma"
+  },
+  {
+    "sctid": "206191000",
+    "preferred_name": "Local subdural hematoma due to birth trauma"
+  },
+  {
+    "sctid": "206192007",
+    "preferred_name": "Tentorial tear due to birth trauma"
+  },
+  {
+    "sctid": "206194008",
+    "preferred_name": "Cerebral hematoma in fetus or newborn"
+  },
+  {
+    "sctid": "206195009",
+    "preferred_name": "Extradural hemorrhage in fetus or newborn"
+  },
+  {
+    "sctid": "206196005",
+    "preferred_name": "Cerebral hemorrhage due to birth injury"
+  },
+  {
+    "sctid": "206223002",
+    "preferred_name": "Spinal cord laceration due to birth trauma"
+  },
+  {
+    "sctid": "206224008",
+    "preferred_name": "Spinal cord rupture due to birth trauma"
+  },
+  {
+    "sctid": "206238001",
+    "preferred_name": "Cerebral edema due to birth injury"
+  },
+  {
+    "sctid": "206395003",
+    "preferred_name": "Intraventricular (nontraumatic) hemorrhage, grade 1, of fetus and newborn"
+  },
+  {
+    "sctid": "206396002",
+    "preferred_name": "Intraventricular (nontraumatic) hemorrhage, grade 2, of fetus and newborn"
+  },
+  {
+    "sctid": "206397006",
+    "preferred_name": "Intraventricular (nontraumatic) hemorrhage, grade 3, of fetus and newborn"
+  },
+  {
+    "sctid": "206398001",
+    "preferred_name": "Intraventricular hemorrhage due to birth injury"
+  },
+  {
+    "sctid": "206399009",
+    "preferred_name": "Subarachnoid hemorrhage due to birth injury"
+  },
+  {
+    "sctid": "206419007",
+    "preferred_name": "Cerebellar (nontraumatic) and posterior fossa hemorrhage of fetus and newborn"
+  },
+  {
+    "sctid": "2065009",
+    "preferred_name": "Dominant hereditary optic atrophy"
+  },
+  {
+    "sctid": "206578007",
+    "preferred_name": "Neonatal cerebral leukomalacia"
+  },
+  {
+    "sctid": "20734000",
+    "preferred_name": "Psychologic conversion disorder"
+  },
+  {
+    "sctid": "207998001",
+    "preferred_name": "Closed fracture of cervical spine with cord lesion"
+  },
+  {
+    "sctid": "208000003",
+    "preferred_name": "Closed spinal fracture with complete cervical cord lesion, C1-4"
+  },
+  {
+    "sctid": "208001004",
+    "preferred_name": "Closed spinal fracture with anterior cervical cord lesion, C1-4"
+  },
+  {
+    "sctid": "208003001",
+    "preferred_name": "Closed spinal fracture with posterior cervical cord lesion, C1-4"
+  },
+  {
+    "sctid": "208006009",
+    "preferred_name": "Closed spinal fracture with complete cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208007000",
+    "preferred_name": "Closed spinal fracture with anterior cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208009002",
+    "preferred_name": "Closed spinal fracture with posterior cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208012004",
+    "preferred_name": "Open fracture of cervical spine with spinal cord lesion"
+  },
+  {
+    "sctid": "208014003",
+    "preferred_name": "Open spinal fracture with complete cervical cord lesion, C1-4"
+  },
+  {
+    "sctid": "208017005",
+    "preferred_name": "Open spinal fracture with posterior cervical cord lesion, C1-4"
+  },
+  {
+    "sctid": "208020002",
+    "preferred_name": "Open spinal fracture with complete cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208022005",
+    "preferred_name": "Open spinal fracture with central cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208023000",
+    "preferred_name": "Open spinal fracture with posterior cervical cord lesion, C5-7"
+  },
+  {
+    "sctid": "208028009",
+    "preferred_name": "Closed spinal fracture with complete thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208029001",
+    "preferred_name": "Closed spinal fracture with anterior thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208031005",
+    "preferred_name": "Closed spinal fracture with posterior thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208034002",
+    "preferred_name": "Closed spinal fracture with complete thoracic cord lesion,T7-12"
+  },
+  {
+    "sctid": "208035001",
+    "preferred_name": "Closed spinal fracture with anterior thoracic cord lesion,T7-12"
+  },
+  {
+    "sctid": "208037009",
+    "preferred_name": "Closed spinal fracture with posterior thoracic cord lesion, T7-12"
+  },
+  {
+    "sctid": "208042001",
+    "preferred_name": "Open spinal fracture with complete thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208043006",
+    "preferred_name": "Open spinal fracture with anterior thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208045004",
+    "preferred_name": "Open spinal fracture with posterior thoracic cord lesion, T1-6"
+  },
+  {
+    "sctid": "208048002",
+    "preferred_name": "Open spinal fracture with complete thoracic cord lesion, T7-12"
+  },
+  {
+    "sctid": "208051009",
+    "preferred_name": "Open spinal fracture with posterior thoracic cord lesion, T7-12"
+  },
+  {
+    "sctid": "208056004",
+    "preferred_name": "Closed spinal fracture with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "208057008",
+    "preferred_name": "Closed spinal fracture with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "208058003",
+    "preferred_name": "Closed spinal fracture with central lumbar cord lesion"
+  },
+  {
+    "sctid": "208059006",
+    "preferred_name": "Closed spinal fracture with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "208063004",
+    "preferred_name": "Open spinal fracture with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "208064005",
+    "preferred_name": "Open spinal fracture with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "208065006",
+    "preferred_name": "Open spinal fracture with central lumbar cord lesion"
+  },
+  {
+    "sctid": "208066007",
+    "preferred_name": "Open spinal fracture with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "20876004",
+    "preferred_name": "Inhalant-induced anxiety disorder"
+  },
+  {
+    "sctid": "20899000",
+    "preferred_name": "Brain stem laceration without open intracranial wound"
+  },
+  {
+    "sctid": "20900005",
+    "preferred_name": "Nonfamilial asexual dwarfism"
+  },
+  {
+    "sctid": "209048009",
+    "preferred_name": "Closed spinal dislocation with complete cervical cord lesion"
+  },
+  {
+    "sctid": "209049001",
+    "preferred_name": "Closed spinal dislocation with anterior cervical cord lesion"
+  },
+  {
+    "sctid": "209050001",
+    "preferred_name": "Closed spinal dislocation with central cervical cord lesion"
+  },
+  {
+    "sctid": "209051002",
+    "preferred_name": "Closed spinal dislocation with posterior cervical cord lesion"
+  },
+  {
+    "sctid": "209066004",
+    "preferred_name": "Open spinal dislocation with complete cervical cord lesion"
+  },
+  {
+    "sctid": "209067008",
+    "preferred_name": "Open spinal dislocation with anterior cervical cord lesion"
+  },
+  {
+    "sctid": "209068003",
+    "preferred_name": "Open spinal dislocation with central cervical cord lesion"
+  },
+  {
+    "sctid": "209069006",
+    "preferred_name": "Open spinal dislocation with posterior cervical cord lesion"
+  },
+  {
+    "sctid": "209077005",
+    "preferred_name": "Closed spinal dislocation with complete thoracic cord lesion"
+  },
+  {
+    "sctid": "209078000",
+    "preferred_name": "Closed spinal dislocation with anterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209079008",
+    "preferred_name": "Closed spinal dislocation with central thoracic cord lesion"
+  },
+  {
+    "sctid": "209080006",
+    "preferred_name": "Closed spinal dislocation with posterior thoracic cord lesion"
+  },
+  {
+    "sctid": "20908003",
+    "preferred_name": "Subcortical hemorrhage"
+  },
+  {
+    "sctid": "209082003",
+    "preferred_name": "Closed spinal dislocation with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "209083008",
+    "preferred_name": "Closed spinal dislocation with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209084002",
+    "preferred_name": "Closed spinal dislocation with central lumbar cord lesion"
+  },
+  {
+    "sctid": "209085001",
+    "preferred_name": "Closed spinal dislocation with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209092006",
+    "preferred_name": "Open spinal dislocation with complete thoracic cord lesion"
+  },
+  {
+    "sctid": "209093001",
+    "preferred_name": "Open spinal dislocation with anterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209094007",
+    "preferred_name": "Open spinal dislocation with central thoracic cord lesion"
+  },
+  {
+    "sctid": "209095008",
+    "preferred_name": "Open spinal dislocation with posterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209097000",
+    "preferred_name": "Open spinal dislocation with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "209098005",
+    "preferred_name": "Open spinal dislocation with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209100005",
+    "preferred_name": "Open spinal dislocation with central lumbar cord lesion"
+  },
+  {
+    "sctid": "209101009",
+    "preferred_name": "Open spinal dislocation with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209145009",
+    "preferred_name": "Closed spinal subluxation with complete cervical cord lesion"
+  },
+  {
+    "sctid": "209146005",
+    "preferred_name": "Closed spinal subluxation with anterior cervical cord lesion"
+  },
+  {
+    "sctid": "209147001",
+    "preferred_name": "Closed spinal subluxation with central cervical cord lesion"
+  },
+  {
+    "sctid": "209148006",
+    "preferred_name": "Closed spinal subluxation with posterior cervical cord lesion"
+  },
+  {
+    "sctid": "209162004",
+    "preferred_name": "Open spinal subluxation with complete cervical cord lesion"
+  },
+  {
+    "sctid": "209163009",
+    "preferred_name": "Open spinal subluxation with anterior cervical cord lesion"
+  },
+  {
+    "sctid": "209164003",
+    "preferred_name": "Open spinal subluxation with central cervical cord lesion"
+  },
+  {
+    "sctid": "209165002",
+    "preferred_name": "Open spinal subluxation with posterior cervical cord lesion"
+  },
+  {
+    "sctid": "209173006",
+    "preferred_name": "Closed spinal subluxation with complete thoracic cord lesion"
+  },
+  {
+    "sctid": "209174000",
+    "preferred_name": "Closed spinal subluxation with anterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209175004",
+    "preferred_name": "Closed spinal subluxation with central thoracic cord lesion"
+  },
+  {
+    "sctid": "209176003",
+    "preferred_name": "Closed spinal subluxation with posterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209178002",
+    "preferred_name": "Closed spinal subluxation with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "209179005",
+    "preferred_name": "Closed spinal subluxation with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209180008",
+    "preferred_name": "Closed spinal subluxation with central lumbar cord lesion"
+  },
+  {
+    "sctid": "209181007",
+    "preferred_name": "Closed spinal subluxation with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209188001",
+    "preferred_name": "Open spinal subluxation with complete thoracic cord lesion"
+  },
+  {
+    "sctid": "209189009",
+    "preferred_name": "Open spinal subluxation with anterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209190000",
+    "preferred_name": "Open spinal subluxation with central thoracic cord lesion"
+  },
+  {
+    "sctid": "209191001",
+    "preferred_name": "Open spinal subluxation with posterior thoracic cord lesion"
+  },
+  {
+    "sctid": "209193003",
+    "preferred_name": "Open spinal subluxation with complete lumbar cord lesion"
+  },
+  {
+    "sctid": "209194009",
+    "preferred_name": "Open spinal subluxation with anterior lumbar cord lesion"
+  },
+  {
+    "sctid": "209195005",
+    "preferred_name": "Open spinal subluxation with central lumbar cord lesion"
+  },
+  {
+    "sctid": "209196006",
+    "preferred_name": "Open spinal subluxation with posterior lumbar cord lesion"
+  },
+  {
+    "sctid": "20960007",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "209827006",
+    "preferred_name": "Concussion with less than 1 hour loss of consciousness"
+  },
+  {
+    "sctid": "209845006",
+    "preferred_name": "Cortex contusion with open intracranial wound, with no loss of consciousness"
+  },
+  {
+    "sctid": "209864000",
+    "preferred_name": "Cortex laceration with open intracranial wound, with no loss of consciousness"
+  },
+  {
+    "sctid": "209900006",
+    "preferred_name": "Hind brain laceration with open intracranial wound"
+  },
+  {
+    "sctid": "209902003",
+    "preferred_name": "Hind brain laceration with open intracranial wound, with no loss of consciousness"
+  },
+  {
+    "sctid": "209947002",
+    "preferred_name": "Closed traumatic subdural hemorrhage"
+  },
+  {
+    "sctid": "209956005",
+    "preferred_name": "Subdural hemorrhage following open wound of head"
+  },
+  {
+    "sctid": "209987007",
+    "preferred_name": "Traumatic subdural hemorrhage"
+  },
+  {
+    "sctid": "210038008",
+    "preferred_name": "Focal brain injury"
+  },
+  {
+    "sctid": "21007002",
+    "preferred_name": "Wernicke's disease"
+  },
+  {
+    "sctid": "21071000119101",
+    "preferred_name": "Mood disorder of manic type"
+  },
+  {
+    "sctid": "21086008",
+    "preferred_name": "Cockayne syndrome"
+  },
+  {
+    "sctid": "2109003",
+    "preferred_name": "Isolated somatotropin deficiency"
+  },
+  {
+    "sctid": "21095000",
+    "preferred_name": "Secondary hyperprolactinemia"
+  },
+  {
+    "sctid": "21098003",
+    "preferred_name": "Primary optic atrophy"
+  },
+  {
+    "sctid": "21201006",
+    "preferred_name": "Sporadic cerebellar degeneration"
+  },
+  {
+    "sctid": "21202004",
+    "preferred_name": "Perinatal subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "212141007",
+    "preferred_name": "Optic nerve and pathway injury"
+  },
+  {
+    "sctid": "212142000",
+    "preferred_name": "Visual cortex injury"
+  },
+  {
+    "sctid": "212169004",
+    "preferred_name": "Thoracic cord injury without spinal bone injury"
+  },
+  {
+    "sctid": "212171004",
+    "preferred_name": "Complete thoracic cord injury, without bony injury, T1-6"
+  },
+  {
+    "sctid": "212172006",
+    "preferred_name": "Anterior thoracic cord injury, without bony injury, T1-6"
+  },
+  {
+    "sctid": "212173001",
+    "preferred_name": "Central thoracic cord injury, without bony injury, T1-6"
+  },
+  {
+    "sctid": "212174007",
+    "preferred_name": "Posterior thoracic cord injury without bony injury, T1-6"
+  },
+  {
+    "sctid": "212177000",
+    "preferred_name": "Complete thoracic cord injury, without bony injury, T7-12"
+  },
+  {
+    "sctid": "212178005",
+    "preferred_name": "Anterior thoracic cord injury, without bony injury, T7-12"
+  },
+  {
+    "sctid": "212179002",
+    "preferred_name": "Central thoracic cord injury, without bony injury, T7-12"
+  },
+  {
+    "sctid": "212180004",
+    "preferred_name": "Posterior thoracic cord injury without bony injury, T7-12"
+  },
+  {
+    "sctid": "212183002",
+    "preferred_name": "Lumbar cord injury without spinal bone injury"
+  },
+  {
+    "sctid": "212185009",
+    "preferred_name": "Complete lumbar cord injury without bony injury"
+  },
+  {
+    "sctid": "212186005",
+    "preferred_name": "Anterior lumbar cord injury without bony injury"
+  },
+  {
+    "sctid": "212187001",
+    "preferred_name": "Central lumbar cord injury without bony injury"
+  },
+  {
+    "sctid": "212188006",
+    "preferred_name": "Posterior lumbar cord injury without bony injury"
+  },
+  {
+    "sctid": "212194003",
+    "preferred_name": "Spinal cord injury of multiple sites without spinal bone injury"
+  },
+  {
+    "sctid": "21233002",
+    "preferred_name": "Meningeal hemorrhage"
+  },
+  {
+    "sctid": "212356007",
+    "preferred_name": "Concussion and edema of cervical spinal cord"
+  },
+  {
+    "sctid": "212358008",
+    "preferred_name": "Concussion and edema of thoracic spinal cord"
+  },
+  {
+    "sctid": "212360005",
+    "preferred_name": "Concussion and edema of lumbar spinal cord"
+  },
+  {
+    "sctid": "21244005",
+    "preferred_name": "Borries' syndrome"
+  },
+  {
+    "sctid": "21258007",
+    "preferred_name": "Thrombosis of lateral venous sinus"
+  },
+  {
+    "sctid": "21263006",
+    "preferred_name": "Myxedema coma"
+  },
+  {
+    "sctid": "213054005",
+    "preferred_name": "Mechanical complication of dorsal column stimulator"
+  },
+  {
+    "sctid": "213207003",
+    "preferred_name": "Central nervous system complications of care"
+  },
+  {
+    "sctid": "213208008",
+    "preferred_name": "Anoxic brain damage complication"
+  },
+  {
+    "sctid": "213209000",
+    "preferred_name": "Cerebral anoxia complication"
+  },
+  {
+    "sctid": "213210005",
+    "preferred_name": "Postoperative cerebrospinal fluid leak"
+  },
+  {
+    "sctid": "213383004",
+    "preferred_name": "Injuries of brain and cranial nerves with injuries of nerves and spinal cord at neck level"
+  },
+  {
+    "sctid": "21350002",
+    "preferred_name": "Colloid cyst of third ventricle"
+  },
+  {
+    "sctid": "21391000119102",
+    "preferred_name": "Partial parietal lobe epilepsy"
+  },
+  {
+    "sctid": "21454007",
+    "preferred_name": "Subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "21523006",
+    "preferred_name": "Syphilitic gumma of central nervous system"
+  },
+  {
+    "sctid": "21586000",
+    "preferred_name": "Munchausen's syndrome"
+  },
+  {
+    "sctid": "21601000119103",
+    "preferred_name": "Hypoxic ischemic encephalopathy due to birth trauma"
+  },
+  {
+    "sctid": "21634003",
+    "preferred_name": "Borjeson-Forssman-Lehmann syndrome"
+  },
+  {
+    "sctid": "21664006",
+    "preferred_name": "Chronic meningitis"
+  },
+  {
+    "sctid": "21831000119109",
+    "preferred_name": "Phencyclidine psychosis"
+  },
+  {
+    "sctid": "21841000119100",
+    "preferred_name": "Phencyclidine induced mental problem"
+  },
+  {
+    "sctid": "21897009",
+    "preferred_name": "Generalized anxiety disorder"
+  },
+  {
+    "sctid": "21900002",
+    "preferred_name": "Bipolar I disorder, most recent episode depressed with catatonic features"
+  },
+  {
+    "sctid": "21921000119103",
+    "preferred_name": "Dementia due to Pick's disease"
+  },
+  {
+    "sctid": "21978005",
+    "preferred_name": "Open fracture of C1-C4 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "2198002",
+    "preferred_name": "Visceral epilepsy"
+  },
+  {
+    "sctid": "22121000",
+    "preferred_name": "Depressed bipolar I disorder in full remission"
+  },
+  {
+    "sctid": "22126005",
+    "preferred_name": "Hereditary neuraxial edema"
+  },
+  {
+    "sctid": "22230001",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in partial remission AND panic attacks in full remission"
+  },
+  {
+    "sctid": "22255007",
+    "preferred_name": "Progressive multifocal leukoencephalopathy"
+  },
+  {
+    "sctid": "22306000",
+    "preferred_name": "Transient somatotropin deficiency"
+  },
+  {
+    "sctid": "223176004",
+    "preferred_name": "Cerebellar disorder"
+  },
+  {
+    "sctid": "22381000119105",
+    "preferred_name": "Primary degenerative dementia"
+  },
+  {
+    "sctid": "22383006",
+    "preferred_name": "Closed fracture of vault of skull with cerebral laceration AND/OR contusion"
+  },
+  {
+    "sctid": "22386003",
+    "preferred_name": "Syphilitic optic atrophy"
+  },
+  {
+    "sctid": "22407005",
+    "preferred_name": "Bipolar II disorder, most recent episode major depressive with catatonic features"
+  },
+  {
+    "sctid": "224186005",
+    "preferred_name": "Cerebellar deficiency syndrome"
+  },
+  {
+    "sctid": "22419002",
+    "preferred_name": "Mood disorder with mixed features due to general medical condition"
+  },
+  {
+    "sctid": "22443004",
+    "preferred_name": "Vestibulocerebellar ataxia"
+  },
+  {
+    "sctid": "22451001",
+    "preferred_name": "Primary torsion dystonia"
+  },
+  {
+    "sctid": "22471005",
+    "preferred_name": "Hemispheric cerebellar agenesis"
+  },
+  {
+    "sctid": "225040001",
+    "preferred_name": "Localized dissociative amnesia"
+  },
+  {
+    "sctid": "22621000119103",
+    "preferred_name": "Anxiety disorder caused by drug"
+  },
+  {
+    "sctid": "22641000119109",
+    "preferred_name": "Psychosis in early childhood"
+  },
+  {
+    "sctid": "22811006",
+    "preferred_name": "Leukoencephalopathy"
+  },
+  {
+    "sctid": "22819008",
+    "preferred_name": "Laceration of brain with open intracranial wound"
+  },
+  {
+    "sctid": "229623002",
+    "preferred_name": "Developmental dysfluency"
+  },
+  {
+    "sctid": "229676007",
+    "preferred_name": "Language-related cognitive disorder"
+  },
+  {
+    "sctid": "229683000",
+    "preferred_name": "Motor speech disorder"
+  },
+  {
+    "sctid": "229692002",
+    "preferred_name": "Oral dystonia"
+  },
+  {
+    "sctid": "229698003",
+    "preferred_name": "Articulatory dyspraxia"
+  },
+  {
+    "sctid": "229699006",
+    "preferred_name": "Immature articulatory praxis"
+  },
+  {
+    "sctid": "229700007",
+    "preferred_name": "Developmental motor speech disorder"
+  },
+  {
+    "sctid": "229701006",
+    "preferred_name": "Developmental articulatory dyspraxia"
+  },
+  {
+    "sctid": "229715008",
+    "preferred_name": "Deficits in attention motor control and perception"
+  },
+  {
+    "sctid": "229721007",
+    "preferred_name": "Speech delay"
+  },
+  {
+    "sctid": "22973003",
+    "preferred_name": "Closed fracture of vertebral column with spinal cord injury"
+  },
+  {
+    "sctid": "229734008",
+    "preferred_name": "Expressive language delay"
+  },
+  {
+    "sctid": "229736005",
+    "preferred_name": "Receptive language delay"
+  },
+  {
+    "sctid": "229738006",
+    "preferred_name": "Word finding difficulty"
+  },
+  {
+    "sctid": "229740001",
+    "preferred_name": "Delayed pre-verbal development"
+  },
+  {
+    "sctid": "229741002",
+    "preferred_name": "Restricted language development"
+  },
+  {
+    "sctid": "229742009",
+    "preferred_name": "Restricted expressive language development"
+  },
+  {
+    "sctid": "229743004",
+    "preferred_name": "Restricted receptive language development"
+  },
+  {
+    "sctid": "229744005",
+    "preferred_name": "Developmental syntactic impairment"
+  },
+  {
+    "sctid": "229745006",
+    "preferred_name": "Developmental semantic impairment"
+  },
+  {
+    "sctid": "229748008",
+    "preferred_name": "Congenital auditory imperception"
+  },
+  {
+    "sctid": "22981000119106",
+    "preferred_name": "Recurrent severe manic episodes"
+  },
+  {
+    "sctid": "230142004",
+    "preferred_name": "Coxsackie A viral meningitis"
+  },
+  {
+    "sctid": "230143009",
+    "preferred_name": "Coxsackie B viral meningitis"
+  },
+  {
+    "sctid": "230144003",
+    "preferred_name": "Chronic echovirus meningoencephalitis"
+  },
+  {
+    "sctid": "230146001",
+    "preferred_name": "Post measles meningitis"
+  },
+  {
+    "sctid": "230148000",
+    "preferred_name": "Staphylococcus aureus meningitis"
+  },
+  {
+    "sctid": "230149008",
+    "preferred_name": "Staphylococcus epidermidis meningitis"
+  },
+  {
+    "sctid": "230150008",
+    "preferred_name": "Meningitis in Lyme disease"
+  },
+  {
+    "sctid": "230152000",
+    "preferred_name": "Late congenital syphilitic meningitis"
+  },
+  {
+    "sctid": "230153005",
+    "preferred_name": "Parasitic meningitis"
+  },
+  {
+    "sctid": "230154004",
+    "preferred_name": "Chronic lymphocytic meningitis"
+  },
+  {
+    "sctid": "230155003",
+    "preferred_name": "Non-infective meningitis"
+  },
+  {
+    "sctid": "230156002",
+    "preferred_name": "Malignant meningitis"
+  },
+  {
+    "sctid": "230157006",
+    "preferred_name": "Viral ventriculitis"
+  },
+  {
+    "sctid": "230158001",
+    "preferred_name": "Bacterial ventriculitis"
+  },
+  {
+    "sctid": "230159009",
+    "preferred_name": "Fungal ventriculitis"
+  },
+  {
+    "sctid": "230160004",
+    "preferred_name": "Malignant ventriculitis"
+  },
+  {
+    "sctid": "230161000",
+    "preferred_name": "Acute viral encephalitis"
+  },
+  {
+    "sctid": "230162007",
+    "preferred_name": "Enteroviral encephalitis"
+  },
+  {
+    "sctid": "230166005",
+    "preferred_name": "Rocio virus encephalitis"
+  },
+  {
+    "sctid": "230168006",
+    "preferred_name": "Tensaw encephalitis"
+  },
+  {
+    "sctid": "230170002",
+    "preferred_name": "Kumlinge virus encephalitis"
+  },
+  {
+    "sctid": "230174006",
+    "preferred_name": "Rhabdovirus encephalitis"
+  },
+  {
+    "sctid": "230175007",
+    "preferred_name": "Infectious mononucleosis encephalitis"
+  },
+  {
+    "sctid": "230176008",
+    "preferred_name": "Herpes zoster encephalitis"
+  },
+  {
+    "sctid": "230177004",
+    "preferred_name": "Herpes simiae encephalitis"
+  },
+  {
+    "sctid": "230179001",
+    "preferred_name": "Chronic viral encephalitis"
+  },
+  {
+    "sctid": "230180003",
+    "preferred_name": "Human immunodeficiency virus leukoencephalopathy"
+  },
+  {
+    "sctid": "230181004",
+    "preferred_name": "Bacterial encephalitis"
+  },
+  {
+    "sctid": "230182006",
+    "preferred_name": "Late syphilitic encephalitis"
+  },
+  {
+    "sctid": "230183001",
+    "preferred_name": "Fungal encephalitis"
+  },
+  {
+    "sctid": "230185008",
+    "preferred_name": "Amebic encephalitis"
+  },
+  {
+    "sctid": "230186009",
+    "preferred_name": "Primary amebic encephalitis"
+  },
+  {
+    "sctid": "230187000",
+    "preferred_name": "Granulomatous amebic encephalitis"
+  },
+  {
+    "sctid": "230188005",
+    "preferred_name": "Post-influenza encephalitis"
+  },
+  {
+    "sctid": "230189002",
+    "preferred_name": "Focal encephalitis"
+  },
+  {
+    "sctid": "230190006",
+    "preferred_name": "Brainstem encephalitis"
+  },
+  {
+    "sctid": "230191005",
+    "preferred_name": "Rasmussen syndrome"
+  },
+  {
+    "sctid": "230192003",
+    "preferred_name": "Limbic encephalitis"
+  },
+  {
+    "sctid": "230194002",
+    "preferred_name": "Neuro - Whipple's disease"
+  },
+  {
+    "sctid": "230197009",
+    "preferred_name": "Acute viral transverse myelitis"
+  },
+  {
+    "sctid": "230198004",
+    "preferred_name": "Varicella transverse myelitis"
+  },
+  {
+    "sctid": "230199007",
+    "preferred_name": "Post-infectious encephalomyelitis"
+  },
+  {
+    "sctid": "230202002",
+    "preferred_name": "Vacuolar myelopathy"
+  },
+  {
+    "sctid": "230204001",
+    "preferred_name": "Epidural supratentorial pyogenic abscess"
+  },
+  {
+    "sctid": "230206004",
+    "preferred_name": "Subdural supratentorial pyogenic abscess"
+  },
+  {
+    "sctid": "230207008",
+    "preferred_name": "Subdural infratentorial pyogenic abscess"
+  },
+  {
+    "sctid": "230208003",
+    "preferred_name": "Cerebral pyogenic abscess"
+  },
+  {
+    "sctid": "230209006",
+    "preferred_name": "Actinomycotic brain abscess"
+  },
+  {
+    "sctid": "230210001",
+    "preferred_name": "Brainstem pyogenic abscess"
+  },
+  {
+    "sctid": "230211002",
+    "preferred_name": "Multiple intracranial pyogenic abscesses"
+  },
+  {
+    "sctid": "230213004",
+    "preferred_name": "Candidal brain abscess"
+  },
+  {
+    "sctid": "230214005",
+    "preferred_name": "Cerebral hydatid cyst"
+  },
+  {
+    "sctid": "230215006",
+    "preferred_name": "Cerebral cysticercosis"
+  },
+  {
+    "sctid": "230216007",
+    "preferred_name": "Intraspinal pyogenic abscess"
+  },
+  {
+    "sctid": "230223008",
+    "preferred_name": "Septic thrombophlebitis of sigmoid sinus"
+  },
+  {
+    "sctid": "230225001",
+    "preferred_name": "Septic thrombophlebitis of great cerebral vein"
+  },
+  {
+    "sctid": "230227009",
+    "preferred_name": "Early onset cerebellar ataxia"
+  },
+  {
+    "sctid": "230228004",
+    "preferred_name": "Early onset cerebellar ataxia with retained tendon reflexes"
+  },
+  {
+    "sctid": "230229007",
+    "preferred_name": "Early onset cerebellar ataxia with hypogonadism"
+  },
+  {
+    "sctid": "230230002",
+    "preferred_name": "Early onset cerebellar ataxia with retinitis pigmentosa and optic atrophy"
+  },
+  {
+    "sctid": "230231003",
+    "preferred_name": "Early onset cerebellar ataxia with essential tremor"
+  },
+  {
+    "sctid": "230235007",
+    "preferred_name": "Olivopontocerebellar atrophy with slow eye movement"
+  },
+  {
+    "sctid": "230236008",
+    "preferred_name": "Olivopontocerebellar atrophy with blindness"
+  },
+  {
+    "sctid": "230238009",
+    "preferred_name": "Progressive spinocerebellar ataxia with retained tendon reflexes"
+  },
+  {
+    "sctid": "230240004",
+    "preferred_name": "Progressive cerebellar ataxia with hypogonadism"
+  },
+  {
+    "sctid": "23024003",
+    "preferred_name": "Macrogyria"
+  },
+  {
+    "sctid": "230241000",
+    "preferred_name": "Secondary cerebellar degeneration"
+  },
+  {
+    "sctid": "230242007",
+    "preferred_name": "Drug-induced cerebellar ataxia"
+  },
+  {
+    "sctid": "230243002",
+    "preferred_name": "Cerebellar ataxia due to toxin"
+  },
+  {
+    "sctid": "230246005",
+    "preferred_name": "Progressive bulbar palsy of childhood"
+  },
+  {
+    "sctid": "230260007",
+    "preferred_name": "Pure hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "230261006",
+    "preferred_name": "Complicated hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "230263009",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 17"
+  },
+  {
+    "sctid": "230265002",
+    "preferred_name": "Familial Alzheimer's disease of early onset"
+  },
+  {
+    "sctid": "230266001",
+    "preferred_name": "Non-familial Alzheimer's disease of early onset"
+  },
+  {
+    "sctid": "230267005",
+    "preferred_name": "Familial Alzheimer's disease of late onset"
+  },
+  {
+    "sctid": "230268000",
+    "preferred_name": "Non-familial Alzheimer's disease of late onset"
+  },
+  {
+    "sctid": "230269008",
+    "preferred_name": "Focal Alzheimer's disease"
+  },
+  {
+    "sctid": "230270009",
+    "preferred_name": "Frontotemporal dementia"
+  },
+  {
+    "sctid": "230271008",
+    "preferred_name": "Pick's disease with Pick bodies"
+  },
+  {
+    "sctid": "230272001",
+    "preferred_name": "Pick's disease with Pick cells and no Pick bodies"
+  },
+  {
+    "sctid": "230273006",
+    "preferred_name": "Frontotemporal degeneration"
+  },
+  {
+    "sctid": "230274000",
+    "preferred_name": "Frontal lobe degeneration with motor neurone disease"
+  },
+  {
+    "sctid": "230278002",
+    "preferred_name": "Progressive aphasia"
+  },
+  {
+    "sctid": "230279005",
+    "preferred_name": "Non-Alzheimer's progressive dysphasia"
+  },
+  {
+    "sctid": "230280008",
+    "preferred_name": "Progressive aphasia in Alzheimer's disease"
+  },
+  {
+    "sctid": "230281007",
+    "preferred_name": "Argyrophilic grain disease"
+  },
+  {
+    "sctid": "230282000",
+    "preferred_name": "Traumatic encephalopathy"
+  },
+  {
+    "sctid": "230283005",
+    "preferred_name": "Punch drunk syndrome"
+  },
+  {
+    "sctid": "230284004",
+    "preferred_name": "Spongiform encephalopathy"
+  },
+  {
+    "sctid": "230285003",
+    "preferred_name": "Vascular dementia of acute onset"
+  },
+  {
+    "sctid": "230286002",
+    "preferred_name": "Subcortical vascular dementia"
+  },
+  {
+    "sctid": "230287006",
+    "preferred_name": "Mixed cortical and subcortical vascular dementia"
+  },
+  {
+    "sctid": "230288001",
+    "preferred_name": "Semantic dementia"
+  },
+  {
+    "sctid": "230289009",
+    "preferred_name": "Patchy dementia"
+  },
+  {
+    "sctid": "230291001",
+    "preferred_name": "Juvenile Parkinson's disease"
+  },
+  {
+    "sctid": "230292008",
+    "preferred_name": "Secondary parkinsonism"
+  },
+  {
+    "sctid": "230293003",
+    "preferred_name": "Carbon monoxide-induced parkinsonism"
+  },
+  {
+    "sctid": "230294009",
+    "preferred_name": "Manganese-induced parkinsonism"
+  },
+  {
+    "sctid": "230295005",
+    "preferred_name": "Parkinsonism with calcification of basal ganglia"
+  },
+  {
+    "sctid": "230296006",
+    "preferred_name": "Vascular parkinsonism"
+  },
+  {
+    "sctid": "230297002",
+    "preferred_name": "Multiple system atrophy"
+  },
+  {
+    "sctid": "230299004",
+    "preferred_name": "Juvenile onset Huntington's disease"
+  },
+  {
+    "sctid": "230300007",
+    "preferred_name": "Late onset Huntington's disease"
+  },
+  {
+    "sctid": "230301006",
+    "preferred_name": "Akinetic-rigid form of Huntington's disease"
+  },
+  {
+    "sctid": "230302004",
+    "preferred_name": "Pallidal degeneration"
+  },
+  {
+    "sctid": "230305002",
+    "preferred_name": "Chronic hepatocerebral degeneration"
+  },
+  {
+    "sctid": "230309008",
+    "preferred_name": "Kinesiogenic choreoathetosis"
+  },
+  {
+    "sctid": "230310003",
+    "preferred_name": "Paroxysmal dystonia"
+  },
+  {
+    "sctid": "230311004",
+    "preferred_name": "Basal ganglia degeneration with calcification"
+  },
+  {
+    "sctid": "230312006",
+    "preferred_name": "Aicardi Goutieres syndrome"
+  },
+  {
+    "sctid": "230313001",
+    "preferred_name": "Autosomal dominant late onset basal ganglia degeneration"
+  },
+  {
+    "sctid": "230314007",
+    "preferred_name": "Sandifer syndrome"
+  },
+  {
+    "sctid": "230315008",
+    "preferred_name": "Drug-induced dystonia"
+  },
+  {
+    "sctid": "230316009",
+    "preferred_name": "Drug-induced acute dystonia"
+  },
+  {
+    "sctid": "230317000",
+    "preferred_name": "Drug-induced tardive dystonia"
+  },
+  {
+    "sctid": "230318005",
+    "preferred_name": "Idiopathic familial dystonia"
+  },
+  {
+    "sctid": "230319002",
+    "preferred_name": "Autosomal dominant idiopathic familial dystonia"
+  },
+  {
+    "sctid": "230320008",
+    "preferred_name": "Autosomal recessive idiopathic familial dystonia"
+  },
+  {
+    "sctid": "230321007",
+    "preferred_name": "Idiopathic non-familial dystonia"
+  },
+  {
+    "sctid": "230322000",
+    "preferred_name": "Isolated cervical dystonia"
+  },
+  {
+    "sctid": "230323005",
+    "preferred_name": "Spasmodic retrocollis"
+  },
+  {
+    "sctid": "230324004",
+    "preferred_name": "Isolated blepharospasm"
+  },
+  {
+    "sctid": "230325003",
+    "preferred_name": "Meige syndrome"
+  },
+  {
+    "sctid": "230326002",
+    "preferred_name": "Idiopathic orofacial dystonia"
+  },
+  {
+    "sctid": "230327006",
+    "preferred_name": "Edentulous orofacial dystonia"
+  },
+  {
+    "sctid": "230328001",
+    "preferred_name": "Isolated oromandibular dystonia"
+  },
+  {
+    "sctid": "230329009",
+    "preferred_name": "Posthemiplegic dystonia"
+  },
+  {
+    "sctid": "230330004",
+    "preferred_name": "Occupational dystonia"
+  },
+  {
+    "sctid": "230332007",
+    "preferred_name": "Diurnal dystonia"
+  },
+  {
+    "sctid": "230334008",
+    "preferred_name": "Drug-induced tic"
+  },
+  {
+    "sctid": "230335009",
+    "preferred_name": "Facial tic disorder"
+  },
+  {
+    "sctid": "230336005",
+    "preferred_name": "Vocal tic disorder"
+  },
+  {
+    "sctid": "230337001",
+    "preferred_name": "Motor tic disorder"
+  },
+  {
+    "sctid": "230338006",
+    "preferred_name": "Gestural tic disorder"
+  },
+  {
+    "sctid": "230345006",
+    "preferred_name": "Postencephalitic myoclonus"
+  },
+  {
+    "sctid": "230347003",
+    "preferred_name": "Segmental cord myoclonus"
+  },
+  {
+    "sctid": "230348008",
+    "preferred_name": "Palatal-tympanic myoclonus"
+  },
+  {
+    "sctid": "230349000",
+    "preferred_name": "Hyoid myoclonus"
+  },
+  {
+    "sctid": "230352008",
+    "preferred_name": "Encephalopathy due to vitamin deficiency"
+  },
+  {
+    "sctid": "230353003",
+    "preferred_name": "Morel laminar sclerosis"
+  },
+  {
+    "sctid": "230354009",
+    "preferred_name": "Drug-induced encephalopathy"
+  },
+  {
+    "sctid": "230355005",
+    "preferred_name": "Encephalopathy caused by heavy metal"
+  },
+  {
+    "sctid": "230357002",
+    "preferred_name": "Urate encephalopathy"
+  },
+  {
+    "sctid": "230358007",
+    "preferred_name": "Hyponatremic encephalopathy"
+  },
+  {
+    "sctid": "230359004",
+    "preferred_name": "Secondary amyloid encephalopathy"
+  },
+  {
+    "sctid": "230360009",
+    "preferred_name": "Encephalopathy due to radiation damage"
+  },
+  {
+    "sctid": "230361008",
+    "preferred_name": "Sepsis-associated encephalopathy"
+  },
+  {
+    "sctid": "230365004",
+    "preferred_name": "Neuroaxonal dystrophy"
+  },
+  {
+    "sctid": "230366003",
+    "preferred_name": "Late infantile and juvenile neuroaxonal dystrophy"
+  },
+  {
+    "sctid": "230367007",
+    "preferred_name": "Neuroaxonal leukodystrophy"
+  },
+  {
+    "sctid": "230368002",
+    "preferred_name": "Type III transitional Pelizaeus-Merzbacher disease"
+  },
+  {
+    "sctid": "230369005",
+    "preferred_name": "Type IV adult Pelizaeus-Merzbacher disease"
+  },
+  {
+    "sctid": "230370006",
+    "preferred_name": "Type V atypical Pelizaeus-Merzbacher disease"
+  },
+  {
+    "sctid": "230371005",
+    "preferred_name": "Type VI Cockayne Pelizaeus-Merzbacher disease"
+  },
+  {
+    "sctid": "230372003",
+    "preferred_name": "Acute relapsing multiple sclerosis"
+  },
+  {
+    "sctid": "230377009",
+    "preferred_name": "Extrapontine myelinolysis"
+  },
+  {
+    "sctid": "230378004",
+    "preferred_name": "Acute non-infective transverse myelitis"
+  },
+  {
+    "sctid": "230379007",
+    "preferred_name": "Subacute necrotizing myelitis"
+  },
+  {
+    "sctid": "230380005",
+    "preferred_name": "Balo concentric sclerosis"
+  },
+  {
+    "sctid": "230381009",
+    "preferred_name": "Localization-related epilepsy"
+  },
+  {
+    "sctid": "230382002",
+    "preferred_name": "Benign frontal epilepsy of childhood"
+  },
+  {
+    "sctid": "230383007",
+    "preferred_name": "Benign psychomotor epilepsy of childhood"
+  },
+  {
+    "sctid": "230384001",
+    "preferred_name": "Benign atypical partial epilepsy in childhood"
+  },
+  {
+    "sctid": "230386004",
+    "preferred_name": "Childhood epilepsy with occipital paroxysms"
+  },
+  {
+    "sctid": "230387008",
+    "preferred_name": "Benign occipital epilepsy of childhood - early onset variant"
+  },
+  {
+    "sctid": "230388003",
+    "preferred_name": "Benign occipital epilepsy of childhood - late onset variant"
+  },
+  {
+    "sctid": "230389006",
+    "preferred_name": "Primary inherited reading epilepsy"
+  },
+  {
+    "sctid": "230390002",
+    "preferred_name": "Localization-related symptomatic epilepsy"
+  },
+  {
+    "sctid": "230391003",
+    "preferred_name": "Amygdalo-hippocampal epilepsy"
+  },
+  {
+    "sctid": "230392005",
+    "preferred_name": "Rhinencephalic epilepsy"
+  },
+  {
+    "sctid": "230393000",
+    "preferred_name": "Lateral temporal epilepsy"
+  },
+  {
+    "sctid": "230394006",
+    "preferred_name": "Frontal lobe epilepsy"
+  },
+  {
+    "sctid": "230395007",
+    "preferred_name": "Supplementary motor epilepsy"
+  },
+  {
+    "sctid": "230396008",
+    "preferred_name": "Cingulate epilepsy"
+  },
+  {
+    "sctid": "230397004",
+    "preferred_name": "Anterior frontopolar epilepsy"
+  },
+  {
+    "sctid": "230398009",
+    "preferred_name": "Orbitofrontal epilepsy"
+  },
+  {
+    "sctid": "230399001",
+    "preferred_name": "Dorsolateral epilepsy"
+  },
+  {
+    "sctid": "230400008",
+    "preferred_name": "Opercular epilepsy"
+  },
+  {
+    "sctid": "230401007",
+    "preferred_name": "Non-progressive Kozhevnikow syndrome"
+  },
+  {
+    "sctid": "230403005",
+    "preferred_name": "Parietal lobe epilepsy"
+  },
+  {
+    "sctid": "230404004",
+    "preferred_name": "Occipital lobe epilepsy"
+  },
+  {
+    "sctid": "230405003",
+    "preferred_name": "Chronic progressive epilepsia partialis continua of childhood"
+  },
+  {
+    "sctid": "230406002",
+    "preferred_name": "Localization-related symptomatic epilepsy with specific precipitant"
+  },
+  {
+    "sctid": "230407006",
+    "preferred_name": "Hemiplegia-hemiconvulsion-epilepsy syndrome"
+  },
+  {
+    "sctid": "230408001",
+    "preferred_name": "Localization-related cryptogenic epilepsy"
+  },
+  {
+    "sctid": "230410004",
+    "preferred_name": "Benign neonatal familial convulsions"
+  },
+  {
+    "sctid": "230411000",
+    "preferred_name": "Benign non-familial neonatal convulsions"
+  },
+  {
+    "sctid": "230412007",
+    "preferred_name": "Myoclonic epilepsy of early childhood"
+  },
+  {
+    "sctid": "230413002",
+    "preferred_name": "Juvenile absence epilepsy"
+  },
+  {
+    "sctid": "230414008",
+    "preferred_name": "Epilepsy with grand mal seizures on awakening"
+  },
+  {
+    "sctid": "230415009",
+    "preferred_name": "Cryptogenic generalized epilepsy"
+  },
+  {
+    "sctid": "230416005",
+    "preferred_name": "Cryptogenic West syndrome"
+  },
+  {
+    "sctid": "230417001",
+    "preferred_name": "Symptomatic West syndrome"
+  },
+  {
+    "sctid": "230418006",
+    "preferred_name": "Lennox-Gastaut syndrome"
+  },
+  {
+    "sctid": "230419003",
+    "preferred_name": "Cryptogenic Lennox-Gastaut syndrome"
+  },
+  {
+    "sctid": "230420009",
+    "preferred_name": "Symptomatic Lennox-Gastaut syndrome"
+  },
+  {
+    "sctid": "230421008",
+    "preferred_name": "Myoclonic astatic epilepsy"
+  },
+  {
+    "sctid": "230422001",
+    "preferred_name": "Myoclonic absence epilepsy"
+  },
+  {
+    "sctid": "230423006",
+    "preferred_name": "Unverricht-Lundborg syndrome"
+  },
+  {
+    "sctid": "230425004",
+    "preferred_name": "Lafora disease"
+  },
+  {
+    "sctid": "230426003",
+    "preferred_name": "Myoclonic epilepsy with ragged red fibers"
+  },
+  {
+    "sctid": "230427007",
+    "preferred_name": "Cryptogenic myoclonic epilepsy"
+  },
+  {
+    "sctid": "230428002",
+    "preferred_name": "Idiopathic myoclonic epilepsy"
+  },
+  {
+    "sctid": "230429005",
+    "preferred_name": "Early infantile epileptic encephalopathy with suppression bursts"
+  },
+  {
+    "sctid": "230430000",
+    "preferred_name": "Symptomatic myoclonic epilepsy"
+  },
+  {
+    "sctid": "230431001",
+    "preferred_name": "Situation-related seizures"
+  },
+  {
+    "sctid": "230432008",
+    "preferred_name": "Familial febrile convulsions"
+  },
+  {
+    "sctid": "230433003",
+    "preferred_name": "Isolated seizures"
+  },
+  {
+    "sctid": "230435005",
+    "preferred_name": "Epilepsy undetermined whether focal or generalized"
+  },
+  {
+    "sctid": "230437002",
+    "preferred_name": "Severe myoclonic epilepsy in infancy"
+  },
+  {
+    "sctid": "230438007",
+    "preferred_name": "Acquired epileptic aphasia"
+  },
+  {
+    "sctid": "230439004",
+    "preferred_name": "Epilepsy with continuous spike wave during slow-wave sleep"
+  },
+  {
+    "sctid": "230440002",
+    "preferred_name": "Secondary reading epilepsy"
+  },
+  {
+    "sctid": "230441003",
+    "preferred_name": "Drug-induced epilepsy"
+  },
+  {
+    "sctid": "230443000",
+    "preferred_name": "Narcotic withdrawal epilepsy"
+  },
+  {
+    "sctid": "230444006",
+    "preferred_name": "Menstrual epilepsy"
+  },
+  {
+    "sctid": "230445007",
+    "preferred_name": "Nocturnal epilepsy"
+  },
+  {
+    "sctid": "230447004",
+    "preferred_name": "Eyelid myoclonus with absences"
+  },
+  {
+    "sctid": "230448009",
+    "preferred_name": "Writing epilepsy"
+  },
+  {
+    "sctid": "230450001",
+    "preferred_name": "Eating epilepsy"
+  },
+  {
+    "sctid": "230452009",
+    "preferred_name": "Toothbrushing epilepsy"
+  },
+  {
+    "sctid": "230453004",
+    "preferred_name": "Decision-making epilepsy"
+  },
+  {
+    "sctid": "230454005",
+    "preferred_name": "Aquagenic epilepsy"
+  },
+  {
+    "sctid": "230455006",
+    "preferred_name": "Self-induced non-photosensitive epilepsy"
+  },
+  {
+    "sctid": "230456007",
+    "preferred_name": "Status epilepticus"
+  },
+  {
+    "sctid": "230457003",
+    "preferred_name": "Non-convulsive status epilepticus with three per second spike wave"
+  },
+  {
+    "sctid": "230458008",
+    "preferred_name": "Non-convulsive status epilepticus without three per second spike wave"
+  },
+  {
+    "sctid": "230459000",
+    "preferred_name": "Non-convulsive simple partial status epilepticus"
+  },
+  {
+    "sctid": "230460005",
+    "preferred_name": "Complex partial status epilepticus"
+  },
+  {
+    "sctid": "230462002",
+    "preferred_name": "Migraine with typical aura"
+  },
+  {
+    "sctid": "230464001",
+    "preferred_name": "Non-familial hemiplegic migraine"
+  },
+  {
+    "sctid": "230465000",
+    "preferred_name": "Migraine aura without headache"
+  },
+  {
+    "sctid": "230466004",
+    "preferred_name": "Alternating hemiplegia of childhood"
+  },
+  {
+    "sctid": "230467008",
+    "preferred_name": "Status migrainosus"
+  },
+  {
+    "sctid": "230468003",
+    "preferred_name": "Migraine with ischemic complication"
+  },
+  {
+    "sctid": "230470007",
+    "preferred_name": "Episodic tension-type headache"
+  },
+  {
+    "sctid": "230471006",
+    "preferred_name": "Chronic tension-type headache"
+  },
+  {
+    "sctid": "230472004",
+    "preferred_name": "Episodic cluster headache"
+  },
+  {
+    "sctid": "230473009",
+    "preferred_name": "Chronic cluster headache"
+  },
+  {
+    "sctid": "230474003",
+    "preferred_name": "Chronic cluster headache unremitting from onset"
+  },
+  {
+    "sctid": "230475002",
+    "preferred_name": "Chronic cluster headache evolved from episodic cluster headache"
+  },
+  {
+    "sctid": "230476001",
+    "preferred_name": "Atypical cluster headache"
+  },
+  {
+    "sctid": "230488004",
+    "preferred_name": "Hypersomnia of non-organic origin"
+  },
+  {
+    "sctid": "230500006",
+    "preferred_name": "Sleep-related dystonia"
+  },
+  {
+    "sctid": "230504002",
+    "preferred_name": "Tilted optic disc"
+  },
+  {
+    "sctid": "230506000",
+    "preferred_name": "Myelinated nerve fibers of optic disc"
+  },
+  {
+    "sctid": "230507009",
+    "preferred_name": "Retrobulbar neuritis"
+  },
+  {
+    "sctid": "230508004",
+    "preferred_name": "Arteritic ischemic optic neuropathy"
+  },
+  {
+    "sctid": "230509007",
+    "preferred_name": "Non-arteritic ischemic optic neuropathy"
+  },
+  {
+    "sctid": "230511003",
+    "preferred_name": "Optic atrophy secondary to papilledema"
+  },
+  {
+    "sctid": "230513000",
+    "preferred_name": "Avulsion of optic nerve"
+  },
+  {
+    "sctid": "230514006",
+    "preferred_name": "Radiation damage to optic nerve"
+  },
+  {
+    "sctid": "230517004",
+    "preferred_name": "Compression of optic chiasm"
+  },
+  {
+    "sctid": "230518009",
+    "preferred_name": "Infarction of optic tract"
+  },
+  {
+    "sctid": "230519001",
+    "preferred_name": "Injury of optic tract"
+  },
+  {
+    "sctid": "230520007",
+    "preferred_name": "Compression of optic tract"
+  },
+  {
+    "sctid": "230521006",
+    "preferred_name": "Optic radiation disorder"
+  },
+  {
+    "sctid": "230522004",
+    "preferred_name": "Inflammatory disorder of optic radiation"
+  },
+  {
+    "sctid": "230523009",
+    "preferred_name": "Infarction of optic radiation"
+  },
+  {
+    "sctid": "230524003",
+    "preferred_name": "Injury of optic radiation"
+  },
+  {
+    "sctid": "230525002",
+    "preferred_name": "Compression of optic radiation"
+  },
+  {
+    "sctid": "230526001",
+    "preferred_name": "Compression of visual cortex"
+  },
+  {
+    "sctid": "230530003",
+    "preferred_name": "Congenital nuclear ophthalmoplegia"
+  },
+  {
+    "sctid": "230539002",
+    "preferred_name": "Cluster tic syndrome"
+  },
+  {
+    "sctid": "230564004",
+    "preferred_name": "Chronic inflammatory demyelinating polyradiculoneuropathy with central nervous system demyelination"
+  },
+  {
+    "sctid": "230651008",
+    "preferred_name": "Disorders of spinal neurones manifest by hyperactivity"
+  },
+  {
+    "sctid": "230652001",
+    "preferred_name": "Benign fasciculation-cramp syndrome"
+  },
+  {
+    "sctid": "230654000",
+    "preferred_name": "Painful legs and moving toes"
+  },
+  {
+    "sctid": "230689003",
+    "preferred_name": "Cerebrovascular and spinal vascular disorders"
+  },
+  {
+    "sctid": "230690007",
+    "preferred_name": "Cerebrovascular accident"
+  },
+  {
+    "sctid": "230691006",
+    "preferred_name": "CVA - cerebrovascular accident due to cerebral artery occlusion"
+  },
+  {
+    "sctid": "230692004",
+    "preferred_name": "Infarction - precerebral"
+  },
+  {
+    "sctid": "230693009",
+    "preferred_name": "Anterior cerebral circulation infarction"
+  },
+  {
+    "sctid": "230694003",
+    "preferred_name": "Total anterior cerebral circulation infarction"
+  },
+  {
+    "sctid": "230695002",
+    "preferred_name": "Partial anterior cerebral circulation infarction"
+  },
+  {
+    "sctid": "230696001",
+    "preferred_name": "Posterior cerebral circulation infarction"
+  },
+  {
+    "sctid": "230698000",
+    "preferred_name": "Lacunar infarction"
+  },
+  {
+    "sctid": "230699008",
+    "preferred_name": "Pure motor lacunar infarction"
+  },
+  {
+    "sctid": "230700009",
+    "preferred_name": "Pure sensory lacunar infarction"
+  },
+  {
+    "sctid": "230701008",
+    "preferred_name": "Pure sensorimotor lacunar infarction"
+  },
+  {
+    "sctid": "230702001",
+    "preferred_name": "Lacunar ataxic hemiparesis"
+  },
+  {
+    "sctid": "230703006",
+    "preferred_name": "Dysarthria-clumsy hand syndrome"
+  },
+  {
+    "sctid": "230706003",
+    "preferred_name": "Hemorrhagic cerebral infarction"
+  },
+  {
+    "sctid": "230707007",
+    "preferred_name": "Anterior cerebral circulation hemorrhagic infarction"
+  },
+  {
+    "sctid": "230708002",
+    "preferred_name": "Posterior cerebral circulation hemorrhagic infarction"
+  },
+  {
+    "sctid": "230709005",
+    "preferred_name": "Massive supratentorial cerebral hemorrhage"
+  },
+  {
+    "sctid": "230710000",
+    "preferred_name": "Lobar cerebral hemorrhage"
+  },
+  {
+    "sctid": "230711001",
+    "preferred_name": "Thalamic hemorrhage"
+  },
+  {
+    "sctid": "230712008",
+    "preferred_name": "Lacunar hemorrhage"
+  },
+  {
+    "sctid": "230713003",
+    "preferred_name": "Stroke of uncertain pathology"
+  },
+  {
+    "sctid": "230714009",
+    "preferred_name": "Anterior circulation stroke of uncertain pathology"
+  },
+  {
+    "sctid": "230715005",
+    "preferred_name": "Posterior circulation stroke of uncertain pathology"
+  },
+  {
+    "sctid": "230716006",
+    "preferred_name": "Carotid territory transient ischemic attack"
+  },
+  {
+    "sctid": "230717002",
+    "preferred_name": "Vertebrobasilar territory transient ischemic attack"
+  },
+  {
+    "sctid": "230718007",
+    "preferred_name": "Subarachnoid hemorrhage due to ruptured arteriovenous malformation"
+  },
+  {
+    "sctid": "230719004",
+    "preferred_name": "Subarachnoid hemorrhage due to ruptured aneurysm"
+  },
+  {
+    "sctid": "230723007",
+    "preferred_name": "Cerebral venous thrombosis of great cerebral vein"
+  },
+  {
+    "sctid": "230733004",
+    "preferred_name": "Isolated angiitis of central nervous system"
+  },
+  {
+    "sctid": "230734005",
+    "preferred_name": "Granulomatous angiitis of central nervous system"
+  },
+  {
+    "sctid": "230739000",
+    "preferred_name": "Spinal cord stroke"
+  },
+  {
+    "sctid": "230741004",
+    "preferred_name": "Venous infarction of spinal cord"
+  },
+  {
+    "sctid": "230744007",
+    "preferred_name": "Cerebrospinal fluid leak"
+  },
+  {
+    "sctid": "230745008",
+    "preferred_name": "Hydrocephalus"
+  },
+  {
+    "sctid": "230746009",
+    "preferred_name": "Obstructive hydrocephalus"
+  },
+  {
+    "sctid": "230747000",
+    "preferred_name": "Isolated fourth ventricle hydrocephalus"
+  },
+  {
+    "sctid": "230748005",
+    "preferred_name": "Intermittently raised pressure hydrocephalus"
+  },
+  {
+    "sctid": "230749002",
+    "preferred_name": "Hydrocephalus due to and following meningitis"
+  },
+  {
+    "sctid": "230751003",
+    "preferred_name": "Hydrocephalus following traumatic injury"
+  },
+  {
+    "sctid": "230752005",
+    "preferred_name": "Hydrocephalus due to cerebrospinal fluid absorption defect"
+  },
+  {
+    "sctid": "230753000",
+    "preferred_name": "Hydrocephalus due to cerebrospinal fluid overproduction"
+  },
+  {
+    "sctid": "230754006",
+    "preferred_name": "Uncinate herniation"
+  },
+  {
+    "sctid": "230755007",
+    "preferred_name": "Upwards herniation of cerebellum"
+  },
+  {
+    "sctid": "230756008",
+    "preferred_name": "Transtentorial hernia"
+  },
+  {
+    "sctid": "230757004",
+    "preferred_name": "Transtentorial herniation downwards"
+  },
+  {
+    "sctid": "230758009",
+    "preferred_name": "Transtentorial herniation upwards"
+  },
+  {
+    "sctid": "230759001",
+    "preferred_name": "Vasogenic cerebral edema"
+  },
+  {
+    "sctid": "230760006",
+    "preferred_name": "Cytotoxic cerebral edema"
+  },
+  {
+    "sctid": "230761005",
+    "preferred_name": "Periventricular cerebrospinal fluid edema"
+  },
+  {
+    "sctid": "230762003",
+    "preferred_name": "High altitude cerebral edema"
+  },
+  {
+    "sctid": "230763008",
+    "preferred_name": "Traumatic cerebral edema"
+  },
+  {
+    "sctid": "230766000",
+    "preferred_name": "Multicystic encephalomalacia"
+  },
+  {
+    "sctid": "230769007",
+    "preferred_name": "Periventricular leukomalacia"
+  },
+  {
+    "sctid": "230773005",
+    "preferred_name": "Spastic cerebral palsy"
+  },
+  {
+    "sctid": "230777006",
+    "preferred_name": "Monoplegic cerebral palsy affecting upper limb"
+  },
+  {
+    "sctid": "230778001",
+    "preferred_name": "Monoplegic cerebral palsy affecting lower limb"
+  },
+  {
+    "sctid": "230779009",
+    "preferred_name": "Congenital spastic foot"
+  },
+  {
+    "sctid": "230780007",
+    "preferred_name": "Dyskinetic cerebral palsy"
+  },
+  {
+    "sctid": "230781006",
+    "preferred_name": "Dystonic/rigid cerebral palsy"
+  },
+  {
+    "sctid": "230782004",
+    "preferred_name": "Dysequilibrium syndrome"
+  },
+  {
+    "sctid": "230784003",
+    "preferred_name": "Congenital pseudobulbar palsy"
+  },
+  {
+    "sctid": "230786001",
+    "preferred_name": "Congenital dysphasia"
+  },
+  {
+    "sctid": "230787005",
+    "preferred_name": "Congenital expressive dysphasia"
+  },
+  {
+    "sctid": "230788000",
+    "preferred_name": "Congenital receptive dysphasia"
+  },
+  {
+    "sctid": "230790004",
+    "preferred_name": "Choroid plexus cyst"
+  },
+  {
+    "sctid": "230791000",
+    "preferred_name": "Hypothalamic neuronal hamartoma"
+  },
+  {
+    "sctid": "230792007",
+    "preferred_name": "Ependymal cyst"
+  },
+  {
+    "sctid": "230793002",
+    "preferred_name": "Neuroglial cyst"
+  },
+  {
+    "sctid": "230796005",
+    "preferred_name": "Non-diabetic hypoglycemic coma"
+  },
+  {
+    "sctid": "230801000",
+    "preferred_name": "Post-ictal coma"
+  },
+  {
+    "sctid": "230802007",
+    "preferred_name": "Brainstem death"
+  },
+  {
+    "sctid": "230806005",
+    "preferred_name": "Brain ventricular shunt infection"
+  },
+  {
+    "sctid": "230807001",
+    "preferred_name": "Brain ventricular shunt displacement"
+  },
+  {
+    "sctid": "230808006",
+    "preferred_name": "Brain ventricular shunt obstruction"
+  },
+  {
+    "sctid": "2312009",
+    "preferred_name": "Reactive attachment disorder of infancy OR early childhood, inhibited type"
+  },
+  {
+    "sctid": "231437006",
+    "preferred_name": "Reactive psychoses"
+  },
+  {
+    "sctid": "231438001",
+    "preferred_name": "Presbyophrenic psychosis"
+  },
+  {
+    "sctid": "231439009",
+    "preferred_name": "Toxic confusional state"
+  },
+  {
+    "sctid": "231440006",
+    "preferred_name": "Delirium of mixed origin"
+  },
+  {
+    "sctid": "231442003",
+    "preferred_name": "Organic catatonic disorder"
+  },
+  {
+    "sctid": "231443008",
+    "preferred_name": "Right hemispheric organic affective disorder"
+  },
+  {
+    "sctid": "231444002",
+    "preferred_name": "Organic bipolar disorder"
+  },
+  {
+    "sctid": "231445001",
+    "preferred_name": "Organic dissociative disorder"
+  },
+  {
+    "sctid": "231446000",
+    "preferred_name": "Organic emotionally labile disorder"
+  },
+  {
+    "sctid": "231448004",
+    "preferred_name": "Age-associated memory impairment"
+  },
+  {
+    "sctid": "231449007",
+    "preferred_name": "Epileptic psychosis"
+  },
+  {
+    "sctid": "231450007",
+    "preferred_name": "Psychosis associated with intensive care"
+  },
+  {
+    "sctid": "231451006",
+    "preferred_name": "Drug-induced intensive care psychosis"
+  },
+  {
+    "sctid": "231452004",
+    "preferred_name": "Limbic epilepsy personality syndrome"
+  },
+  {
+    "sctid": "231453009",
+    "preferred_name": "Lobotomy syndrome"
+  },
+  {
+    "sctid": "231454003",
+    "preferred_name": "Organic pseudopsychopathic personality"
+  },
+  {
+    "sctid": "231455002",
+    "preferred_name": "Organic pseudoretarded personality"
+  },
+  {
+    "sctid": "231456001",
+    "preferred_name": "Postleucotomy syndrome"
+  },
+  {
+    "sctid": "231458000",
+    "preferred_name": "Abuse of steroids"
+  },
+  {
+    "sctid": "231459008",
+    "preferred_name": "Abuse of nonpsychotropic analgesic drugs"
+  },
+  {
+    "sctid": "231467000",
+    "preferred_name": "Absinthe addiction"
+  },
+  {
+    "sctid": "23148009",
+    "preferred_name": "Undifferentiated attention deficit disorder"
+  },
+  {
+    "sctid": "231485007",
+    "preferred_name": "Post-schizophrenic depression"
+  },
+  {
+    "sctid": "231487004",
+    "preferred_name": "Persistent delusional disorder"
+  },
+  {
+    "sctid": "231489001",
+    "preferred_name": "Acute transient psychotic disorder"
+  },
+  {
+    "sctid": "231494001",
+    "preferred_name": "Mania"
+  },
+  {
+    "sctid": "231495000",
+    "preferred_name": "Manic stupor"
+  },
+  {
+    "sctid": "231496004",
+    "preferred_name": "Hypomania"
+  },
+  {
+    "sctid": "231499006",
+    "preferred_name": "Endogenous depression first episode"
+  },
+  {
+    "sctid": "231500002",
+    "preferred_name": "Masked depression"
+  },
+  {
+    "sctid": "231504006",
+    "preferred_name": "Mixed anxiety and depressive disorder"
+  },
+  {
+    "sctid": "231509001",
+    "preferred_name": "Dissociative astasia-abasia"
+  },
+  {
+    "sctid": "231515001",
+    "preferred_name": "Hypochondriacal pain"
+  },
+  {
+    "sctid": "231516000",
+    "preferred_name": "Cutaneous hypochondriasis"
+  },
+  {
+    "sctid": "231517009",
+    "preferred_name": "Somatoform autonomic dysfunction"
+  },
+  {
+    "sctid": "231518004",
+    "preferred_name": "Globus abdominalis"
+  },
+  {
+    "sctid": "231519007",
+    "preferred_name": "Depersonalization-derealization syndrome"
+  },
+  {
+    "sctid": "231520001",
+    "preferred_name": "Behavioral syndrome associated with physiological disturbance and physical factors"
+  },
+  {
+    "sctid": "231521002",
+    "preferred_name": "Weight fixation"
+  },
+  {
+    "sctid": "231522009",
+    "preferred_name": "Atypical anorexia nervosa"
+  },
+  {
+    "sctid": "231523004",
+    "preferred_name": "Atypical bulimia nervosa"
+  },
+  {
+    "sctid": "231524005",
+    "preferred_name": "Interictal behavior disorder"
+  },
+  {
+    "sctid": "231525006",
+    "preferred_name": "Manipulative personality disorder"
+  },
+  {
+    "sctid": "231526007",
+    "preferred_name": "Fanatic personality"
+  },
+  {
+    "sctid": "231527003",
+    "preferred_name": "Explosive personality disorder"
+  },
+  {
+    "sctid": "231528008",
+    "preferred_name": "Anxious personality disorder"
+  },
+  {
+    "sctid": "231530005",
+    "preferred_name": "Post-concussional personality disorder"
+  },
+  {
+    "sctid": "231536004",
+    "preferred_name": "Atypical autism"
+  },
+  {
+    "sctid": "231537008",
+    "preferred_name": "Developmental agnosia"
+  },
+  {
+    "sctid": "231538003",
+    "preferred_name": "Behavioral and emotional disorder with onset in childhood"
+  },
+  {
+    "sctid": "231539006",
+    "preferred_name": "Adolescent - emotional problem"
+  },
+  {
+    "sctid": "231540008",
+    "preferred_name": "Conduct disorder - in family context"
+  },
+  {
+    "sctid": "231541007",
+    "preferred_name": "Conduct disorder - unsocialized"
+  },
+  {
+    "sctid": "231542000",
+    "preferred_name": "Depressive conduct disorder"
+  },
+  {
+    "sctid": "23186000",
+    "preferred_name": "Menstrual migraine"
+  },
+  {
+    "sctid": "231864002",
+    "preferred_name": "Factitious conjunctivitis"
+  },
+  {
+    "sctid": "232021008",
+    "preferred_name": "Proliferative retinopathy with optic disc neovascularization due to diabetes mellitus"
+  },
+  {
+    "sctid": "232034009",
+    "preferred_name": "Central serous retinopathy with pit of optic disc"
+  },
+  {
+    "sctid": "232059000",
+    "preferred_name": "Laurence-Moon syndrome"
+  },
+  {
+    "sctid": "232280003",
+    "preferred_name": "Post-traumatic cerebrospinal otorrhea"
+  },
+  {
+    "sctid": "232281004",
+    "preferred_name": "Postoperative cerebrospinal otorrhea"
+  },
+  {
+    "sctid": "23276006",
+    "preferred_name": "Ventricular hemorrhage"
+  },
+  {
+    "sctid": "23291008",
+    "preferred_name": "Herpes simplex meningitis"
+  },
+  {
+    "sctid": "233690008",
+    "preferred_name": "Factitious asthma"
+  },
+  {
+    "sctid": "233718008",
+    "preferred_name": "Pulmonary tuberous sclerosis"
+  },
+  {
+    "sctid": "23374007",
+    "preferred_name": "Atypical absence seizure"
+  },
+  {
+    "sctid": "234146006",
+    "preferred_name": "Hennekam syndrome"
+  },
+  {
+    "sctid": "2355008",
+    "preferred_name": "Rud's syndrome"
+  },
+  {
+    "sctid": "23560001",
+    "preferred_name": "Asperger's disorder"
+  },
+  {
+    "sctid": "23645006",
+    "preferred_name": "Organic mood disorder"
+  },
+  {
+    "sctid": "236529001",
+    "preferred_name": "Prune belly syndrome with pulmonic stenosis, mental retardation and deafness"
+  },
+  {
+    "sctid": "237120002",
+    "preferred_name": "Hypothalamic amenorrhea"
+  },
+  {
+    "sctid": "23713006",
+    "preferred_name": "Contusion of cerebral cortex"
+  },
+  {
+    "sctid": "237283007",
+    "preferred_name": "Eclampsia in labor"
+  },
+  {
+    "sctid": "23732000",
+    "preferred_name": "Primary cerebellar degeneration"
+  },
+  {
+    "sctid": "237349002",
+    "preferred_name": "Mild postnatal depression"
+  },
+  {
+    "sctid": "237350002",
+    "preferred_name": "Severe postnatal depression"
+  },
+  {
+    "sctid": "237351003",
+    "preferred_name": "Mild postnatal psychosis"
+  },
+  {
+    "sctid": "237352005",
+    "preferred_name": "Severe postnatal psychosis"
+  },
+  {
+    "sctid": "23741000119105",
+    "preferred_name": "Severe manic bipolar I disorder"
+  },
+  {
+    "sctid": "237512007",
+    "preferred_name": "Thyrotoxicosis due to TSHoma"
+  },
+  {
+    "sctid": "237577005",
+    "preferred_name": "Abnormality of somatostatin secretion"
+  },
+  {
+    "sctid": "237578000",
+    "preferred_name": "Excessive somatostatin secretion"
+  },
+  {
+    "sctid": "237595008",
+    "preferred_name": "Abnormality of neurotensine secretion"
+  },
+  {
+    "sctid": "237612000",
+    "preferred_name": "Photomyoclonus, diabetes mellitus, deafness, nephropathy and cerebral dysfunction"
+  },
+  {
+    "sctid": "237662005",
+    "preferred_name": "Hyperprolactinemia"
+  },
+  {
+    "sctid": "237663000",
+    "preferred_name": "Idiopathic hyperprolactinemia"
+  },
+  {
+    "sctid": "237664006",
+    "preferred_name": "Pituitary stalk compression hyperprolactinemia"
+  },
+  {
+    "sctid": "237665007",
+    "preferred_name": "Drug-induced hyperprolactinemia"
+  },
+  {
+    "sctid": "237666008",
+    "preferred_name": "Physiological hyperprolactinemia"
+  },
+  {
+    "sctid": "237667004",
+    "preferred_name": "Lactation hyperprolactinemia"
+  },
+  {
+    "sctid": "237668009",
+    "preferred_name": "Pregnancy hyperprolactinemia"
+  },
+  {
+    "sctid": "237669001",
+    "preferred_name": "ACTH hypersecretion"
+  },
+  {
+    "sctid": "237670000",
+    "preferred_name": "ACTH hypersecretion not causing Cushing's syndrome"
+  },
+  {
+    "sctid": "237671001",
+    "preferred_name": "Gonadotrophin hypersecretion"
+  },
+  {
+    "sctid": "237672008",
+    "preferred_name": "LH hypersecretion"
+  },
+  {
+    "sctid": "237673003",
+    "preferred_name": "FSH hypersecretion"
+  },
+  {
+    "sctid": "237674009",
+    "preferred_name": "Anterior pituitary hyperplasia"
+  },
+  {
+    "sctid": "237675005",
+    "preferred_name": "Somatotroph hyperplasia"
+  },
+  {
+    "sctid": "237676006",
+    "preferred_name": "Lactotroph hyperplasia"
+  },
+  {
+    "sctid": "237677002",
+    "preferred_name": "Gonadotroph hyperplasia"
+  },
+  {
+    "sctid": "237678007",
+    "preferred_name": "Thyrotroph hyperplasia"
+  },
+  {
+    "sctid": "237680001",
+    "preferred_name": "Corticotroph hyperplasia"
+  },
+  {
+    "sctid": "237682009",
+    "preferred_name": "Panhypopituitarism - anterior and posterior"
+  },
+  {
+    "sctid": "237683004",
+    "preferred_name": "Panhypopituitarism - X-linked"
+  },
+  {
+    "sctid": "237684005",
+    "preferred_name": "Sheehan's syndrome"
+  },
+  {
+    "sctid": "237685006",
+    "preferred_name": "Partial hypopituitarism"
+  },
+  {
+    "sctid": "237687003",
+    "preferred_name": "Autosomal dominant isolated somatotropin deficiency"
+  },
+  {
+    "sctid": "237688008",
+    "preferred_name": "Idiopathic growth hormone deficiency"
+  },
+  {
+    "sctid": "237689000",
+    "preferred_name": "Growth hormone neurosecretory dysfunction"
+  },
+  {
+    "sctid": "237691008",
+    "preferred_name": "Psychosocial growth hormone deficiency"
+  },
+  {
+    "sctid": "237692001",
+    "preferred_name": "ACTH deficiency"
+  },
+  {
+    "sctid": "237693006",
+    "preferred_name": "Idiopathic adrenocorticotropic hormone deficiency"
+  },
+  {
+    "sctid": "237694000",
+    "preferred_name": "Steroid suppression of ACTH secretion"
+  },
+  {
+    "sctid": "237695004",
+    "preferred_name": "Idiopathic TSH deficiency"
+  },
+  {
+    "sctid": "237696003",
+    "preferred_name": "Familial central diabetes insipidus"
+  },
+  {
+    "sctid": "237697007",
+    "preferred_name": "Oxytocin deficiency"
+  },
+  {
+    "sctid": "237698002",
+    "preferred_name": "Iatrogenic hypopituitarism"
+  },
+  {
+    "sctid": "237699005",
+    "preferred_name": "Post-traumatic hypopituitarism"
+  },
+  {
+    "sctid": "237700006",
+    "preferred_name": "Hypopituitarism due to iron overload"
+  },
+  {
+    "sctid": "237701005",
+    "preferred_name": "Pituitary apoplexy"
+  },
+  {
+    "sctid": "237702003",
+    "preferred_name": "Pituitary hemorrhage"
+  },
+  {
+    "sctid": "237703008",
+    "preferred_name": "Pituitary fibrosis"
+  },
+  {
+    "sctid": "237704002",
+    "preferred_name": "Pituitary fibrosis with midline fibrosis"
+  },
+  {
+    "sctid": "237705001",
+    "preferred_name": "Hypophysitis"
+  },
+  {
+    "sctid": "237706000",
+    "preferred_name": "Autoimmune hypophysitis"
+  },
+  {
+    "sctid": "237707009",
+    "preferred_name": "Lymphocytic hypophysitis of pregnancy"
+  },
+  {
+    "sctid": "237708004",
+    "preferred_name": "Granulomatous giant-cell hypophysitis"
+  },
+  {
+    "sctid": "237709007",
+    "preferred_name": "Granuloma of pituitary and hypothalamus"
+  },
+  {
+    "sctid": "237710002",
+    "preferred_name": "Pituitary granuloma"
+  },
+  {
+    "sctid": "237711003",
+    "preferred_name": "Hypothalamic granuloma"
+  },
+  {
+    "sctid": "237714006",
+    "preferred_name": "Hamartoma of hypothalamus"
+  },
+  {
+    "sctid": "237716008",
+    "preferred_name": "Pituitary cyst"
+  },
+  {
+    "sctid": "237717004",
+    "preferred_name": "Arachnoid cyst of pituitary"
+  },
+  {
+    "sctid": "237718009",
+    "preferred_name": "Pituitary gland enlarged"
+  },
+  {
+    "sctid": "237719001",
+    "preferred_name": "Pituitary adenoma with extrasellar extension"
+  },
+  {
+    "sctid": "237720007",
+    "preferred_name": "Hamartoma of pituitary and hypothalamus"
+  },
+  {
+    "sctid": "23772009",
+    "preferred_name": "Dysphonia of Gilles de la Tourette's syndrome"
+  },
+  {
+    "sctid": "237721006",
+    "preferred_name": "Tumor of pituitary and suprasellar region"
+  },
+  {
+    "sctid": "237723009",
+    "preferred_name": "Pituitary stalk compression"
+  },
+  {
+    "sctid": "237724003",
+    "preferred_name": "Hypothalamic disorder of appetite"
+  },
+  {
+    "sctid": "237725002",
+    "preferred_name": "Defective osmoregulation"
+  },
+  {
+    "sctid": "237726001",
+    "preferred_name": "Osmoregulation defect - absent thirst"
+  },
+  {
+    "sctid": "237727005",
+    "preferred_name": "Osmoregulation defect - excess thirst"
+  },
+  {
+    "sctid": "237728000",
+    "preferred_name": "Absent osmoregulation"
+  },
+  {
+    "sctid": "237729008",
+    "preferred_name": "Reset hypothalamic osmostat"
+  },
+  {
+    "sctid": "237730003",
+    "preferred_name": "Hypothalamic overactivity"
+  },
+  {
+    "sctid": "237731004",
+    "preferred_name": "Loss of hypothalamic inhibition"
+  },
+  {
+    "sctid": "237733001",
+    "preferred_name": "Diencephalic syndrome"
+  },
+  {
+    "sctid": "237960000",
+    "preferred_name": "D-2(OH) glutaric aciduria"
+  },
+  {
+    "sctid": "237961001",
+    "preferred_name": "L-2(OH) glutaric aciduria"
+  },
+  {
+    "sctid": "238030005",
+    "preferred_name": "Galactocerebroside beta-galactosidase deficiency - early onset"
+  },
+  {
+    "sctid": "23853001",
+    "preferred_name": "Disorder of the central nervous system"
+  },
+  {
+    "sctid": "23871000119106",
+    "preferred_name": "Somnambulism co-occurrent with sleep terror disorder"
+  },
+  {
+    "sctid": "238826008",
+    "preferred_name": "de Barsy syndrome"
+  },
+  {
+    "sctid": "238959007",
+    "preferred_name": "Disorders of cutaneous image and perception"
+  },
+  {
+    "sctid": "238960002",
+    "preferred_name": "Dermatological non-disease"
+  },
+  {
+    "sctid": "238961003",
+    "preferred_name": "Trichophobia"
+  },
+  {
+    "sctid": "238965007",
+    "preferred_name": "Venereophobia"
+  },
+  {
+    "sctid": "238966008",
+    "preferred_name": "Syphilophobia"
+  },
+  {
+    "sctid": "238967004",
+    "preferred_name": "Psychogenic sensory disturbance of skin"
+  },
+  {
+    "sctid": "238972008",
+    "preferred_name": "Cutaneous monosymptomatic delusional psychosis"
+  },
+  {
+    "sctid": "238973003",
+    "preferred_name": "Delusions of parasitosis"
+  },
+  {
+    "sctid": "238974009",
+    "preferred_name": "Delusions of infestation"
+  },
+  {
+    "sctid": "238975005",
+    "preferred_name": "Delusion of foul odor"
+  },
+  {
+    "sctid": "238976006",
+    "preferred_name": "Bromisodrophobia"
+  },
+  {
+    "sctid": "238977002",
+    "preferred_name": "Delusional hyperhidrosis"
+  },
+  {
+    "sctid": "238978007",
+    "preferred_name": "Hyperschemazia"
+  },
+  {
+    "sctid": "238979004",
+    "preferred_name": "Hyposchemazia"
+  },
+  {
+    "sctid": "239026002",
+    "preferred_name": "Hypohidrosis-diabetes insipidus syndrome"
+  },
+  {
+    "sctid": "23931000119104",
+    "preferred_name": "Hydrocephalus due to Arnold Chiari malformation type 2"
+  },
+  {
+    "sctid": "23941000119108",
+    "preferred_name": "Arnold Chiari type 2 without hydrocephalus"
+  },
+  {
+    "sctid": "239825002",
+    "preferred_name": "Tabetic joint"
+  },
+  {
+    "sctid": "239965291000119107",
+    "preferred_name": "Cerebrovascular accident due to occlusion of basilar artery"
+  },
+  {
+    "sctid": "24003004",
+    "preferred_name": "Postinflammatory optic atrophy"
+  },
+  {
+    "sctid": "2403008",
+    "preferred_name": "Psychoactive substance dependence"
+  },
+  {
+    "sctid": "240312009",
+    "preferred_name": "Cerebral injury due to birth trauma"
+  },
+  {
+    "sctid": "240313004",
+    "preferred_name": "Intracerebral hemorrhage in fetus or newborn"
+  },
+  {
+    "sctid": "240393003",
+    "preferred_name": "Listeria cerebritis"
+  },
+  {
+    "sctid": "240448007",
+    "preferred_name": "Legionella encephalopathy"
+  },
+  {
+    "sctid": "240459003",
+    "preferred_name": "Abortive poliomyelitis"
+  },
+  {
+    "sctid": "240460008",
+    "preferred_name": "Acute paralytic poliomyelitis"
+  },
+  {
+    "sctid": "240461007",
+    "preferred_name": "Incubating rabies"
+  },
+  {
+    "sctid": "240462000",
+    "preferred_name": "Rabies prodrome"
+  },
+  {
+    "sctid": "240463005",
+    "preferred_name": "Acute neurological rabies"
+  },
+  {
+    "sctid": "240464004",
+    "preferred_name": "Rabies coma"
+  },
+  {
+    "sctid": "240465003",
+    "preferred_name": "Rabies - recovery phase"
+  },
+  {
+    "sctid": "240552005",
+    "preferred_name": "Juvenile tabes dorsalis"
+  },
+  {
+    "sctid": "240564002",
+    "preferred_name": "Secondary neurosyphilis"
+  },
+  {
+    "sctid": "240565001",
+    "preferred_name": "Asymptomatic secondary neurosyphilis"
+  },
+  {
+    "sctid": "240568004",
+    "preferred_name": "Meningovascular syphilis - quaternary stage"
+  },
+  {
+    "sctid": "24059009",
+    "preferred_name": "Acute cerebellar ataxia due to varicella"
+  },
+  {
+    "sctid": "240720008",
+    "preferred_name": "Central nervous system candidiasis"
+  },
+  {
+    "sctid": "240845003",
+    "preferred_name": "Cerebral loiasis"
+  },
+  {
+    "sctid": "240875008",
+    "preferred_name": "Cerebral gnathostomiasis"
+  },
+  {
+    "sctid": "241006",
+    "preferred_name": "Epilepsia partialis continua"
+  },
+  {
+    "sctid": "24121004",
+    "preferred_name": "Insomnia disorder related to another mental disorder"
+  },
+  {
+    "sctid": "24125008",
+    "preferred_name": "Mental disorder in infancy"
+  },
+  {
+    "sctid": "241992009",
+    "preferred_name": "Spinal cord decompression injury"
+  },
+  {
+    "sctid": "241993004",
+    "preferred_name": "Cerebral decompression injury"
+  },
+  {
+    "sctid": "241994005",
+    "preferred_name": "Cerebellar decompression injury"
+  },
+  {
+    "sctid": "2421000119107",
+    "preferred_name": "Hallucinations co-occurrent and due to late onset dementia"
+  },
+  {
+    "sctid": "24315006",
+    "preferred_name": "Factitious disorder with combined physical AND psychological symptoms"
+  },
+  {
+    "sctid": "2432006",
+    "preferred_name": "Cerebrospinal fluid circulation disorder"
+  },
+  {
+    "sctid": "24321005",
+    "preferred_name": "Fungal meningitis"
+  },
+  {
+    "sctid": "24326000",
+    "preferred_name": "Metachromatic leukodystrophy, adult type"
+  },
+  {
+    "sctid": "24392008",
+    "preferred_name": "Injury at C1-C4 level with spinal cord injury AND without bone injury"
+  },
+  {
+    "sctid": "24473007",
+    "preferred_name": "Persistent vegetative state"
+  },
+  {
+    "sctid": "24630008",
+    "preferred_name": "Listeria meningoencephalitis"
+  },
+  {
+    "sctid": "246528007",
+    "preferred_name": "Simple partial seizure with focal motor signs without march"
+  },
+  {
+    "sctid": "246529004",
+    "preferred_name": "Simple partial seizure with focal motor signs with march"
+  },
+  {
+    "sctid": "246530009",
+    "preferred_name": "Versive seizure"
+  },
+  {
+    "sctid": "246531008",
+    "preferred_name": "Postural seizure"
+  },
+  {
+    "sctid": "246532001",
+    "preferred_name": "Phonatory seizure"
+  },
+  {
+    "sctid": "246533006",
+    "preferred_name": "Simple partial seizure with somatosensory or special sensory dysfunction"
+  },
+  {
+    "sctid": "246535004",
+    "preferred_name": "Dysphasic seizure"
+  },
+  {
+    "sctid": "246536003",
+    "preferred_name": "Cognitive seizure"
+  },
+  {
+    "sctid": "246537007",
+    "preferred_name": "Affective seizure"
+  },
+  {
+    "sctid": "246538002",
+    "preferred_name": "Seizure causing illusions"
+  },
+  {
+    "sctid": "246539005",
+    "preferred_name": "Seizure with structured hallucinations"
+  },
+  {
+    "sctid": "246540007",
+    "preferred_name": "Simple partial seizure followed by impaired consciousness"
+  },
+  {
+    "sctid": "24654003",
+    "preferred_name": "Weber-Gubler syndrome"
+  },
+  {
+    "sctid": "246541006",
+    "preferred_name": "Simple partial onset of seizure with automatisms"
+  },
+  {
+    "sctid": "246542004",
+    "preferred_name": "Complex part seizure with impairment of consciousness only"
+  },
+  {
+    "sctid": "246544003",
+    "preferred_name": "Partial seizure evolving to secondary generalized seizure"
+  },
+  {
+    "sctid": "246546001",
+    "preferred_name": "Absence seizure with impairment of consciousness only"
+  },
+  {
+    "sctid": "246548000",
+    "preferred_name": "Absence seizure with mild clonic components"
+  },
+  {
+    "sctid": "246549008",
+    "preferred_name": "Absence seizure with atonic components"
+  },
+  {
+    "sctid": "246550008",
+    "preferred_name": "Absence seizure with tonic components"
+  },
+  {
+    "sctid": "246551007",
+    "preferred_name": "Absence seizure with automatisms"
+  },
+  {
+    "sctid": "246552000",
+    "preferred_name": "Absence seizure with autonomic components"
+  },
+  {
+    "sctid": "24700007",
+    "preferred_name": "Multiple sclerosis"
+  },
+  {
+    "sctid": "247099009",
+    "preferred_name": "Optic disc neovascularization"
+  },
+  {
+    "sctid": "247204001",
+    "preferred_name": "Morning glory disc"
+  },
+  {
+    "sctid": "247209006",
+    "preferred_name": "Optic disc vascular anomaly"
+  },
+  {
+    "sctid": "247219000",
+    "preferred_name": "Atrophy of sector of optic disc"
+  },
+  {
+    "sctid": "247233000",
+    "preferred_name": "Optic disc hemorrhage"
+  },
+  {
+    "sctid": "247400008",
+    "preferred_name": "Painful arms and moving fingers"
+  },
+  {
+    "sctid": "247803002",
+    "preferred_name": "Seasonal affective disorder"
+  },
+  {
+    "sctid": "247804008",
+    "preferred_name": "Schizophrenic prodrome"
+  },
+  {
+    "sctid": "24781009",
+    "preferred_name": "Panic disorder with agoraphobia, mild agoraphobic avoidance AND panic attacks in full remission"
+  },
+  {
+    "sctid": "248103001",
+    "preferred_name": "Flashing"
+  },
+  {
+    "sctid": "248118000",
+    "preferred_name": "Self-induced purging to lose weight"
+  },
+  {
+    "sctid": "248231000000103",
+    "preferred_name": "Paruresis"
+  },
+  {
+    "sctid": "248260009",
+    "preferred_name": "Unrefreshed by sleep"
+  },
+  {
+    "sctid": "249520001",
+    "preferred_name": "Self-induced purging"
+  },
+  {
+    "sctid": "24956004",
+    "preferred_name": "Loculation syndrome"
+  },
+  {
+    "sctid": "249892007",
+    "preferred_name": "Progressive pseudobulbar palsy"
+  },
+  {
+    "sctid": "24991000119103",
+    "preferred_name": "Thoracic myelopathy"
+  },
+  {
+    "sctid": "25004000",
+    "preferred_name": "Subdural hemorrhage due to intrapartum anoxia AND/OR hypoxia"
+  },
+  {
+    "sctid": "25029006",
+    "preferred_name": "Deferred diagnosis on Axis III"
+  },
+  {
+    "sctid": "25044007",
+    "preferred_name": "Neuromyelitis optica"
+  },
+  {
+    "sctid": "25053000",
+    "preferred_name": "Obstetrical central nervous system complication of anesthesia AND/OR sedation"
+  },
+  {
+    "sctid": "2506003",
+    "preferred_name": "Early onset dysthymia"
+  },
+  {
+    "sctid": "251000119105",
+    "preferred_name": "Severe major depression, single episode"
+  },
+  {
+    "sctid": "25133001",
+    "preferred_name": "Completed stroke"
+  },
+  {
+    "sctid": "251770561000119107",
+    "preferred_name": "Cerebrovascular accident due to embolism of left anterior cerebral artery"
+  },
+  {
+    "sctid": "25297005",
+    "preferred_name": "Psychogenic adductor spastic dysphonia"
+  },
+  {
+    "sctid": "253010003",
+    "preferred_name": "Microprolactinoma"
+  },
+  {
+    "sctid": "253011004",
+    "preferred_name": "Macroprolactinoma"
+  },
+  {
+    "sctid": "253101008",
+    "preferred_name": "Congenital cerebral hernia"
+  },
+  {
+    "sctid": "253103006",
+    "preferred_name": "Frontal encephalocele"
+  },
+  {
+    "sctid": "253104000",
+    "preferred_name": "Frontoethmoidal encephalocele"
+  },
+  {
+    "sctid": "253106003",
+    "preferred_name": "Nasofrontal encephalocele"
+  },
+  {
+    "sctid": "253107007",
+    "preferred_name": "Nasopharyngeal encephalocele"
+  },
+  {
+    "sctid": "253108002",
+    "preferred_name": "Temporal encephalocele"
+  },
+  {
+    "sctid": "253109005",
+    "preferred_name": "Parietal encephalocele"
+  },
+  {
+    "sctid": "253113003",
+    "preferred_name": "Rachischisis with hydrocephalus"
+  },
+  {
+    "sctid": "253114009",
+    "preferred_name": "Myelocele with hydrocephalus"
+  },
+  {
+    "sctid": "253115005",
+    "preferred_name": "Hydromyelocele with hydrocephalus"
+  },
+  {
+    "sctid": "253117002",
+    "preferred_name": "Closed spina bifida with Arnold-Chiari malformation"
+  },
+  {
+    "sctid": "253118007",
+    "preferred_name": "Thoracolumbar spina bifida with hydrocephalus - closed"
+  },
+  {
+    "sctid": "253119004",
+    "preferred_name": "Hemimyelocele"
+  },
+  {
+    "sctid": "253120005",
+    "preferred_name": "Lipomeningocele"
+  },
+  {
+    "sctid": "253124001",
+    "preferred_name": "Myelodysplasia of spinal cord"
+  },
+  {
+    "sctid": "253125000",
+    "preferred_name": "Spinal hamartoma"
+  },
+  {
+    "sctid": "253131002",
+    "preferred_name": "Hydrocephalus associated with late onset aqueduct stenosis"
+  },
+  {
+    "sctid": "253132009",
+    "preferred_name": "External hydrocephalus"
+  },
+  {
+    "sctid": "253133004",
+    "preferred_name": "Hydrocephalus with anomaly of aqueduct of Sylvius"
+  },
+  {
+    "sctid": "253135006",
+    "preferred_name": "Defect of telencephalic division"
+  },
+  {
+    "sctid": "253136007",
+    "preferred_name": "Lobar holoprosencephaly"
+  },
+  {
+    "sctid": "253137003",
+    "preferred_name": "Alobar holoprosencephaly"
+  },
+  {
+    "sctid": "253138008",
+    "preferred_name": "Semi-lobar holoprosencephaly"
+  },
+  {
+    "sctid": "253139000",
+    "preferred_name": "Agenesis of corpus callosum with lipoma"
+  },
+  {
+    "sctid": "253140003",
+    "preferred_name": "Partial agenesis of corpus callosum"
+  },
+  {
+    "sctid": "253142006",
+    "preferred_name": "Atrophy of corpus callosum"
+  },
+  {
+    "sctid": "253143001",
+    "preferred_name": "Absence of septum pellucidum"
+  },
+  {
+    "sctid": "253144007",
+    "preferred_name": "Cyst of septum pellucidum"
+  },
+  {
+    "sctid": "253145008",
+    "preferred_name": "Reduction anomaly of hypothalamus"
+  },
+  {
+    "sctid": "253146009",
+    "preferred_name": "Disorder of neuronal migration and differentiation"
+  },
+  {
+    "sctid": "253147000",
+    "preferred_name": "Type 1 lissencephaly"
+  },
+  {
+    "sctid": "253148005",
+    "preferred_name": "Miller Dieker syndrome"
+  },
+  {
+    "sctid": "253149002",
+    "preferred_name": "Type 2 lissencephaly"
+  },
+  {
+    "sctid": "253150002",
+    "preferred_name": "Neuronal heterotopia"
+  },
+  {
+    "sctid": "253151003",
+    "preferred_name": "Nodular heterotopia"
+  },
+  {
+    "sctid": "253152005",
+    "preferred_name": "Laminar heterotopia"
+  },
+  {
+    "sctid": "253153000",
+    "preferred_name": "Cortical dysplasia"
+  },
+  {
+    "sctid": "253154006",
+    "preferred_name": "Localized cortical dysplasia"
+  },
+  {
+    "sctid": "253156008",
+    "preferred_name": "Cortical dysplasia with hemimegalencephaly"
+  },
+  {
+    "sctid": "253158009",
+    "preferred_name": "Hydranencephaly with proliferative vasculopathy"
+  },
+  {
+    "sctid": "253159001",
+    "preferred_name": "Schizencephaly"
+  },
+  {
+    "sctid": "253160006",
+    "preferred_name": "Colpocephaly"
+  },
+  {
+    "sctid": "253162003",
+    "preferred_name": "Cerebral arachnoid cyst"
+  },
+  {
+    "sctid": "253163008",
+    "preferred_name": "Spinal arachnoid cyst"
+  },
+  {
+    "sctid": "253164002",
+    "preferred_name": "Intradural spinal arachnoid cyst"
+  },
+  {
+    "sctid": "253165001",
+    "preferred_name": "Extradural spinal arachnoid cyst"
+  },
+  {
+    "sctid": "253166000",
+    "preferred_name": "Lateral meningocele"
+  },
+  {
+    "sctid": "253167009",
+    "preferred_name": "Microdysgenesis"
+  },
+  {
+    "sctid": "253168004",
+    "preferred_name": "Familial megalencephaly"
+  },
+  {
+    "sctid": "253169007",
+    "preferred_name": "Sporadic megalencephaly"
+  },
+  {
+    "sctid": "253170008",
+    "preferred_name": "Hemimegalencephaly"
+  },
+  {
+    "sctid": "253171007",
+    "preferred_name": "Dysgenesis of the cerebellum"
+  },
+  {
+    "sctid": "253172000",
+    "preferred_name": "Agenesis of cerebellum"
+  },
+  {
+    "sctid": "253174004",
+    "preferred_name": "Aplasia of the vermis"
+  },
+  {
+    "sctid": "253175003",
+    "preferred_name": "Familial aplasia of the vermis"
+  },
+  {
+    "sctid": "253176002",
+    "preferred_name": "Gillespie syndrome"
+  },
+  {
+    "sctid": "253177006",
+    "preferred_name": "Absence of the vermis"
+  },
+  {
+    "sctid": "253178001",
+    "preferred_name": "Granular cell hypoplasia"
+  },
+  {
+    "sctid": "253179009",
+    "preferred_name": "Cerebellar cortical dysplasia"
+  },
+  {
+    "sctid": "253180007",
+    "preferred_name": "Dysgenesis of the brainstem"
+  },
+  {
+    "sctid": "253181006",
+    "preferred_name": "Olive dysplasia"
+  },
+  {
+    "sctid": "253182004",
+    "preferred_name": "Dentate dysplasia"
+  },
+  {
+    "sctid": "253183009",
+    "preferred_name": "Olivary heterotopia"
+  },
+  {
+    "sctid": "253184003",
+    "preferred_name": "Chiari malformation"
+  },
+  {
+    "sctid": "253185002",
+    "preferred_name": "Chiari malformation type I"
+  },
+  {
+    "sctid": "253186001",
+    "preferred_name": "Chiari malformation type III"
+  },
+  {
+    "sctid": "253187005",
+    "preferred_name": "Chiari malformation type IV"
+  },
+  {
+    "sctid": "253188000",
+    "preferred_name": "Abnormality of canalization and retrogressive differentiation"
+  },
+  {
+    "sctid": "253192007",
+    "preferred_name": "Fibrolipoma of filum terminale"
+  },
+  {
+    "sctid": "253194008",
+    "preferred_name": "Aneurysm of the vein of Galen"
+  },
+  {
+    "sctid": "253199003",
+    "preferred_name": "Congenital malformation of the meninges"
+  },
+  {
+    "sctid": "253203003",
+    "preferred_name": "Hypoplasia of brain gyri"
+  },
+  {
+    "sctid": "253238001",
+    "preferred_name": "Partial hypoplasia of optic disc"
+  },
+  {
+    "sctid": "253239009",
+    "preferred_name": "Sectorial hypoplasia of optic disc"
+  },
+  {
+    "sctid": "25331007",
+    "preferred_name": "Injury at T7-T12 level with spinal cord injury AND without bone injury"
+  },
+  {
+    "sctid": "25362006",
+    "preferred_name": "HSMN IV"
+  },
+  {
+    "sctid": "25397008",
+    "preferred_name": "Aqueduct of Sylvius anomaly"
+  },
+  {
+    "sctid": "254092004",
+    "preferred_name": "Saldino-Mainzer dysplasia"
+  },
+  {
+    "sctid": "25410001000004103",
+    "preferred_name": "Mass of right parietal lobe of brain"
+  },
+  {
+    "sctid": "254132000",
+    "preferred_name": "Endosteal hyperostoses with cerebellar hypoplasia"
+  },
+  {
+    "sctid": "254243001",
+    "preferred_name": "Ash leaf spot, tuberous sclerosis"
+  },
+  {
+    "sctid": "254255007",
+    "preferred_name": "Congenital malformation of anterior pituitary"
+  },
+  {
+    "sctid": "254256008",
+    "preferred_name": "Congenital malformation of posterior pituitary"
+  },
+  {
+    "sctid": "254936001",
+    "preferred_name": "Glial tumor of brain"
+  },
+  {
+    "sctid": "254938000",
+    "preferred_name": "Astrocytoma of brain"
+  },
+  {
+    "sctid": "254939008",
+    "preferred_name": "Ependymoma of brain"
+  },
+  {
+    "sctid": "254940005",
+    "preferred_name": "Oligodendroglioma of brain"
+  },
+  {
+    "sctid": "254941009",
+    "preferred_name": "Mixed glial tumor of brain"
+  },
+  {
+    "sctid": "254942002",
+    "preferred_name": "Tumor of choroid plexus"
+  },
+  {
+    "sctid": "254943007",
+    "preferred_name": "Benign tumor of choroid plexus"
+  },
+  {
+    "sctid": "254945000",
+    "preferred_name": "Embryonal tumor of brain"
+  },
+  {
+    "sctid": "254946004",
+    "preferred_name": "Glial tumor of spinal cord"
+  },
+  {
+    "sctid": "254947008",
+    "preferred_name": "Glioma of spinal cord"
+  },
+  {
+    "sctid": "254948003",
+    "preferred_name": "Astrocytoma of spinal cord"
+  },
+  {
+    "sctid": "254949006",
+    "preferred_name": "Ependymoma of spinal cord"
+  },
+  {
+    "sctid": "254950006",
+    "preferred_name": "Oligodendroglioma of spinal cord"
+  },
+  {
+    "sctid": "254951005",
+    "preferred_name": "Mixed glial tumor of spinal cord"
+  },
+  {
+    "sctid": "254954002",
+    "preferred_name": "Embryonal tumor of spinal cord"
+  },
+  {
+    "sctid": "254955001",
+    "preferred_name": "Pituitary carcinoma"
+  },
+  {
+    "sctid": "254956000",
+    "preferred_name": "Pituitary adenoma"
+  },
+  {
+    "sctid": "254957009",
+    "preferred_name": "Somatotroph adenoma"
+  },
+  {
+    "sctid": "254958004",
+    "preferred_name": "Corticotroph adenoma"
+  },
+  {
+    "sctid": "254959007",
+    "preferred_name": "Thyrotroph adenoma"
+  },
+  {
+    "sctid": "254960002",
+    "preferred_name": "Gonadotroph adenoma"
+  },
+  {
+    "sctid": "254961003",
+    "preferred_name": "Mixed-functioning pituitary adenoma"
+  },
+  {
+    "sctid": "254962005",
+    "preferred_name": "Functionless pituitary adenoma"
+  },
+  {
+    "sctid": "254963000",
+    "preferred_name": "Pituitary microadenoma"
+  },
+  {
+    "sctid": "254964006",
+    "preferred_name": "Pituitary mesoadenoma"
+  },
+  {
+    "sctid": "254965007",
+    "preferred_name": "Pituitary macroadenoma"
+  },
+  {
+    "sctid": "254966008",
+    "preferred_name": "Suprasellar extension of pituitary adenoma"
+  },
+  {
+    "sctid": "254968009",
+    "preferred_name": "Tumor of hypothalamus"
+  },
+  {
+    "sctid": "254969001",
+    "preferred_name": "Malignant tumor of olfactory tract"
+  },
+  {
+    "sctid": "254970000",
+    "preferred_name": "Benign tumor of olfactory tract"
+  },
+  {
+    "sctid": "254972008",
+    "preferred_name": "Malignant tumor of optic nerve and sheath"
+  },
+  {
+    "sctid": "254973003",
+    "preferred_name": "Malignant astrocytoma of optic nerve"
+  },
+  {
+    "sctid": "254974009",
+    "preferred_name": "Malignant tumor of optic nerve sheath"
+  },
+  {
+    "sctid": "254975005",
+    "preferred_name": "Malignant meningioma of optic nerve sheath"
+  },
+  {
+    "sctid": "254976006",
+    "preferred_name": "Optic nerve glioma"
+  },
+  {
+    "sctid": "254977002",
+    "preferred_name": "Benign neoplasm of optic nerve and nerve sheath"
+  },
+  {
+    "sctid": "254978007",
+    "preferred_name": "Meningioma of optic nerve sheath"
+  },
+  {
+    "sctid": "254979004",
+    "preferred_name": "Melanocytoma of optic nerve head"
+  },
+  {
+    "sctid": "25501002",
+    "preferred_name": "Social phobia"
+  },
+  {
+    "sctid": "255112006",
+    "preferred_name": "Malignant tumor of pituitary and hypothalamus"
+  },
+  {
+    "sctid": "255200003",
+    "preferred_name": "Benign tumor of hypothalamus"
+  },
+  {
+    "sctid": "25521000119106",
+    "preferred_name": "Neoplasm of uncertain behavior of hypothalamus"
+  },
+  {
+    "sctid": "25671008",
+    "preferred_name": "Eosinophilic meningitis"
+  },
+  {
+    "sctid": "25772007",
+    "preferred_name": "Multi-infarct dementia with delusions"
+  },
+  {
+    "sctid": "25816005",
+    "preferred_name": "Brain stem compression"
+  },
+  {
+    "sctid": "25822001",
+    "preferred_name": "Pachymeningitis"
+  },
+  {
+    "sctid": "2584003",
+    "preferred_name": "Cerebral degeneration in childhood"
+  },
+  {
+    "sctid": "25922000",
+    "preferred_name": "Major depressive disorder, single episode with postpartum onset"
+  },
+  {
+    "sctid": "2593002",
+    "preferred_name": "Dubowitz's syndrome"
+  },
+  {
+    "sctid": "25957002",
+    "preferred_name": "Aseptic leptospiral meningitis"
+  },
+  {
+    "sctid": "25971005",
+    "preferred_name": "Pedophilia, exclusive type"
+  },
+  {
+    "sctid": "26016002",
+    "preferred_name": "Cerebrospinal nematodiasis"
+  },
+  {
+    "sctid": "26025008",
+    "preferred_name": "Residual schizophrenia"
+  },
+  {
+    "sctid": "26037005",
+    "preferred_name": "Radiation-induced myelopathy"
+  },
+  {
+    "sctid": "26039008",
+    "preferred_name": "Neurosyphilis"
+  },
+  {
+    "sctid": "260912008",
+    "preferred_name": "Abnormal involuntary movement"
+  },
+  {
+    "sctid": "261000119107",
+    "preferred_name": "Severe depressed bipolar I disorder"
+  },
+  {
+    "sctid": "26125006",
+    "preferred_name": "Toxic optic neuropathy"
+  },
+  {
+    "sctid": "26135000",
+    "preferred_name": "Syphilitic encephalitis"
+  },
+  {
+    "sctid": "2618002",
+    "preferred_name": "Chronic recurrent major depressive disorder"
+  },
+  {
+    "sctid": "261808007",
+    "preferred_name": "Neonatal cerebral hemorrhage"
+  },
+  {
+    "sctid": "26203008",
+    "preferred_name": "Severe depressed bipolar I disorder with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "26206000",
+    "preferred_name": "Hepatic coma due to viral hepatitis B"
+  },
+  {
+    "sctid": "262687004",
+    "preferred_name": "Cerebellar laceration and contusion"
+  },
+  {
+    "sctid": "262688009",
+    "preferred_name": "Cortex laceration and contusion"
+  },
+  {
+    "sctid": "262689001",
+    "preferred_name": "Contusion of cerebrum"
+  },
+  {
+    "sctid": "262691009",
+    "preferred_name": "Laceration of cerebrum"
+  },
+  {
+    "sctid": "262692002",
+    "preferred_name": "Burst lobe of brain"
+  },
+  {
+    "sctid": "262693007",
+    "preferred_name": "Diffuse brain injury"
+  },
+  {
+    "sctid": "262694001",
+    "preferred_name": "Traumatic generalized cerebral edema"
+  },
+  {
+    "sctid": "262695000",
+    "preferred_name": "Traumatic focal cerebral edema"
+  },
+  {
+    "sctid": "262696004",
+    "preferred_name": "Contusion of spinal cord"
+  },
+  {
+    "sctid": "262697008",
+    "preferred_name": "Contusion of cervical cord"
+  },
+  {
+    "sctid": "262698003",
+    "preferred_name": "Contusion of thoracic cord"
+  },
+  {
+    "sctid": "262699006",
+    "preferred_name": "Contusion of lumbar cord"
+  },
+  {
+    "sctid": "262700007",
+    "preferred_name": "Contusion of sacral cord"
+  },
+  {
+    "sctid": "262701006",
+    "preferred_name": "Edema of cervical cord"
+  },
+  {
+    "sctid": "262702004",
+    "preferred_name": "Edema of thoracic cord"
+  },
+  {
+    "sctid": "262703009",
+    "preferred_name": "Edema of lumbar cord"
+  },
+  {
+    "sctid": "262704003",
+    "preferred_name": "Edema of sacral cord"
+  },
+  {
+    "sctid": "262705002",
+    "preferred_name": "Laceration of spinal cord"
+  },
+  {
+    "sctid": "262706001",
+    "preferred_name": "Laceration of cervical cord"
+  },
+  {
+    "sctid": "262707005",
+    "preferred_name": "Laceration of thoracic spinal cord"
+  },
+  {
+    "sctid": "262708000",
+    "preferred_name": "Laceration of lumbar cord"
+  },
+  {
+    "sctid": "262709008",
+    "preferred_name": "Laceration of sacral cord"
+  },
+  {
+    "sctid": "262710003",
+    "preferred_name": "Transection of spinal cord"
+  },
+  {
+    "sctid": "262711004",
+    "preferred_name": "Transection of cervical cord"
+  },
+  {
+    "sctid": "262712006",
+    "preferred_name": "Transection of thoracic cord"
+  },
+  {
+    "sctid": "262713001",
+    "preferred_name": "Transection of lumbar cord"
+  },
+  {
+    "sctid": "262714007",
+    "preferred_name": "Transection of sacral cord"
+  },
+  {
+    "sctid": "262718005",
+    "preferred_name": "Traumatic spinal cord hemorrhage"
+  },
+  {
+    "sctid": "262719002",
+    "preferred_name": "Traumatic spinal subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "262720008",
+    "preferred_name": "Traumatic spinal epidural hematoma"
+  },
+  {
+    "sctid": "262721007",
+    "preferred_name": "Traumatic spinal subdural hematoma"
+  },
+  {
+    "sctid": "262949005",
+    "preferred_name": "Traumatic extradural hematoma"
+  },
+  {
+    "sctid": "262952002",
+    "preferred_name": "Traumatic subdural hematoma"
+  },
+  {
+    "sctid": "262955000",
+    "preferred_name": "Subarachnoid hemorrhage due to traumatic injury"
+  },
+  {
+    "sctid": "26298008",
+    "preferred_name": "Ketoacidotic coma due to diabetes mellitus"
+  },
+  {
+    "sctid": "263179007",
+    "preferred_name": "Fracture of transverse process of spine with spinal cord lesion"
+  },
+  {
+    "sctid": "26360005",
+    "preferred_name": "Hereditary optic atrophy"
+  },
+  {
+    "sctid": "26453000",
+    "preferred_name": "Mental disorder in adolescence"
+  },
+  {
+    "sctid": "264534009",
+    "preferred_name": "Hypothalamic injury"
+  },
+  {
+    "sctid": "26472000",
+    "preferred_name": "Paraphrenia"
+  },
+  {
+    "sctid": "264906008",
+    "preferred_name": "Pituitary macroadenoma with extrasellar extension"
+  },
+  {
+    "sctid": "26516009",
+    "preferred_name": "Severe mood disorder with psychotic features"
+  },
+  {
+    "sctid": "26520008",
+    "preferred_name": "Optic nerve infarction"
+  },
+  {
+    "sctid": "26530004",
+    "preferred_name": "Severe bipolar disorder with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "265377002",
+    "preferred_name": "Symptomatic parkinsonism"
+  },
+  {
+    "sctid": "26554009",
+    "preferred_name": "Nuclear facial nerve paralysis"
+  },
+  {
+    "sctid": "26568002",
+    "preferred_name": "Faun tail syndrome"
+  },
+  {
+    "sctid": "26594006",
+    "preferred_name": "Syringobulbia"
+  },
+  {
+    "sctid": "26595007",
+    "preferred_name": "Congenital absence of part of brain"
+  },
+  {
+    "sctid": "266126006",
+    "preferred_name": "Late congenital neurosyphilis"
+  },
+  {
+    "sctid": "266133006",
+    "preferred_name": "Late quaternary neurosyphilis"
+  },
+  {
+    "sctid": "266196000",
+    "preferred_name": "Rabies - hydrophobia"
+  },
+  {
+    "sctid": "26665006",
+    "preferred_name": "Antisocial personality disorder"
+  },
+  {
+    "sctid": "26714005",
+    "preferred_name": "Cannabis-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "267320004",
+    "preferred_name": "Pregnancy with mental disorders"
+  },
+  {
+    "sctid": "26738009",
+    "preferred_name": "Spinal cord injury without spinal bone injury"
+  },
+  {
+    "sctid": "267384006",
+    "preferred_name": "Hypoglycemic coma"
+  },
+  {
+    "sctid": "267386008",
+    "preferred_name": "Gigantism and acromegaly"
+  },
+  {
+    "sctid": "267388009",
+    "preferred_name": "Idiopathic hypopituitarism"
+  },
+  {
+    "sctid": "267389001",
+    "preferred_name": "Post-birth injury hypopituitarism"
+  },
+  {
+    "sctid": "267390005",
+    "preferred_name": "Post-infarction hypopituitarism"
+  },
+  {
+    "sctid": "267414004",
+    "preferred_name": "Jumping disease"
+  },
+  {
+    "sctid": "267576008",
+    "preferred_name": "Encephalitis, myelitis and encephalomyelitis"
+  },
+  {
+    "sctid": "267581004",
+    "preferred_name": "Progressive myoclonic epilepsy"
+  },
+  {
+    "sctid": "267592003",
+    "preferred_name": "Motor cortex epilepsy"
+  },
+  {
+    "sctid": "268143001",
+    "preferred_name": "Spina bifida with hydrocephalus - open"
+  },
+  {
+    "sctid": "268146009",
+    "preferred_name": "Spina bifida without hydrocephalus - open"
+  },
+  {
+    "sctid": "26852004",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset, with depression"
+  },
+  {
+    "sctid": "268612007",
+    "preferred_name": "Senile and presenile organic psychotic conditions"
+  },
+  {
+    "sctid": "268617001",
+    "preferred_name": "Acute schizophrenic episode"
+  },
+  {
+    "sctid": "268619003",
+    "preferred_name": "Manic disorder, single episode"
+  },
+  {
+    "sctid": "268621008",
+    "preferred_name": "Recurrent major depressive episodes"
+  },
+  {
+    "sctid": "268622001",
+    "preferred_name": "Chronic paranoid psychosis"
+  },
+  {
+    "sctid": "268624000",
+    "preferred_name": "Acute paranoid reaction"
+  },
+  {
+    "sctid": "268633003",
+    "preferred_name": "Introverted personality disorder"
+  },
+  {
+    "sctid": "268634009",
+    "preferred_name": "Psychoneurotic personality disorder"
+  },
+  {
+    "sctid": "268645007",
+    "preferred_name": "Nondependent alcohol abuse"
+  },
+  {
+    "sctid": "268650001",
+    "preferred_name": "Somatoform autonomic dysfunction - gastrointestinal tract"
+  },
+  {
+    "sctid": "268658008",
+    "preferred_name": "Specific academic or work inhibition"
+  },
+  {
+    "sctid": "268661009",
+    "preferred_name": "Nonaggressive unsocial conduct disorder"
+  },
+  {
+    "sctid": "268662002",
+    "preferred_name": "Unsocial childhood truancy"
+  },
+  {
+    "sctid": "268664001",
+    "preferred_name": "Childhood emotional disorder"
+  },
+  {
+    "sctid": "268666004",
+    "preferred_name": "Childhood and adolescent disturbance with sensitivity"
+  },
+  {
+    "sctid": "268667008",
+    "preferred_name": "Childhood and adolescent disturbance with shyness"
+  },
+  {
+    "sctid": "268668003",
+    "preferred_name": "Childhood and adolescent disturbance with introversion"
+  },
+  {
+    "sctid": "268672004",
+    "preferred_name": "Disorder of speech and language development"
+  },
+  {
+    "sctid": "268673009",
+    "preferred_name": "Developmental aphasia"
+  },
+  {
+    "sctid": "268715000",
+    "preferred_name": "Dissociative motor disorder"
+  },
+  {
+    "sctid": "268722008",
+    "preferred_name": "Non-organic disorder of the sleep-wake schedule"
+  },
+  {
+    "sctid": "268724009",
+    "preferred_name": "Excessive sexual drive"
+  },
+  {
+    "sctid": "268727002",
+    "preferred_name": "Abuse of non-dependence-producing substances"
+  },
+  {
+    "sctid": "268734000",
+    "preferred_name": "Developmental expressive language disorder"
+  },
+  {
+    "sctid": "268738002",
+    "preferred_name": "Specific spelling disorder"
+  },
+  {
+    "sctid": "268957000",
+    "preferred_name": "Neurotic condition, insight present"
+  },
+  {
+    "sctid": "268958005",
+    "preferred_name": "Poor insight into neurotic condition"
+  },
+  {
+    "sctid": "2691000124105",
+    "preferred_name": "Recurrent optic neuritis"
+  },
+  {
+    "sctid": "269144002",
+    "preferred_name": "Cerebral laceration and contusion"
+  },
+  {
+    "sctid": "26929004",
+    "preferred_name": "Alzheimer's disease"
+  },
+  {
+    "sctid": "26954004",
+    "preferred_name": "Thrombophlebitis of superior sagittal sinus"
+  },
+  {
+    "sctid": "2701000124105",
+    "preferred_name": "Recurrent acute disseminated encephalomyelitis"
+  },
+  {
+    "sctid": "270291000119109",
+    "preferred_name": "Identity disorder of childhood"
+  },
+  {
+    "sctid": "27040004",
+    "preferred_name": "Experimental allergic encephalomyelitis"
+  },
+  {
+    "sctid": "270487001",
+    "preferred_name": "Non-organic sleep disorder"
+  },
+  {
+    "sctid": "27051000119102",
+    "preferred_name": "Chronic abuse of laxatives"
+  },
+  {
+    "sctid": "270901009",
+    "preferred_name": "Schizoaffective disorder, mixed type"
+  },
+  {
+    "sctid": "270902002",
+    "preferred_name": "Overeating associated with other psychological disturbances"
+  },
+  {
+    "sctid": "270903007",
+    "preferred_name": "Lack or loss of sexual desire"
+  },
+  {
+    "sctid": "270905000",
+    "preferred_name": "Childhood disinhibited attachment disorder"
+  },
+  {
+    "sctid": "270907008",
+    "preferred_name": "Spontaneous subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "271000119101",
+    "preferred_name": "Severe mixed bipolar I disorder"
+  },
+  {
+    "sctid": "271386001",
+    "preferred_name": "Post-infective hypopituitarism"
+  },
+  {
+    "sctid": "271428004",
+    "preferred_name": "Schizoaffective disorder, manic type"
+  },
+  {
+    "sctid": "271479005",
+    "preferred_name": "Benign neoplasm of pituitary gland and craniopharyngeal duct"
+  },
+  {
+    "sctid": "271547004",
+    "preferred_name": "Stokes-Adams attack"
+  },
+  {
+    "sctid": "271569006",
+    "preferred_name": "Communicating hydrocephalus"
+  },
+  {
+    "sctid": "27195007",
+    "preferred_name": "Chronic non-psychotic brain syndrome"
+  },
+  {
+    "sctid": "271952001",
+    "preferred_name": "Stress and adjustment reaction"
+  },
+  {
+    "sctid": "271969004",
+    "preferred_name": "Disorder of dorsal column stimulator"
+  },
+  {
+    "sctid": "271986005",
+    "preferred_name": "Disorder of brain ventricular shunt"
+  },
+  {
+    "sctid": "27270004",
+    "preferred_name": "Pituitary dwarfism with large sella turcica"
+  },
+  {
+    "sctid": "27358001",
+    "preferred_name": "Sylvian aqueduct syndrome"
+  },
+  {
+    "sctid": "27387000",
+    "preferred_name": "Subchronic disorganized schizophrenia"
+  },
+  {
+    "sctid": "274100004",
+    "preferred_name": "Cerebral hemorrhage"
+  },
+  {
+    "sctid": "274156000",
+    "preferred_name": "Fracture of cervical spine with cord lesion"
+  },
+  {
+    "sctid": "274157009",
+    "preferred_name": "Fracture of thoracic spine with cord lesion"
+  },
+  {
+    "sctid": "274158004",
+    "preferred_name": "Fracture of lumbar spine with cord lesion"
+  },
+  {
+    "sctid": "274659008",
+    "preferred_name": "Semicoma"
+  },
+  {
+    "sctid": "274948002",
+    "preferred_name": "Endogenous depression - recurrent"
+  },
+  {
+    "sctid": "274952002",
+    "preferred_name": "Borderline schizophrenia"
+  },
+  {
+    "sctid": "274953007",
+    "preferred_name": "Acute polymorphic psychotic disorder"
+  },
+  {
+    "sctid": "275269004",
+    "preferred_name": "Benign cerebral tumor"
+  },
+  {
+    "sctid": "275361004",
+    "preferred_name": "Tentorial laceration"
+  },
+  {
+    "sctid": "275362006",
+    "preferred_name": "Falx laceration"
+  },
+  {
+    "sctid": "275382005",
+    "preferred_name": "Cerebral trauma"
+  },
+  {
+    "sctid": "275434003",
+    "preferred_name": "Stroke in the puerperium"
+  },
+  {
+    "sctid": "27544004",
+    "preferred_name": "Developmental coordination disorder"
+  },
+  {
+    "sctid": "275468009",
+    "preferred_name": "Congenital quadriplegia"
+  },
+  {
+    "sctid": "275470000",
+    "preferred_name": "Post-cardiorespiratory arrest coma"
+  },
+  {
+    "sctid": "275473003",
+    "preferred_name": "Specific work inhibition"
+  },
+  {
+    "sctid": "275474009",
+    "preferred_name": "Psychogenic overeating"
+  },
+  {
+    "sctid": "276064006",
+    "preferred_name": "Lymphocytic meningitis"
+  },
+  {
+    "sctid": "276219001",
+    "preferred_name": "Occipital cerebral infarction"
+  },
+  {
+    "sctid": "276220007",
+    "preferred_name": "Foville syndrome"
+  },
+  {
+    "sctid": "276221006",
+    "preferred_name": "Millard-Gubler syndrome"
+  },
+  {
+    "sctid": "276222004",
+    "preferred_name": "Top of basilar syndrome"
+  },
+  {
+    "sctid": "276277008",
+    "preferred_name": "Subarachnoid hemorrhage from multiple aneurysms"
+  },
+  {
+    "sctid": "276278003",
+    "preferred_name": "Subarachnoid hemorrhage from anterior cerebral artery aneurysm"
+  },
+  {
+    "sctid": "276280009",
+    "preferred_name": "Subarachnoid hemorrhage from middle cerebral artery aneurysm"
+  },
+  {
+    "sctid": "276281008",
+    "preferred_name": "Subarachnoid hemorrhage from posterior cerebral artery aneurysm"
+  },
+  {
+    "sctid": "276282001",
+    "preferred_name": "Subarachnoid hemorrhage from anterior communicating artery aneurysm"
+  },
+  {
+    "sctid": "276283006",
+    "preferred_name": "Subarachnoid hemorrhage from posterior communicating artery aneurysm"
+  },
+  {
+    "sctid": "276284000",
+    "preferred_name": "Subarachnoid hemorrhage from basilar artery aneurysm"
+  },
+  {
+    "sctid": "276285004",
+    "preferred_name": "Subarachnoid hemorrhage from posterior inferior cerebellar artery aneurysm"
+  },
+  {
+    "sctid": "276286003",
+    "preferred_name": "Subarachnoid hemorrhage from carotid artery aneurysm"
+  },
+  {
+    "sctid": "276296007",
+    "preferred_name": "Dissociative trance"
+  },
+  {
+    "sctid": "276297003",
+    "preferred_name": "Dissociative possession disorder"
+  },
+  {
+    "sctid": "276300008",
+    "preferred_name": "Dissociative stupor"
+  },
+  {
+    "sctid": "276589006",
+    "preferred_name": "Perinatal tentorial laceration"
+  },
+  {
+    "sctid": "276590002",
+    "preferred_name": "Tentorial laceration - acute syndrome"
+  },
+  {
+    "sctid": "276591003",
+    "preferred_name": "Tentorial laceration - subacute syndrome"
+  },
+  {
+    "sctid": "276592005",
+    "preferred_name": "Perinatal occipital diastasis"
+  },
+  {
+    "sctid": "276593000",
+    "preferred_name": "Perinatal falx laceration"
+  },
+  {
+    "sctid": "276595007",
+    "preferred_name": "Perinatal nonspecific brain dysfunction"
+  },
+  {
+    "sctid": "276596008",
+    "preferred_name": "Cerebral irritation"
+  },
+  {
+    "sctid": "276597004",
+    "preferred_name": "Fifth day fits"
+  },
+  {
+    "sctid": "276599001",
+    "preferred_name": "Cerebral leukomalacia"
+  },
+  {
+    "sctid": "276630006",
+    "preferred_name": "Transient hypothyrotropinemia"
+  },
+  {
+    "sctid": "276648002",
+    "preferred_name": "Intraventricular hemorrhage of prematurity"
+  },
+  {
+    "sctid": "276650005",
+    "preferred_name": "Perinatal subependymal hemorrhage"
+  },
+  {
+    "sctid": "276651009",
+    "preferred_name": "Perinatal subependymal hemorrhage with intraventricular extension"
+  },
+  {
+    "sctid": "276652002",
+    "preferred_name": "Perinatal subependymal hemorrhage with intraventricular and intracerebral extension"
+  },
+  {
+    "sctid": "276674008",
+    "preferred_name": "Neonatal meningitis"
+  },
+  {
+    "sctid": "276706004",
+    "preferred_name": "Perinatal cerebral ischemia"
+  },
+  {
+    "sctid": "276722003",
+    "preferred_name": "Intracerebellar and posterior fossa hemorrhage"
+  },
+  {
+    "sctid": "276817007",
+    "preferred_name": "Lymphocytic meningoencephalitis"
+  },
+  {
+    "sctid": "276826005",
+    "preferred_name": "Malignant glioma of brain"
+  },
+  {
+    "sctid": "276827001",
+    "preferred_name": "Malignant glioma of spinal cord"
+  },
+  {
+    "sctid": "276828006",
+    "preferred_name": "Glioblastoma multiforme of brain"
+  },
+  {
+    "sctid": "276829003",
+    "preferred_name": "Glioblastoma multiforme of spinal cord"
+  },
+  {
+    "sctid": "276836002",
+    "preferred_name": "Primary cerebral lymphoma"
+  },
+  {
+    "sctid": "276837006",
+    "preferred_name": "Epidermoid cyst of brain"
+  },
+  {
+    "sctid": "27720003",
+    "preferred_name": "Dermatitis factitia"
+  },
+  {
+    "sctid": "277303004",
+    "preferred_name": "Angiogram-negative subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "277326006",
+    "preferred_name": "Spinal cord rupture"
+  },
+  {
+    "sctid": "277333006",
+    "preferred_name": "Cyst of central nervous system"
+  },
+  {
+    "sctid": "277340007",
+    "preferred_name": "Tension pneumocephalus"
+  },
+  {
+    "sctid": "277369003",
+    "preferred_name": "Hamartoma of brain"
+  },
+  {
+    "sctid": "277456001",
+    "preferred_name": "Suprasellar germ cell tumor"
+  },
+  {
+    "sctid": "277461004",
+    "preferred_name": "Anaplastic astrocytoma of brain"
+  },
+  {
+    "sctid": "277476007",
+    "preferred_name": "Cerebral ventricular distension"
+  },
+  {
+    "sctid": "277478008",
+    "preferred_name": "Post-asphyxial encephalopathy"
+  },
+  {
+    "sctid": "277479000",
+    "preferred_name": "Postnatal hypoxic encephalopathy"
+  },
+  {
+    "sctid": "277480002",
+    "preferred_name": "Neonatal asphyxial encephalopathy"
+  },
+  {
+    "sctid": "277505007",
+    "preferred_name": "Medulloblastoma of cerebellum"
+  },
+  {
+    "sctid": "277507004",
+    "preferred_name": "Pilocytic astrocytoma of cerebellum"
+  },
+  {
+    "sctid": "277508009",
+    "preferred_name": "Pineal germ cell tumor"
+  },
+  {
+    "sctid": "277522009",
+    "preferred_name": "Hemangiopericytoma of meninges"
+  },
+  {
+    "sctid": "277523004",
+    "preferred_name": "Primary melanocytic lesion of meninges"
+  },
+  {
+    "sctid": "277526007",
+    "preferred_name": "Diffuse melanosis of meninges"
+  },
+  {
+    "sctid": "277527003",
+    "preferred_name": "Melanocytoma of meninges"
+  },
+  {
+    "sctid": "277530005",
+    "preferred_name": "Malignant melanoma of meninges"
+  },
+  {
+    "sctid": "277532002",
+    "preferred_name": "Meningeal melanosis"
+  },
+  {
+    "sctid": "2776000",
+    "preferred_name": "Delirium"
+  },
+  {
+    "sctid": "277921008",
+    "preferred_name": "Atelencephaly"
+  },
+  {
+    "sctid": "277922001",
+    "preferred_name": "Aprosencephaly"
+  },
+  {
+    "sctid": "277949001",
+    "preferred_name": "Combined malformation of central nervous system and skeletal muscle"
+  },
+  {
+    "sctid": "277950001",
+    "preferred_name": "Muscle eye brain disease"
+  },
+  {
+    "sctid": "27803006",
+    "preferred_name": "Qi-gong psychotic reaction"
+  },
+  {
+    "sctid": "278284007",
+    "preferred_name": "Right hemiplegia"
+  },
+  {
+    "sctid": "278285008",
+    "preferred_name": "Left hemiplegia"
+  },
+  {
+    "sctid": "278286009",
+    "preferred_name": "Right hemiparesis"
+  },
+  {
+    "sctid": "278287000",
+    "preferred_name": "Left hemiparesis"
+  },
+  {
+    "sctid": "278506006",
+    "preferred_name": "Involutional paranoid state"
+  },
+  {
+    "sctid": "278508007",
+    "preferred_name": "Delusional dysmorphophobia"
+  },
+  {
+    "sctid": "278510009",
+    "preferred_name": "Localization-related idiopathic epilepsy"
+  },
+  {
+    "sctid": "278512001",
+    "preferred_name": "Ataxic cerebral palsy"
+  },
+  {
+    "sctid": "27873005",
+    "preferred_name": "Spinopontine degeneration"
+  },
+  {
+    "sctid": "278849000",
+    "preferred_name": "Cerebral atrophy"
+  },
+  {
+    "sctid": "278852008",
+    "preferred_name": "Paranoid-hallucinatory epileptic psychosis"
+  },
+  {
+    "sctid": "278853003",
+    "preferred_name": "Acute schizophrenia-like psychotic disorder"
+  },
+  {
+    "sctid": "278855005",
+    "preferred_name": "Frontal lobe degeneration"
+  },
+  {
+    "sctid": "278857002",
+    "preferred_name": "Dementia of frontal lobe type"
+  },
+  {
+    "sctid": "27908001",
+    "preferred_name": "Amebic brain abscess"
+  },
+  {
+    "sctid": "279225001",
+    "preferred_name": "Maternity blues"
+  },
+  {
+    "sctid": "27937002",
+    "preferred_name": "Open fracture of T7-T12 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "279611005",
+    "preferred_name": "Shell shock"
+  },
+  {
+    "sctid": "27982003",
+    "preferred_name": "Brown-S\u00e9quard syndrome"
+  },
+  {
+    "sctid": "279953009",
+    "preferred_name": "Familial neonatal seizures"
+  },
+  {
+    "sctid": "279982005",
+    "preferred_name": "Cerebral degeneration presenting primarily with dementia"
+  },
+  {
+    "sctid": "280032002",
+    "preferred_name": "Developmental language disorder"
+  },
+  {
+    "sctid": "28055006",
+    "preferred_name": "West syndrome"
+  },
+  {
+    "sctid": "280901000",
+    "preferred_name": "Couvade"
+  },
+  {
+    "sctid": "280943007",
+    "preferred_name": "Dissociative confusion"
+  },
+  {
+    "sctid": "280945000",
+    "preferred_name": "Derealization syndrome"
+  },
+  {
+    "sctid": "280946004",
+    "preferred_name": "Occupational neurosis"
+  },
+  {
+    "sctid": "280949006",
+    "preferred_name": "Erotomania"
+  },
+  {
+    "sctid": "280982009",
+    "preferred_name": "Abuse of laxatives"
+  },
+  {
+    "sctid": "280983004",
+    "preferred_name": "Abuse of vitamins"
+  },
+  {
+    "sctid": "280984005",
+    "preferred_name": "Abuse of herbal medicine"
+  },
+  {
+    "sctid": "280986007",
+    "preferred_name": "Abuse of antacids"
+  },
+  {
+    "sctid": "280994000",
+    "preferred_name": "Chronic confusional state"
+  },
+  {
+    "sctid": "281000119103",
+    "preferred_name": "Severe recurrent major depression"
+  },
+  {
+    "sctid": "281004",
+    "preferred_name": "Dementia associated with alcoholism"
+  },
+  {
+    "sctid": "281222009",
+    "preferred_name": "Postoperative meningocele"
+  },
+  {
+    "sctid": "281223004",
+    "preferred_name": "Traumatic meningocele"
+  },
+  {
+    "sctid": "281240008",
+    "preferred_name": "Extension of cerebrovascular accident"
+  },
+  {
+    "sctid": "28140001000004102",
+    "preferred_name": "Mass of posterior lobe of pituitary"
+  },
+  {
+    "sctid": "2815001",
+    "preferred_name": "Sexual pyromania"
+  },
+  {
+    "sctid": "281509000",
+    "preferred_name": "Hypoxic-ischemic coma"
+  },
+  {
+    "sctid": "28155008",
+    "preferred_name": "Extradural hemorrhage following injury with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "281560004",
+    "preferred_name": "Neuroblastoma of brain"
+  },
+  {
+    "sctid": "281864001",
+    "preferred_name": "Non-traumatic intracranial subdural hematoma"
+  },
+  {
+    "sctid": "281865000",
+    "preferred_name": "Non-traumatic extradural intracranial hematoma"
+  },
+  {
+    "sctid": "28188001",
+    "preferred_name": "Brain injury with open intracranial wound"
+  },
+  {
+    "sctid": "281899002",
+    "preferred_name": "Congenital hydrocephalus due to toxoplasmosis"
+  },
+  {
+    "sctid": "28192008",
+    "preferred_name": "Enterovirus meningitis"
+  },
+  {
+    "sctid": "282785008",
+    "preferred_name": "Anterior cord syndrome"
+  },
+  {
+    "sctid": "282786009",
+    "preferred_name": "Posterior cord syndrome"
+  },
+  {
+    "sctid": "282787000",
+    "preferred_name": "Central cord syndrome"
+  },
+  {
+    "sctid": "28318001",
+    "preferred_name": "Pars basalis hemorrhage"
+  },
+  {
+    "sctid": "28357009",
+    "preferred_name": "Transitory postpartum mood disturbance"
+  },
+  {
+    "sctid": "28368009",
+    "preferred_name": "Psychoactive substance-induced organic hallucinosis"
+  },
+  {
+    "sctid": "2838003",
+    "preferred_name": "Piblokto"
+  },
+  {
+    "sctid": "28394000",
+    "preferred_name": "Toxic encephalopathy"
+  },
+  {
+    "sctid": "284591009",
+    "preferred_name": "Persistent alcohol abuse"
+  },
+  {
+    "sctid": "28475009",
+    "preferred_name": "Severe recurrent major depression with psychotic features"
+  },
+  {
+    "sctid": "2851000119101",
+    "preferred_name": "Anterior pituitary hormone deficiency"
+  },
+  {
+    "sctid": "28534004",
+    "preferred_name": "Spastic paralysis due to intracranial birth injury"
+  },
+  {
+    "sctid": "285641009",
+    "preferred_name": "Metastasis to brain of unknown primary"
+  },
+  {
+    "sctid": "28634005",
+    "preferred_name": "Cerebral ataxia"
+  },
+  {
+    "sctid": "28663008",
+    "preferred_name": "Severe manic bipolar I disorder with psychotic features"
+  },
+  {
+    "sctid": "28676002",
+    "preferred_name": "Mood disorder with manic features due to general medical condition"
+  },
+  {
+    "sctid": "286914008",
+    "preferred_name": "Pituitary, parathyroid, thymus disorder"
+  },
+  {
+    "sctid": "286933003",
+    "preferred_name": "Confusional state"
+  },
+  {
+    "sctid": "28721000119108",
+    "preferred_name": "Postvaricella myelitis"
+  },
+  {
+    "sctid": "288031000119105",
+    "preferred_name": "Alcohol induced disorder co-occurrent and due to alcohol dependence"
+  },
+  {
+    "sctid": "288276001",
+    "preferred_name": "Fetal cerebral hemorrhage"
+  },
+  {
+    "sctid": "288281000119100",
+    "preferred_name": "Abuse of herbal medicine or folk remedy"
+  },
+  {
+    "sctid": "288421000119100",
+    "preferred_name": "Hyposomnia co-occurrent and due to psychological disorder"
+  },
+  {
+    "sctid": "288461000119105",
+    "preferred_name": "Psychosis caused by inhalant"
+  },
+  {
+    "sctid": "288511000119108",
+    "preferred_name": "Chronic mood disorder"
+  },
+  {
+    "sctid": "288631000119104",
+    "preferred_name": "Vascular dementia with behavioral disturbance"
+  },
+  {
+    "sctid": "28864000",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced mood disorder"
+  },
+  {
+    "sctid": "288751000119101",
+    "preferred_name": "Reactive depressive psychosis, single episode"
+  },
+  {
+    "sctid": "28884001",
+    "preferred_name": "Moderate bipolar I disorder, single manic episode"
+  },
+  {
+    "sctid": "288851000119106",
+    "preferred_name": "Opioid-induced mood disorder due to opioid abuse"
+  },
+  {
+    "sctid": "288861000119108",
+    "preferred_name": "Opioid-induced mood disorder due to opioid dependence"
+  },
+  {
+    "sctid": "28978003",
+    "preferred_name": "Progressive supranuclear ophthalmoplegia"
+  },
+  {
+    "sctid": "29003001",
+    "preferred_name": "Spastic dysphonia"
+  },
+  {
+    "sctid": "290241000119109",
+    "preferred_name": "Meningeal adhesions"
+  },
+  {
+    "sctid": "290461000119109",
+    "preferred_name": "Spastic hemiplegia of left dominant side"
+  },
+  {
+    "sctid": "290471000119103",
+    "preferred_name": "Spastic hemiplegia of left nondominant side"
+  },
+  {
+    "sctid": "290481000119100",
+    "preferred_name": "Spastic hemiplegia of right dominant side"
+  },
+  {
+    "sctid": "290491000119102",
+    "preferred_name": "Spastic hemiplegia of right nondominant side"
+  },
+  {
+    "sctid": "290531000119102",
+    "preferred_name": "Intractable chronic tension headache"
+  },
+  {
+    "sctid": "290541000119106",
+    "preferred_name": "Intractable episodic tension-type headache"
+  },
+  {
+    "sctid": "290621000119101",
+    "preferred_name": "Cognitive deficit due to and following cerebrovascular disease"
+  },
+  {
+    "sctid": "290653008",
+    "preferred_name": "Postpartum hypopituitarism"
+  },
+  {
+    "sctid": "290671000119100",
+    "preferred_name": "Status epilepticus due to complex partial epileptic seizure"
+  },
+  {
+    "sctid": "290681000119102",
+    "preferred_name": "Status epilepticus due to refractory complex partial seizures"
+  },
+  {
+    "sctid": "290691000119104",
+    "preferred_name": "Status epilepticus due to generalized idiopathic epilepsy"
+  },
+  {
+    "sctid": "290711000119101",
+    "preferred_name": "Status epilepticus due to intractable idiopathic generalized epilepsy"
+  },
+  {
+    "sctid": "290721000119108",
+    "preferred_name": "Status epilepticus due to refractory epilepsy"
+  },
+  {
+    "sctid": "290731000119106",
+    "preferred_name": "Idiopathic partial status epilepticus"
+  },
+  {
+    "sctid": "290741000119102",
+    "preferred_name": "Intractable idiopathic partial epilepsy"
+  },
+  {
+    "sctid": "290761000119103",
+    "preferred_name": "Status epilepticus due to refractory simple partial epilepsy"
+  },
+  {
+    "sctid": "290871000119101",
+    "preferred_name": "Infantile spasms co-occurrent with status epilepticus"
+  },
+  {
+    "sctid": "290881000119103",
+    "preferred_name": "Refractory infantile spasms co-occurrent with status epilepticus"
+  },
+  {
+    "sctid": "29093005",
+    "preferred_name": "Crossed hemiparesis"
+  },
+  {
+    "sctid": "291311000119108",
+    "preferred_name": "Status epilepticus in benign Rolandic epilepsy"
+  },
+  {
+    "sctid": "291351000119109",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from basilar artery"
+  },
+  {
+    "sctid": "291371000119100",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from intracranial artery"
+  },
+  {
+    "sctid": "291401000119102",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from left middle cerebral artery"
+  },
+  {
+    "sctid": "291411000119104",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from left posterior communicating artery"
+  },
+  {
+    "sctid": "291471000119107",
+    "preferred_name": "Non-traumatic hemorrhage of subarachnoid space from right middle cerebral artery"
+  },
+  {
+    "sctid": "291481000119105",
+    "preferred_name": "Spontaneous hemorrhage of subarachnoid space from right posterior communicating artery"
+  },
+  {
+    "sctid": "291511000119103",
+    "preferred_name": "Spontaneous hemorrhage of deep cerebral hemisphere"
+  },
+  {
+    "sctid": "291521000119105",
+    "preferred_name": "Spontaneous hemorrhage of cortical intracerebral hemisphere"
+  },
+  {
+    "sctid": "291531000119108",
+    "preferred_name": "Spontaneous hemorrhage of cerebral hemisphere"
+  },
+  {
+    "sctid": "291541000119104",
+    "preferred_name": "Spontaneous hemorrhage of brain stem"
+  },
+  {
+    "sctid": "291571000119106",
+    "preferred_name": "Spontaneous cerebral hemorrhage"
+  },
+  {
+    "sctid": "291581000119109",
+    "preferred_name": "Acute nontraumatic subdural hemorrhage"
+  },
+  {
+    "sctid": "291591000119107",
+    "preferred_name": "Subacute non-traumatic intracranial subdural hemorrhage"
+  },
+  {
+    "sctid": "291621000119109",
+    "preferred_name": "Cognitive deficit due to and following nontraumatic subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "291665000",
+    "preferred_name": "Postpartum intrapituitary hemorrhage"
+  },
+  {
+    "sctid": "291711000119109",
+    "preferred_name": "Cognitive deficit due to and following nontraumatic intracerebral hemorrhage"
+  },
+  {
+    "sctid": "29197009",
+    "preferred_name": "Meningoencephalomyelitis"
+  },
+  {
+    "sctid": "29212009",
+    "preferred_name": "Alcohol-induced organic mental disorder"
+  },
+  {
+    "sctid": "292661000119105",
+    "preferred_name": "Cerebrovascular accident due to stenosis of right vertebral artery"
+  },
+  {
+    "sctid": "292671000119104",
+    "preferred_name": "Cerebrovascular accident due to stenosis of left vertebral artery"
+  },
+  {
+    "sctid": "292681000119101",
+    "preferred_name": "Cerebrovascular accident due to right vertebral artery occlusion"
+  },
+  {
+    "sctid": "292691000119103",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left vertebral artery"
+  },
+  {
+    "sctid": "292851000119109",
+    "preferred_name": "Lacunar ataxic hemiparesis of right dominant side"
+  },
+  {
+    "sctid": "292861000119106",
+    "preferred_name": "Lacunar ataxic hemiparesis of left dominant side"
+  },
+  {
+    "sctid": "292871000119100",
+    "preferred_name": "Acquired pseudoporencephaly"
+  },
+  {
+    "sctid": "292901000119100",
+    "preferred_name": "Intracranial subdural granuloma"
+  },
+  {
+    "sctid": "292911000119102",
+    "preferred_name": "Intracranial epidural granuloma"
+  },
+  {
+    "sctid": "292921000119109",
+    "preferred_name": "Intraspinal granuloma"
+  },
+  {
+    "sctid": "292931000119107",
+    "preferred_name": "Intraspinal subdural granuloma"
+  },
+  {
+    "sctid": "292941000119103",
+    "preferred_name": "Intraspinal epidural granuloma"
+  },
+  {
+    "sctid": "292971000119105",
+    "preferred_name": "Sequela of injury of thoracic spinal cord"
+  },
+  {
+    "sctid": "29315008",
+    "preferred_name": "Idiopathic adductor spastic dysphonia"
+  },
+  {
+    "sctid": "293811000119100",
+    "preferred_name": "Cerebral infarction due to vertebral artery stenosis"
+  },
+  {
+    "sctid": "293831000119105",
+    "preferred_name": "Cerebral infarction due to stenosis of precerebral artery"
+  },
+  {
+    "sctid": "293901000119108",
+    "preferred_name": "Intractable episodic cluster headache"
+  },
+  {
+    "sctid": "294011000119108",
+    "preferred_name": "Spontaneous rupture of dura mater"
+  },
+  {
+    "sctid": "294041000119107",
+    "preferred_name": "Flaccid hemiplegia of left dominant side"
+  },
+  {
+    "sctid": "294051000119109",
+    "preferred_name": "Flaccid hemiplegia of left nondominant side"
+  },
+  {
+    "sctid": "294061000119106",
+    "preferred_name": "Flaccid hemiplegia of right dominant side"
+  },
+  {
+    "sctid": "294071000119100",
+    "preferred_name": "Flaccid hemiplegia of right nondominant side"
+  },
+  {
+    "sctid": "294101000119109",
+    "preferred_name": "Hemiplegia of left dominant side"
+  },
+  {
+    "sctid": "294111000119107",
+    "preferred_name": "Hemiplegia of left nondominant side"
+  },
+  {
+    "sctid": "294121000119100",
+    "preferred_name": "Hemiplegia of right dominant side"
+  },
+  {
+    "sctid": "294131000119102",
+    "preferred_name": "Hemiplegia of right nondominant side"
+  },
+  {
+    "sctid": "29570005",
+    "preferred_name": "Leigh's disease"
+  },
+  {
+    "sctid": "29599000",
+    "preferred_name": "Chronic undifferentiated schizophrenia"
+  },
+  {
+    "sctid": "29610001000004107",
+    "preferred_name": "Mass of parietotemporal region of brain"
+  },
+  {
+    "sctid": "29618004",
+    "preferred_name": "Striatonigral degeneration"
+  },
+  {
+    "sctid": "29657007",
+    "preferred_name": "Deferred diagnosis on Axis IV"
+  },
+  {
+    "sctid": "29702001",
+    "preferred_name": "Aphasia-left parietal lobe syndrome"
+  },
+  {
+    "sctid": "29733004",
+    "preferred_name": "Opioid-induced mood disorder"
+  },
+  {
+    "sctid": "29753000",
+    "preferred_name": "Partial seizure"
+  },
+  {
+    "sctid": "29774004",
+    "preferred_name": "Vascular myelopathy"
+  },
+  {
+    "sctid": "29807001",
+    "preferred_name": "Brain stem contusion without open intracranial wound AND with loss of consciousness"
+  },
+  {
+    "sctid": "298282001",
+    "preferred_name": "Spastic tetraparesis"
+  },
+  {
+    "sctid": "2992000",
+    "preferred_name": "Pigmentary pallidal degeneration"
+  },
+  {
+    "sctid": "29929003",
+    "preferred_name": "Bipolar I disorder, most recent episode depressed with atypical features"
+  },
+  {
+    "sctid": "2994004",
+    "preferred_name": "Brain fag"
+  },
+  {
+    "sctid": "29951000119107",
+    "preferred_name": "Ataxic hemiparesis"
+  },
+  {
+    "sctid": "29956001",
+    "preferred_name": "Myelatelia"
+  },
+  {
+    "sctid": "29963001",
+    "preferred_name": "Dysmnesic seizure"
+  },
+  {
+    "sctid": "30023002",
+    "preferred_name": "Hydranencephaly"
+  },
+  {
+    "sctid": "30031007",
+    "preferred_name": "Cerebellar laceration without open intracranial wound"
+  },
+  {
+    "sctid": "30057005",
+    "preferred_name": "Polioencephalopathy"
+  },
+  {
+    "sctid": "30059008",
+    "preferred_name": "Panic disorder with agoraphobia, severe agoraphobic avoidance AND moderate panic attacks"
+  },
+  {
+    "sctid": "300706003",
+    "preferred_name": "Endogenous depression"
+  },
+  {
+    "sctid": "30077003",
+    "preferred_name": "Somatoform pain disorder"
+  },
+  {
+    "sctid": "300979000",
+    "preferred_name": "Caregiver stress syndrome"
+  },
+  {
+    "sctid": "300992002",
+    "preferred_name": "Alcohol-induced cerebellar ataxia"
+  },
+  {
+    "sctid": "300993007",
+    "preferred_name": "Drug-induced orofacial dyskinesia"
+  },
+  {
+    "sctid": "301086002",
+    "preferred_name": "Syphilitic meningitis"
+  },
+  {
+    "sctid": "301643003",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced persisting amnestic disorder"
+  },
+  {
+    "sctid": "301764006",
+    "preferred_name": "Hematoma of brain"
+  },
+  {
+    "sctid": "301765007",
+    "preferred_name": "Cerebellar hematoma"
+  },
+  {
+    "sctid": "301770000",
+    "preferred_name": "Aseptic meningitis"
+  },
+  {
+    "sctid": "30243004",
+    "preferred_name": "Cerebral anoxia following molar AND/OR ectopic pregnancy"
+  },
+  {
+    "sctid": "302507002",
+    "preferred_name": "Sedative amnestic disorder"
+  },
+  {
+    "sctid": "30278004",
+    "preferred_name": "Kundrat's syndrome"
+  },
+  {
+    "sctid": "302810003",
+    "preferred_name": "Viral infection of central nervous system"
+  },
+  {
+    "sctid": "302811004",
+    "preferred_name": "Progressive congenital rubella encephalomyelitis"
+  },
+  {
+    "sctid": "302820008",
+    "preferred_name": "Intracranial meningioma"
+  },
+  {
+    "sctid": "302877009",
+    "preferred_name": "Proteus meningitis"
+  },
+  {
+    "sctid": "302879007",
+    "preferred_name": "Septic thrombophlebitis of cavernous sinus"
+  },
+  {
+    "sctid": "302880005",
+    "preferred_name": "Septic thrombophlebitis of sagittal sinus"
+  },
+  {
+    "sctid": "302881009",
+    "preferred_name": "Septic thrombophlebitis of lateral sinus"
+  },
+  {
+    "sctid": "302882002",
+    "preferred_name": "Hydrocephalus associated with congenital aqueduct stenosis"
+  },
+  {
+    "sctid": "302883007",
+    "preferred_name": "Meningeal cyst"
+  },
+  {
+    "sctid": "302902003",
+    "preferred_name": "Infarction of optic chiasm"
+  },
+  {
+    "sctid": "302904002",
+    "preferred_name": "Infarction of visual cortex"
+  },
+  {
+    "sctid": "303061003",
+    "preferred_name": "Cerebellar pyogenic abscess"
+  },
+  {
+    "sctid": "303063000",
+    "preferred_name": "Eclampsia in puerperium"
+  },
+  {
+    "sctid": "30310000",
+    "preferred_name": "Nicotine-induced organic mental disorder"
+  },
+  {
+    "sctid": "30336007",
+    "preferred_name": "Chronic residual schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "30371007",
+    "preferred_name": "Open fracture of base of skull with cerebral laceration AND contusion"
+  },
+  {
+    "sctid": "304603007",
+    "preferred_name": "Variant Creutzfeldt-Jakob disease"
+  },
+  {
+    "sctid": "30483005",
+    "preferred_name": "Tobacco amblyopia"
+  },
+  {
+    "sctid": "304831001",
+    "preferred_name": "Chronic intracranial subdural hematoma"
+  },
+  {
+    "sctid": "30491001",
+    "preferred_name": "Cocaine delusional disorder"
+  },
+  {
+    "sctid": "30509009",
+    "preferred_name": "Gender identity disorder of adolescence, previously homosexual"
+  },
+  {
+    "sctid": "30520009",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive with psychotic features"
+  },
+  {
+    "sctid": "30605009",
+    "preferred_name": "Major depression in partial remission"
+  },
+  {
+    "sctid": "30687003",
+    "preferred_name": "Bipolar II disorder, most recent episode major depressive with postpartum onset"
+  },
+  {
+    "sctid": "3072001",
+    "preferred_name": "Hormone-induced hypopituitarism"
+  },
+  {
+    "sctid": "307212006",
+    "preferred_name": "Brain ventricular shunt malfunction"
+  },
+  {
+    "sctid": "307355007",
+    "preferred_name": "Congenital athetosis"
+  },
+  {
+    "sctid": "307356008",
+    "preferred_name": "Motor epilepsy"
+  },
+  {
+    "sctid": "307357004",
+    "preferred_name": "Jacksonian, focal or motor epilepsy"
+  },
+  {
+    "sctid": "307359001",
+    "preferred_name": "Congenital agenesis of brainstem nuclei"
+  },
+  {
+    "sctid": "30736009",
+    "preferred_name": "Dysphonia of palatopharyngolaryngeal myoclonus"
+  },
+  {
+    "sctid": "307363008",
+    "preferred_name": "Multiple lacunar infarcts"
+  },
+  {
+    "sctid": "307417003",
+    "preferred_name": "Cycloid psychosis"
+  },
+  {
+    "sctid": "30753002",
+    "preferred_name": "Normal pressure hydrocephalus"
+  },
+  {
+    "sctid": "307649006",
+    "preferred_name": "Primary central nervous system lymphoma"
+  },
+  {
+    "sctid": "307672008",
+    "preferred_name": "Oculopalatal myoclonus"
+  },
+  {
+    "sctid": "307680001",
+    "preferred_name": "Abducting nystagmus"
+  },
+  {
+    "sctid": "307756005",
+    "preferred_name": "Cerebral palsy, not congenital or infantile, acute"
+  },
+  {
+    "sctid": "307766002",
+    "preferred_name": "Left sided cerebral infarction"
+  },
+  {
+    "sctid": "307767006",
+    "preferred_name": "Right sided cerebral infarction"
+  },
+  {
+    "sctid": "30858001",
+    "preferred_name": "Cerebellar laceration with open intracranial wound"
+  },
+  {
+    "sctid": "308634000",
+    "preferred_name": "Demyelination of spinal cord"
+  },
+  {
+    "sctid": "308680003",
+    "preferred_name": "Hypoglycemia-induced convulsion"
+  },
+  {
+    "sctid": "30871003",
+    "preferred_name": "Flashbacks"
+  },
+  {
+    "sctid": "308742005",
+    "preferred_name": "Alcohol withdrawal-induced convulsion"
+  },
+  {
+    "sctid": "309279000",
+    "preferred_name": "Caffeine-induced organic mental disorder"
+  },
+  {
+    "sctid": "30935000",
+    "preferred_name": "Manic bipolar I disorder in full remission"
+  },
+  {
+    "sctid": "309789002",
+    "preferred_name": "Encephalitis due to influenza"
+  },
+  {
+    "sctid": "310202009",
+    "preferred_name": "Arylcyclohexylamine-induced organic mental disorder"
+  },
+  {
+    "sctid": "31027006",
+    "preferred_name": "Schizotypal personality disorder"
+  },
+  {
+    "sctid": "31033002",
+    "preferred_name": "Closed fracture of T1-T6 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "310495003",
+    "preferred_name": "Mild depression"
+  },
+  {
+    "sctid": "310496002",
+    "preferred_name": "Moderate depression"
+  },
+  {
+    "sctid": "310497006",
+    "preferred_name": "Severe depression"
+  },
+  {
+    "sctid": "31076000",
+    "preferred_name": "Congenital ischemic atrophy of central nervous system structure"
+  },
+  {
+    "sctid": "31081000119101",
+    "preferred_name": "Presenile dementia with delusions"
+  },
+  {
+    "sctid": "310814007",
+    "preferred_name": "Discourse difficulties"
+  },
+  {
+    "sctid": "3109008",
+    "preferred_name": "Secondary dysthymia early onset"
+  },
+  {
+    "sctid": "31112008",
+    "preferred_name": "Tuberculous meningoencephalitis"
+  },
+  {
+    "sctid": "311173003",
+    "preferred_name": "Phencyclidine-related disorder"
+  },
+  {
+    "sctid": "311191000119109",
+    "preferred_name": "Myelopathy co-occurrent and due to lumbosacral intervertebral disc disorder"
+  },
+  {
+    "sctid": "31177006",
+    "preferred_name": "Attention deficit hyperactivity disorder, combined type"
+  },
+  {
+    "sctid": "311826007",
+    "preferred_name": "Traumatic cerebral edema with open intracranial wound"
+  },
+  {
+    "sctid": "3119002",
+    "preferred_name": "Brain stem laceration with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "312098001",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-related disorder"
+  },
+  {
+    "sctid": "31216003",
+    "preferred_name": "Profound intellectual disability"
+  },
+  {
+    "sctid": "312214005",
+    "preferred_name": "Floating-Harbor syndrome"
+  },
+  {
+    "sctid": "312215006",
+    "preferred_name": "Infective encephalitis"
+  },
+  {
+    "sctid": "312216007",
+    "preferred_name": "Infective meningitis"
+  },
+  {
+    "sctid": "312217003",
+    "preferred_name": "Infective ventriculitis"
+  },
+  {
+    "sctid": "31235003",
+    "preferred_name": "Closed fracture of C5-C7 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "312372003",
+    "preferred_name": "Cerebral akinetopsia"
+  },
+  {
+    "sctid": "312786001",
+    "preferred_name": "Spinal subluxation with cervical cord lesion"
+  },
+  {
+    "sctid": "312787005",
+    "preferred_name": "Spinal subluxation with thoracic cord lesion"
+  },
+  {
+    "sctid": "312788000",
+    "preferred_name": "Spinal subluxation with lumbar cord lesion"
+  },
+  {
+    "sctid": "31283000",
+    "preferred_name": "Abductor spastic dysphonia"
+  },
+  {
+    "sctid": "312837005",
+    "preferred_name": "Spinal dislocation with cervical cord lesion"
+  },
+  {
+    "sctid": "312838000",
+    "preferred_name": "Spinal dislocation with thoracic cord lesion"
+  },
+  {
+    "sctid": "312839008",
+    "preferred_name": "Spinal dislocation with lumbar cord lesion"
+  },
+  {
+    "sctid": "312915004",
+    "preferred_name": "Nerve fiber layer infarct"
+  },
+  {
+    "sctid": "312923002",
+    "preferred_name": "Chronic central serous chorioretinopathy"
+  },
+  {
+    "sctid": "312924008",
+    "preferred_name": "Inactive central serous chorioretinopathy"
+  },
+  {
+    "sctid": "312936002",
+    "preferred_name": "Anxiolytic-induced organic mental disorder"
+  },
+  {
+    "sctid": "312942003",
+    "preferred_name": "Inherited optic neuropathy"
+  },
+  {
+    "sctid": "312943008",
+    "preferred_name": "Idiopathic optic disc swelling"
+  },
+  {
+    "sctid": "312944002",
+    "preferred_name": "Compressive optic atrophy"
+  },
+  {
+    "sctid": "312945001",
+    "preferred_name": "Infiltrative optic neuropathy"
+  },
+  {
+    "sctid": "312947009",
+    "preferred_name": "Acute central serous chorioretinopathy"
+  },
+  {
+    "sctid": "312956001",
+    "preferred_name": "Central serous chorioretinopathy"
+  },
+  {
+    "sctid": "312957005",
+    "preferred_name": "Variant central serous chorioretinopathy"
+  },
+  {
+    "sctid": "31297008",
+    "preferred_name": "Somatoform disorder"
+  },
+  {
+    "sctid": "312991009",
+    "preferred_name": "Senile dementia of the Lewy body type"
+  },
+  {
+    "sctid": "313182004",
+    "preferred_name": "Chronic post-traumatic stress disorder"
+  },
+  {
+    "sctid": "313304007",
+    "preferred_name": "Non-traumatic spinal subdural hematoma"
+  },
+  {
+    "sctid": "313434001",
+    "preferred_name": "Residual hemiplegia"
+  },
+  {
+    "sctid": "31358003",
+    "preferred_name": "Coprophilia"
+  },
+  {
+    "sctid": "31367003",
+    "preferred_name": "Postvaccinal encephalomyelitis"
+  },
+  {
+    "sctid": "31373002",
+    "preferred_name": "Disorganized schizophrenia in remission"
+  },
+  {
+    "sctid": "313915006",
+    "preferred_name": "Hypnotic-induced organic mental disorder"
+  },
+  {
+    "sctid": "314006008",
+    "preferred_name": "Acute central serous retinopathy with subretinal fluid"
+  },
+  {
+    "sctid": "314007004",
+    "preferred_name": "Chronic central serous retinopathy with diffuse retinal pigment epithelial detachment"
+  },
+  {
+    "sctid": "314008009",
+    "preferred_name": "Inactive central serous retinopathy with focal retinal pigment epithelial detachment"
+  },
+  {
+    "sctid": "314009001",
+    "preferred_name": "Central serous retinopathy with small retinal pigment epithelial detachment"
+  },
+  {
+    "sctid": "31429000",
+    "preferred_name": "Cerebral cortical dysgenesis"
+  },
+  {
+    "sctid": "31446002",
+    "preferred_name": "Bipolar I disorder, most recent episode hypomanic"
+  },
+  {
+    "sctid": "314537004",
+    "preferred_name": "Diabetic optic papillopathy"
+  },
+  {
+    "sctid": "314538009",
+    "preferred_name": "Tobacco related optic neuropathy"
+  },
+  {
+    "sctid": "314539001",
+    "preferred_name": "Alcohol related optic neuropathy"
+  },
+  {
+    "sctid": "314540004",
+    "preferred_name": "Drug induced optic neuropathy"
+  },
+  {
+    "sctid": "314783008",
+    "preferred_name": "Pontine one and a half syndrome"
+  },
+  {
+    "sctid": "314840009",
+    "preferred_name": "Progressive locomotor ataxia"
+  },
+  {
+    "sctid": "314950006",
+    "preferred_name": "Migration of spinal cord stimulator"
+  },
+  {
+    "sctid": "315019000",
+    "preferred_name": "HIV infection with aseptic meningitis"
+  },
+  {
+    "sctid": "315047001",
+    "preferred_name": "Traumatic subdural hematoma with open intracranial wound"
+  },
+  {
+    "sctid": "315048006",
+    "preferred_name": "Traumatic extradural hematoma without open intracranial wound"
+  },
+  {
+    "sctid": "315049003",
+    "preferred_name": "Traumatic extradural hematoma with open intracranial wound"
+  },
+  {
+    "sctid": "31568009",
+    "preferred_name": "Listeria meningitis"
+  },
+  {
+    "sctid": "3158007",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in partial remission AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "315826004",
+    "preferred_name": "Tabetic neurosyphilis"
+  },
+  {
+    "sctid": "31611000",
+    "preferred_name": "Multiple personality disorder"
+  },
+  {
+    "sctid": "31646008",
+    "preferred_name": "Mumps encephalitis"
+  },
+  {
+    "sctid": "31648009",
+    "preferred_name": "Unaggressive type unsocialized behavior disorder"
+  },
+  {
+    "sctid": "31658008",
+    "preferred_name": "Chronic paranoid schizophrenia"
+  },
+  {
+    "sctid": "31715000",
+    "preferred_name": "Phencyclidine (PCP) delirium"
+  },
+  {
+    "sctid": "31781004",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in partial remission AND mild panic attacks"
+  },
+  {
+    "sctid": "317816007",
+    "preferred_name": "Stockholm syndrome"
+  },
+  {
+    "sctid": "318784009",
+    "preferred_name": "Posttraumatic stress disorder, delayed onset"
+  },
+  {
+    "sctid": "31882001",
+    "preferred_name": "Closed fracture of T1-T6 level with spinal cord injury"
+  },
+  {
+    "sctid": "319768000",
+    "preferred_name": "Recurrent major depressive disorder with melancholic features"
+  },
+  {
+    "sctid": "32009006",
+    "preferred_name": "Hallucinogen hallucinosis"
+  },
+  {
+    "sctid": "320751009",
+    "preferred_name": "Major depression, melancholic type"
+  },
+  {
+    "sctid": "32106001",
+    "preferred_name": "Cortex contusion without open intracranial wound"
+  },
+  {
+    "sctid": "32112006",
+    "preferred_name": "Phlebitis of inferior sagittal sinus"
+  },
+  {
+    "sctid": "32162001",
+    "preferred_name": "Facial hemiplegia"
+  },
+  {
+    "sctid": "321717001",
+    "preferred_name": "Involutional depression"
+  },
+  {
+    "sctid": "322112361000132104",
+    "preferred_name": "Scar epilepsy"
+  },
+  {
+    "sctid": "32358001",
+    "preferred_name": "Amphetamine delusional disorder"
+  },
+  {
+    "sctid": "32388005",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in partial remission AND moderate panic attacks"
+  },
+  {
+    "sctid": "32390006",
+    "preferred_name": "Panhypopituitarism"
+  },
+  {
+    "sctid": "32410009",
+    "preferred_name": "Pederasty"
+  },
+  {
+    "sctid": "32415004",
+    "preferred_name": "Cerebellar contusion without open intracranial wound AND with concussion"
+  },
+  {
+    "sctid": "32552001",
+    "preferred_name": "Psychoactive substance-induced organic delusional disorder"
+  },
+  {
+    "sctid": "32641000119107",
+    "preferred_name": "Exercise induced hypothalamic insufficiency"
+  },
+  {
+    "sctid": "32651000119109",
+    "preferred_name": "Primary hypothalamic insufficiency"
+  },
+  {
+    "sctid": "32680009",
+    "preferred_name": "Nothnagel's syndrome"
+  },
+  {
+    "sctid": "32721004",
+    "preferred_name": "Bulimia nervosa, purging type"
+  },
+  {
+    "sctid": "32728005",
+    "preferred_name": "Hemorrhage due to ruptured congenital cerebral aneurysm"
+  },
+  {
+    "sctid": "32735002",
+    "preferred_name": "Congenital syphilitic encephalitis"
+  },
+  {
+    "sctid": "32798002",
+    "preferred_name": "Parkinsonism"
+  },
+  {
+    "sctid": "32875003",
+    "preferred_name": "Inhalant-induced persisting dementia"
+  },
+  {
+    "sctid": "32880007",
+    "preferred_name": "Adjustment disorder with work inhibition"
+  },
+  {
+    "sctid": "329361000119107",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right middle cerebral artery by embolus"
+  },
+  {
+    "sctid": "329371000119101",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left middle cerebral artery by embolus"
+  },
+  {
+    "sctid": "329391000119100",
+    "preferred_name": "Right anterior cerebral artery embolism with stroke"
+  },
+  {
+    "sctid": "329401000119103",
+    "preferred_name": "Left anterior cerebral artery embolism with stroke"
+  },
+  {
+    "sctid": "329421000119107",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right posterior cerebral artery by embolus"
+  },
+  {
+    "sctid": "329431000119105",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left posterior cerebral artery by embolus"
+  },
+  {
+    "sctid": "329451000119104",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right cerebellar artery by embolus"
+  },
+  {
+    "sctid": "329461000119102",
+    "preferred_name": "Cerebrovascular accident due to occlusion of left cerebellar artery by embolus"
+  },
+  {
+    "sctid": "329621000119105",
+    "preferred_name": "Cerebrovascular accident due to thrombus of right vertebral artery"
+  },
+  {
+    "sctid": "329631000119108",
+    "preferred_name": "Left vertebral artery thrombosis with stroke"
+  },
+  {
+    "sctid": "329641000119104",
+    "preferred_name": "Cerebrovascular accident due to thrombus of basilar artery"
+  },
+  {
+    "sctid": "329651000119102",
+    "preferred_name": "Cerebrovascular accident due to thrombus of right carotid artery"
+  },
+  {
+    "sctid": "329671000119106",
+    "preferred_name": "Traumatic subarachnoid hemorrhage with loss of consciousness"
+  },
+  {
+    "sctid": "3298001",
+    "preferred_name": "Amnestic disorder"
+  },
+  {
+    "sctid": "329991000119104",
+    "preferred_name": "Intractable atypical absence epilepsy"
+  },
+  {
+    "sctid": "330011000119102",
+    "preferred_name": "Non-traumatic cerebral edema"
+  },
+  {
+    "sctid": "330041000119103",
+    "preferred_name": "Congenital porencephalic cyst"
+  },
+  {
+    "sctid": "330061000119104",
+    "preferred_name": "Acquired cerebral ventriculomegaly"
+  },
+  {
+    "sctid": "330111000119103",
+    "preferred_name": "Ruptured acquired aneurysm of cerebral artery"
+  },
+  {
+    "sctid": "330411000119109",
+    "preferred_name": "Lacunar ataxic hemiparesis of left nondominant side"
+  },
+  {
+    "sctid": "330421000119102",
+    "preferred_name": "Lacunar ataxic hemiparesis of right nondominant side"
+  },
+  {
+    "sctid": "330521000119103",
+    "preferred_name": "Neuromuscular scoliosis of thoracolumbar spine co-occurrent and due to cerebral palsy"
+  },
+  {
+    "sctid": "33078009",
+    "preferred_name": "Severe recurrent major depression with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "330791000119108",
+    "preferred_name": "Cerebrovascular accident due to thrombus of left carotid artery"
+  },
+  {
+    "sctid": "33135002",
+    "preferred_name": "Recurrent major depression in partial remission"
+  },
+  {
+    "sctid": "33147008",
+    "preferred_name": "Open fracture of C1-C4 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "332091000119105",
+    "preferred_name": "Serous detachment of right retinal pigment epithelium"
+  },
+  {
+    "sctid": "332101000119100",
+    "preferred_name": "Serous retinal detachment of right eye"
+  },
+  {
+    "sctid": "332851000119107",
+    "preferred_name": "Pseudopapilledema of right eye"
+  },
+  {
+    "sctid": "3331000119108",
+    "preferred_name": "Laryngeal dystonia"
+  },
+  {
+    "sctid": "33323008",
+    "preferred_name": "Somatic delusion disorder"
+  },
+  {
+    "sctid": "33332005",
+    "preferred_name": "Brain injury without open intracranial wound AND with concussion"
+  },
+  {
+    "sctid": "33346005",
+    "preferred_name": "Granular ependymitis"
+  },
+  {
+    "sctid": "333531000119105",
+    "preferred_name": "Optic papillitis of right eye"
+  },
+  {
+    "sctid": "33380008",
+    "preferred_name": "Severe manic bipolar I disorder with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "33441000119100",
+    "preferred_name": "Transitional lipoma of spinal cord"
+  },
+  {
+    "sctid": "33449004",
+    "preferred_name": "Personality disorder"
+  },
+  {
+    "sctid": "334651000119101",
+    "preferred_name": "Ischemic optic neuropathy of right eye"
+  },
+  {
+    "sctid": "334711000119109",
+    "preferred_name": "Internuclear ophthalmoplegia of right eye"
+  },
+  {
+    "sctid": "334911000119107",
+    "preferred_name": "Hemorrhage in right optic nerve sheath"
+  },
+  {
+    "sctid": "33559001",
+    "preferred_name": "Rabson-Mendenhall syndrome"
+  },
+  {
+    "sctid": "33581000119109",
+    "preferred_name": "Primary malignant neoplasm of extradural spinal cord"
+  },
+  {
+    "sctid": "33595009",
+    "preferred_name": "Arachnoid cyst"
+  },
+  {
+    "sctid": "33693007",
+    "preferred_name": "Compensation neurosis"
+  },
+  {
+    "sctid": "3371000119106",
+    "preferred_name": "Refractory generalized convulsive epilepsy"
+  },
+  {
+    "sctid": "33736005",
+    "preferred_name": "Severe major depression with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "337701000119103",
+    "preferred_name": "Serous detachment of left retinal pigment epithelium"
+  },
+  {
+    "sctid": "337711000119100",
+    "preferred_name": "Serous retinal detachment of left eye"
+  },
+  {
+    "sctid": "33772003",
+    "preferred_name": "Myelomalacia"
+  },
+  {
+    "sctid": "338461000119109",
+    "preferred_name": "Pseudopapilledema of left eye"
+  },
+  {
+    "sctid": "33871004",
+    "preferred_name": "Phencyclidine-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "339141000119108",
+    "preferred_name": "Optic papillitis of left eye"
+  },
+  {
+    "sctid": "33927004",
+    "preferred_name": "Hypogonadotropic hypogonadism"
+  },
+  {
+    "sctid": "33941008",
+    "preferred_name": "Simple partial seizure with disturbance of higher cerebral function"
+  },
+  {
+    "sctid": "33982008",
+    "preferred_name": "Hyperphosphatasemia with intellectual disability"
+  },
+  {
+    "sctid": "340251000119108",
+    "preferred_name": "Ischemic optic neuropathy of left eye"
+  },
+  {
+    "sctid": "340311000119104",
+    "preferred_name": "Internuclear ophthalmoplegia of left eye"
+  },
+  {
+    "sctid": "34041000119108",
+    "preferred_name": "Benign neoplasm of extramedullary spinal cord"
+  },
+  {
+    "sctid": "340521000119102",
+    "preferred_name": "Hemorrhage in left optic nerve sheath"
+  },
+  {
+    "sctid": "34116005",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in full remission AND severe panic attacks"
+  },
+  {
+    "sctid": "34134009",
+    "preferred_name": "Shenjing shuairuo"
+  },
+  {
+    "sctid": "34139004",
+    "preferred_name": "Intervertebral disc disorder of lumbar region with myelopathy"
+  },
+  {
+    "sctid": "341551000000108",
+    "preferred_name": "Cerebral degeneration in Parkinson's disease"
+  },
+  {
+    "sctid": "34181000119102",
+    "preferred_name": "Cerebral infarction due to occlusion of basilar artery"
+  },
+  {
+    "sctid": "34184002",
+    "preferred_name": "Corpus callosum syndrome"
+  },
+  {
+    "sctid": "34191000119104",
+    "preferred_name": "Cerebral infarction due to vertebral artery occlusion"
+  },
+  {
+    "sctid": "34209003",
+    "preferred_name": "Cerebral hemiplegia"
+  },
+  {
+    "sctid": "342741000119103",
+    "preferred_name": "Cortical blindness of right side of brain"
+  },
+  {
+    "sctid": "342751000119101",
+    "preferred_name": "Cortical blindness of left side of brain"
+  },
+  {
+    "sctid": "34315001",
+    "preferred_name": "Bipolar II disorder, most recent episode major depressive with melancholic features"
+  },
+  {
+    "sctid": "343471000119108",
+    "preferred_name": "Bilateral serous detachment of retinal pigment epithelium"
+  },
+  {
+    "sctid": "343481000119106",
+    "preferred_name": "Bilateral serous retinal detachment of eyes"
+  },
+  {
+    "sctid": "344231000119109",
+    "preferred_name": "Bilateral pseudopapilledema of eyes"
+  },
+  {
+    "sctid": "344271000119107",
+    "preferred_name": "Bilateral primary optic atrophy"
+  },
+  {
+    "sctid": "3446000",
+    "preferred_name": "Open fracture of T7-T12 level with spinal cord injury"
+  },
+  {
+    "sctid": "34476008",
+    "preferred_name": "Viral encephalitis"
+  },
+  {
+    "sctid": "34485008",
+    "preferred_name": "Axis IV diagnosis"
+  },
+  {
+    "sctid": "344891000119109",
+    "preferred_name": "Bilateral optic papillitis"
+  },
+  {
+    "sctid": "3456001",
+    "preferred_name": "Chronic progressive non-hereditary chorea"
+  },
+  {
+    "sctid": "345611000119102",
+    "preferred_name": "Bilateral ischemic optic neuropathy of eyes"
+  },
+  {
+    "sctid": "345671000119105",
+    "preferred_name": "Bilateral internuclear ophthalmoplegia of eyes"
+  },
+  {
+    "sctid": "345831000119106",
+    "preferred_name": "Bilateral hemorrhage in optic nerve sheaths"
+  },
+  {
+    "sctid": "34601006",
+    "preferred_name": "Somatosensory seizure"
+  },
+  {
+    "sctid": "34663006",
+    "preferred_name": "Contusion of brain"
+  },
+  {
+    "sctid": "346674811000119104",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral cerebellar arteries"
+  },
+  {
+    "sctid": "34741005",
+    "preferred_name": "Nervios"
+  },
+  {
+    "sctid": "348051000119102",
+    "preferred_name": "Atrophy of right optic nerve following inflammation"
+  },
+  {
+    "sctid": "348131000119109",
+    "preferred_name": "Partial optic atrophy of right eye"
+  },
+  {
+    "sctid": "348151000119103",
+    "preferred_name": "Congenital pit of optic disc of right eye"
+  },
+  {
+    "sctid": "348501000119108",
+    "preferred_name": "Atrophy of left optic nerve following inflammation"
+  },
+  {
+    "sctid": "348581000119100",
+    "preferred_name": "Partial optic atrophy of left eye"
+  },
+  {
+    "sctid": "348601000119109",
+    "preferred_name": "Congenital pit of optic disc of left eye"
+  },
+  {
+    "sctid": "349161000119106",
+    "preferred_name": "Bilateral partial optic atrophy"
+  },
+  {
+    "sctid": "34938008",
+    "preferred_name": "Alcohol-induced anxiety disorder"
+  },
+  {
+    "sctid": "350841000119107",
+    "preferred_name": "Benign neoplasm of infratentorial brain"
+  },
+  {
+    "sctid": "35111000119109",
+    "preferred_name": "Cystic malformation of posterior fossa"
+  },
+  {
+    "sctid": "35145002",
+    "preferred_name": "Uremic encephalopathy"
+  },
+  {
+    "sctid": "351861000000106",
+    "preferred_name": "Stranger anxiety"
+  },
+  {
+    "sctid": "35218008",
+    "preferred_name": "Chronic disorganized schizophrenia with acute exacerbation"
+  },
+  {
+    "sctid": "35252006",
+    "preferred_name": "Disorganized schizophrenia"
+  },
+  {
+    "sctid": "35253001",
+    "preferred_name": "Attention deficit hyperactivity disorder, predominantly inattentive type"
+  },
+  {
+    "sctid": "352818000",
+    "preferred_name": "Tonic-clonic epilepsy"
+  },
+  {
+    "sctid": "352911000119101",
+    "preferred_name": "Primary malignant neoplasm of left optic nerve"
+  },
+  {
+    "sctid": "352921000119108",
+    "preferred_name": "Primary malignant neoplasm of right optic nerve"
+  },
+  {
+    "sctid": "3530005",
+    "preferred_name": "Bipolar I disorder, single manic episode, in full remission"
+  },
+  {
+    "sctid": "35403005",
+    "preferred_name": "Closed fracture of C5-C7 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "35481005",
+    "preferred_name": "Mixed bipolar I disorder in remission"
+  },
+  {
+    "sctid": "35486000",
+    "preferred_name": "Subdural hemorrhage"
+  },
+  {
+    "sctid": "35489007",
+    "preferred_name": "Depressive disorder"
+  },
+  {
+    "sctid": "35607004",
+    "preferred_name": "Panic disorder with agoraphobia"
+  },
+  {
+    "sctid": "35640008",
+    "preferred_name": "Acute adenoviral encephalitis"
+  },
+  {
+    "sctid": "35722002",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive, in remission"
+  },
+  {
+    "sctid": "357705009",
+    "preferred_name": "Cotard's syndrome"
+  },
+  {
+    "sctid": "35786001",
+    "preferred_name": "Tuberculoma of meninges"
+  },
+  {
+    "sctid": "35827000",
+    "preferred_name": "Recurrent conversion disorder"
+  },
+  {
+    "sctid": "35846004",
+    "preferred_name": "Moderate bipolar II disorder, most recent episode major depressive"
+  },
+  {
+    "sctid": "3586005",
+    "preferred_name": "Psychogenic fugue"
+  },
+  {
+    "sctid": "359007",
+    "preferred_name": "Kernicterus due to isoimmunization"
+  },
+  {
+    "sctid": "35919005",
+    "preferred_name": "Autism spectrum disorder"
+  },
+  {
+    "sctid": "359619007",
+    "preferred_name": "Pinealoma"
+  },
+  {
+    "sctid": "359621002",
+    "preferred_name": "Acquired periventricular cysts of newborn"
+  },
+  {
+    "sctid": "359624005",
+    "preferred_name": "Acquired periventricular cyst"
+  },
+  {
+    "sctid": "359629000",
+    "preferred_name": "Progressive post hemorrhagic ventricular dilatation"
+  },
+  {
+    "sctid": "359634001",
+    "preferred_name": "Infantile posthemorrhagic hydrocephalus"
+  },
+  {
+    "sctid": "359661001",
+    "preferred_name": "Specific number difficulty"
+  },
+  {
+    "sctid": "359683002",
+    "preferred_name": "Complete optic atrophy"
+  },
+  {
+    "sctid": "359686005",
+    "preferred_name": "Van Bogaert's sclerosing leukoencephalitis"
+  },
+  {
+    "sctid": "359824007",
+    "preferred_name": "Incomplete anencephaly"
+  },
+  {
+    "sctid": "359844001",
+    "preferred_name": "Extradural infratentorial pyogenic abscess"
+  },
+  {
+    "sctid": "36010004",
+    "preferred_name": "Congenital cerebral meningocele"
+  },
+  {
+    "sctid": "36025004",
+    "preferred_name": "Fibrous skin tumor of tuberous sclerosis"
+  },
+  {
+    "sctid": "360353005",
+    "preferred_name": "Thyrotoxicosis due to pituitary thyroid hormone resistance"
+  },
+  {
+    "sctid": "360358001",
+    "preferred_name": "Thyrotoxicosis due to overproduction of thyroid stimulating hormone"
+  },
+  {
+    "sctid": "360361000",
+    "preferred_name": "Thyrotoxicosis due to inappropriate TSH secretion"
+  },
+  {
+    "sctid": "36039004",
+    "preferred_name": "Rumination disorder of infancy"
+  },
+  {
+    "sctid": "360527003",
+    "preferred_name": "Diplomyelia"
+  },
+  {
+    "sctid": "360530005",
+    "preferred_name": "Myeloschisis"
+  },
+  {
+    "sctid": "361117008",
+    "preferred_name": "Female hypogonadotropic hypogonadism"
+  },
+  {
+    "sctid": "361123003",
+    "preferred_name": "Psychomotor epilepsy"
+  },
+  {
+    "sctid": "361151007",
+    "preferred_name": "Delirium due to sedative withdrawal"
+  },
+  {
+    "sctid": "361268000",
+    "preferred_name": "Alcohol-induced epilepsy"
+  },
+  {
+    "sctid": "361272001",
+    "preferred_name": "Cerebellar ataxia due to alcoholism"
+  },
+  {
+    "sctid": "361273006",
+    "preferred_name": "Alcoholic cerebellar degeneration"
+  },
+  {
+    "sctid": "36158005",
+    "preferred_name": "Schizophreniform disorder with good prognostic features"
+  },
+  {
+    "sctid": "36170009",
+    "preferred_name": "Secondary dysthymia late onset"
+  },
+  {
+    "sctid": "36179005",
+    "preferred_name": "R.I.N.D. syndrome"
+  },
+  {
+    "sctid": "36217008",
+    "preferred_name": "Organic personality disorder"
+  },
+  {
+    "sctid": "36262007",
+    "preferred_name": "Pygmalionism"
+  },
+  {
+    "sctid": "36276008",
+    "preferred_name": "Syphilitic retrobulbar neuritis"
+  },
+  {
+    "sctid": "363467004",
+    "preferred_name": "Malignant neoplasm of frontal lobe"
+  },
+  {
+    "sctid": "363468009",
+    "preferred_name": "Malignant neoplasm of temporal lobe"
+  },
+  {
+    "sctid": "363469001",
+    "preferred_name": "Malignant neoplasm of parietal lobe"
+  },
+  {
+    "sctid": "363470000",
+    "preferred_name": "Malignant neoplasm of occipital lobe"
+  },
+  {
+    "sctid": "363471001",
+    "preferred_name": "Malignant neoplasm of cerebral ventricles"
+  },
+  {
+    "sctid": "363473003",
+    "preferred_name": "Malignant neoplasm of brainstem"
+  },
+  {
+    "sctid": "363474009",
+    "preferred_name": "Malignant neoplasm of cerebral meninges"
+  },
+  {
+    "sctid": "363475005",
+    "preferred_name": "Malignant tumor of spinal cord"
+  },
+  {
+    "sctid": "363476006",
+    "preferred_name": "Malignant neoplasm of spinal meninges"
+  },
+  {
+    "sctid": "363482009",
+    "preferred_name": "Malignant tumor of pituitary gland"
+  },
+  {
+    "sctid": "363483004",
+    "preferred_name": "Malignant tumor of pineal gland"
+  },
+  {
+    "sctid": "363497007",
+    "preferred_name": "Malignant tumor of meninges"
+  },
+  {
+    "sctid": "363498002",
+    "preferred_name": "Malignant tumor of optic nerve"
+  },
+  {
+    "sctid": "36474008",
+    "preferred_name": "Severe recurrent major depression without psychotic features"
+  },
+  {
+    "sctid": "3652007",
+    "preferred_name": "Overproduction of growth hormone"
+  },
+  {
+    "sctid": "36583000",
+    "preferred_name": "Mixed bipolar I disorder in partial remission"
+  },
+  {
+    "sctid": "36622002",
+    "preferred_name": "Mild mood disorder"
+  },
+  {
+    "sctid": "367241000119104",
+    "preferred_name": "Hyperosmolar coma due to drug induced diabetes mellitus"
+  },
+  {
+    "sctid": "367411000119102",
+    "preferred_name": "Hypopituitarism caused by drug"
+  },
+  {
+    "sctid": "367460001",
+    "preferred_name": "Pituitary dwarfism"
+  },
+  {
+    "sctid": "36785009",
+    "preferred_name": "Aphasia-angular gyrus syndrome"
+  },
+  {
+    "sctid": "36803009",
+    "preferred_name": "Idiopathic generalized epilepsy"
+  },
+  {
+    "sctid": "3681008",
+    "preferred_name": "Thrombophlebitis of torcular Herophili"
+  },
+  {
+    "sctid": "368361000119108",
+    "preferred_name": "Thyrotoxicosis factitia without thyrotoxic crisis"
+  },
+  {
+    "sctid": "368601000119102",
+    "preferred_name": "Hyperosmolar coma due to secondary diabetes mellitus"
+  },
+  {
+    "sctid": "368961000119107",
+    "preferred_name": "Partial nephrogenic diabetes insipidus"
+  },
+  {
+    "sctid": "36923009",
+    "preferred_name": "Major depression, single episode"
+  },
+  {
+    "sctid": "370143000",
+    "preferred_name": "Major depressive disorder"
+  },
+  {
+    "sctid": "370502006",
+    "preferred_name": "Encephalomyelopathy"
+  },
+  {
+    "sctid": "370987005",
+    "preferred_name": "Anaplastic astrocytoma of spinal cord"
+  },
+  {
+    "sctid": "371022006",
+    "preferred_name": "Seizures due to metabolic disorder"
+  },
+  {
+    "sctid": "371024007",
+    "preferred_name": "Senile dementia with delusion"
+  },
+  {
+    "sctid": "371026009",
+    "preferred_name": "Senile dementia with psychosis"
+  },
+  {
+    "sctid": "371029002",
+    "preferred_name": "Ischemic disorder of spinal cord"
+  },
+  {
+    "sctid": "371031006",
+    "preferred_name": "Staphylococcus epidermidis ventriculitis"
+  },
+  {
+    "sctid": "371040005",
+    "preferred_name": "Thrombotic stroke"
+  },
+  {
+    "sctid": "371041009",
+    "preferred_name": "Embolic stroke"
+  },
+  {
+    "sctid": "371050006",
+    "preferred_name": "Traumatic intracranial subdural hematoma with brief loss of consciousness"
+  },
+  {
+    "sctid": "371076006",
+    "preferred_name": "Congenital syringomyelia"
+  },
+  {
+    "sctid": "371077002",
+    "preferred_name": "Ventriculoperitoneal shunt malfunction"
+  },
+  {
+    "sctid": "371079004",
+    "preferred_name": "Paraplegic cerebral palsy"
+  },
+  {
+    "sctid": "371107004",
+    "preferred_name": "Seizures complicating intracranial hemorrhage in the newborn"
+  },
+  {
+    "sctid": "371114002",
+    "preferred_name": "Seizures complicating intracranial hemorrhage"
+  },
+  {
+    "sctid": "371115001",
+    "preferred_name": "Seizures complicating infection"
+  },
+  {
+    "sctid": "371116000",
+    "preferred_name": "Posthemorrhagic hydrocephalus"
+  },
+  {
+    "sctid": "371121002",
+    "preferred_name": "Neonatal stroke"
+  },
+  {
+    "sctid": "371313002",
+    "preferred_name": "Congenital cerebellar cortical atrophy"
+  },
+  {
+    "sctid": "37145001",
+    "preferred_name": "Central nervous system dysfunction in newborn"
+  },
+  {
+    "sctid": "371596008",
+    "preferred_name": "Bipolar I disorder"
+  },
+  {
+    "sctid": "371599001",
+    "preferred_name": "Severe bipolar I disorder"
+  },
+  {
+    "sctid": "371600003",
+    "preferred_name": "Severe bipolar disorder"
+  },
+  {
+    "sctid": "371604007",
+    "preferred_name": "Severe bipolar II disorder"
+  },
+  {
+    "sctid": "371631005",
+    "preferred_name": "Panic disorder"
+  },
+  {
+    "sctid": "372062007",
+    "preferred_name": "Malignant neoplasm of central nervous system"
+  },
+  {
+    "sctid": "372441001",
+    "preferred_name": "Seizures complicating infection in the newborn"
+  },
+  {
+    "sctid": "372477008",
+    "preferred_name": "Post-traumatic syrinx"
+  },
+  {
+    "sctid": "37331004",
+    "preferred_name": "Psychoactive substance-induced organic mood disorder"
+  },
+  {
+    "sctid": "37356005",
+    "preferred_name": "Myoclonic seizure"
+  },
+  {
+    "sctid": "373587001",
+    "preferred_name": "Chiari malformation type II"
+  },
+  {
+    "sctid": "373590007",
+    "preferred_name": "Convergence retraction nystagmus"
+  },
+  {
+    "sctid": "373606000",
+    "preferred_name": "Occlusive stroke"
+  },
+  {
+    "sctid": "373618009",
+    "preferred_name": "Autistic spectrum disorder with isolated skills"
+  },
+  {
+    "sctid": "373650004",
+    "preferred_name": "Hypoplasia of optic disc"
+  },
+  {
+    "sctid": "373661007",
+    "preferred_name": "Optic disc structural anomaly"
+  },
+  {
+    "sctid": "37429009",
+    "preferred_name": "Hypothalamic hypothyroidism"
+  },
+  {
+    "sctid": "37650008",
+    "preferred_name": "Hereditary cerebellar degeneration"
+  },
+  {
+    "sctid": "37660004",
+    "preferred_name": "Subdural abscess"
+  },
+  {
+    "sctid": "37739004",
+    "preferred_name": "Mood disorder due to a general medical condition"
+  },
+  {
+    "sctid": "37746008",
+    "preferred_name": "Avoidant personality disorder"
+  },
+  {
+    "sctid": "37754005",
+    "preferred_name": "Asymptomatic neurosyphilis"
+  },
+  {
+    "sctid": "37868008",
+    "preferred_name": "Anxiety disorder of adolescence"
+  },
+  {
+    "sctid": "37872007",
+    "preferred_name": "Avoidant disorder of childhood OR adolescence"
+  },
+  {
+    "sctid": "37941009",
+    "preferred_name": "Rumination disorder"
+  },
+  {
+    "sctid": "37960002",
+    "preferred_name": "Sanger-Brown cerebellar ataxia"
+  },
+  {
+    "sctid": "37991008",
+    "preferred_name": "Parinaud's syndrome"
+  },
+  {
+    "sctid": "38023001",
+    "preferred_name": "Locked in syndrome"
+  },
+  {
+    "sctid": "38115001",
+    "preferred_name": "Tuberculosis of spinal meninges"
+  },
+  {
+    "sctid": "38116000",
+    "preferred_name": "Hydromyelocele"
+  },
+  {
+    "sctid": "38281008",
+    "preferred_name": "Benign neonatal convulsions"
+  },
+  {
+    "sctid": "38295006",
+    "preferred_name": "Involutional paraphrenia"
+  },
+  {
+    "sctid": "38328002",
+    "preferred_name": "Panic disorder with agoraphobia, severe agoraphobic avoidance AND panic attacks in full remission"
+  },
+  {
+    "sctid": "38353004",
+    "preferred_name": "Congenital porencephaly"
+  },
+  {
+    "sctid": "38368003",
+    "preferred_name": "Schizoaffective disorder, bipolar type"
+  },
+  {
+    "sctid": "38403006",
+    "preferred_name": "Vertigo of central origin"
+  },
+  {
+    "sctid": "384430101000119103",
+    "preferred_name": "Cerebrovascular accident due to embolism of right carotid artery"
+  },
+  {
+    "sctid": "38451003",
+    "preferred_name": "Primary dysthymia early onset"
+  },
+  {
+    "sctid": "38453000",
+    "preferred_name": "Cerebral hemorrhage due to intrapartum anoxia or hypoxia"
+  },
+  {
+    "sctid": "384993003",
+    "preferred_name": "Periventricular hemorrhagic venous infarct"
+  },
+  {
+    "sctid": "38523005",
+    "preferred_name": "Syphilitic parkinsonism"
+  },
+  {
+    "sctid": "38547003",
+    "preferred_name": "Mood disorder in full remission"
+  },
+  {
+    "sctid": "38576000",
+    "preferred_name": "Nonfamilial hyperinsulinemic isolated somatotropin deficiency"
+  },
+  {
+    "sctid": "38595071000119104",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of right posterior cerebral artery"
+  },
+  {
+    "sctid": "38599001",
+    "preferred_name": "Serous retinal detachment"
+  },
+  {
+    "sctid": "38632003",
+    "preferred_name": "Pharyngeal pituitary tissue"
+  },
+  {
+    "sctid": "386537007",
+    "preferred_name": "Psychogenic pylorospasm"
+  },
+  {
+    "sctid": "386572005",
+    "preferred_name": "Psychogenic syncope"
+  },
+  {
+    "sctid": "386701004",
+    "preferred_name": "Developmental articulation disorder"
+  },
+  {
+    "sctid": "386766007",
+    "preferred_name": "Marchiafava-Bignami disease"
+  },
+  {
+    "sctid": "386781001",
+    "preferred_name": "Spastic syndrome"
+  },
+  {
+    "sctid": "386805003",
+    "preferred_name": "Mild cognitive disorder"
+  },
+  {
+    "sctid": "386810004",
+    "preferred_name": "Phobic disorder"
+  },
+  {
+    "sctid": "386820009",
+    "preferred_name": "Socialized behavior disorder"
+  },
+  {
+    "sctid": "386821008",
+    "preferred_name": "Adjustment reaction in infancy"
+  },
+  {
+    "sctid": "386822001",
+    "preferred_name": "Adjustment reaction of adolescence"
+  },
+  {
+    "sctid": "386823006",
+    "preferred_name": "Adjustment reaction of adult life"
+  },
+  {
+    "sctid": "386824000",
+    "preferred_name": "Adjustment reaction of childhood"
+  },
+  {
+    "sctid": "386825004",
+    "preferred_name": "Adjustment reaction of late life"
+  },
+  {
+    "sctid": "38694004",
+    "preferred_name": "Recurrent major depressive disorder with atypical features"
+  },
+  {
+    "sctid": "38837006",
+    "preferred_name": "Acquired porencephaly"
+  },
+  {
+    "sctid": "388871003",
+    "preferred_name": "Primary optic nerve sheath meningioma"
+  },
+  {
+    "sctid": "388872005",
+    "preferred_name": "Secondary optic nerve sheath meningioma"
+  },
+  {
+    "sctid": "389088001",
+    "preferred_name": "Hypoxia of brain"
+  },
+  {
+    "sctid": "389089009",
+    "preferred_name": "Anoxia of brain"
+  },
+  {
+    "sctid": "389098007",
+    "preferred_name": "Anoxic encephalopathy"
+  },
+  {
+    "sctid": "389100007",
+    "preferred_name": "Ischemic encephalopathy"
+  },
+  {
+    "sctid": "389101006",
+    "preferred_name": "Anoxic-ischemic encephalopathy"
+  },
+  {
+    "sctid": "389271000",
+    "preferred_name": "Spondyloenchondromatosis with basal ganglia calcification"
+  },
+  {
+    "sctid": "39003006",
+    "preferred_name": "Psychoactive substance-induced organic delirium"
+  },
+  {
+    "sctid": "39134007",
+    "preferred_name": "Hematomyelia"
+  },
+  {
+    "sctid": "3914008",
+    "preferred_name": "Mental disorder in childhood"
+  },
+  {
+    "sctid": "39150004",
+    "preferred_name": "Congenital anomaly of spinal meninges"
+  },
+  {
+    "sctid": "39194005",
+    "preferred_name": "Visual epilepsy"
+  },
+  {
+    "sctid": "392662004",
+    "preferred_name": "West Nile encephalitis"
+  },
+  {
+    "sctid": "39367000",
+    "preferred_name": "Inflammatory disease of the central nervous system"
+  },
+  {
+    "sctid": "39465007",
+    "preferred_name": "Emotional deprivation syndrome"
+  },
+  {
+    "sctid": "395502002",
+    "preferred_name": "Neoplasm of optic nerve and sheath"
+  },
+  {
+    "sctid": "395505000",
+    "preferred_name": "Neoplasm of optic nerve"
+  },
+  {
+    "sctid": "39574006",
+    "preferred_name": "Congenital hypoplasia of inner granular layer of cerebellum"
+  },
+  {
+    "sctid": "39610001",
+    "preferred_name": "Undifferentiated schizophrenia in remission"
+  },
+  {
+    "sctid": "39648006",
+    "preferred_name": "Fibrous hypertrophic cervical pachymeningitis"
+  },
+  {
+    "sctid": "39745004",
+    "preferred_name": "Chronic progressive epilepsia partialis continua"
+  },
+  {
+    "sctid": "397763006",
+    "preferred_name": "Human immunodeficiency virus encephalopathy"
+  },
+  {
+    "sctid": "397795007",
+    "preferred_name": "Polysomatizing disorder"
+  },
+  {
+    "sctid": "397809001",
+    "preferred_name": "Nontraumatic extradural hemorrhage"
+  },
+  {
+    "sctid": "397826007",
+    "preferred_name": "Briquet's syndrome"
+  },
+  {
+    "sctid": "397827003",
+    "preferred_name": "Growth hormone deficiency"
+  },
+  {
+    "sctid": "397923000",
+    "preferred_name": "Somatization disorder"
+  },
+  {
+    "sctid": "397928009",
+    "preferred_name": "Infantile paralysis"
+  },
+  {
+    "sctid": "397961002",
+    "preferred_name": "Encephalomyelitis caused by lymphocytic choriomeningitis virus"
+  },
+  {
+    "sctid": "398066007",
+    "preferred_name": "Intensive care psychiatric disorder"
+  },
+  {
+    "sctid": "39807006",
+    "preferred_name": "Cannabis intoxication delirium"
+  },
+  {
+    "sctid": "39809009",
+    "preferred_name": "Recurrent major depressive disorder with catatonic features"
+  },
+  {
+    "sctid": "398102009",
+    "preferred_name": "Acute poliomyelitis"
+  },
+  {
+    "sctid": "398136003",
+    "preferred_name": "Lymphocytic choriomeningitis"
+  },
+  {
+    "sctid": "398256009",
+    "preferred_name": "Epidemic acute poliomyelitis"
+  },
+  {
+    "sctid": "398327006",
+    "preferred_name": "Anterior acute poliomyelitis"
+  },
+  {
+    "sctid": "398329009",
+    "preferred_name": "Human immunodeficiency virus encephalitis"
+  },
+  {
+    "sctid": "398432008",
+    "preferred_name": "Bulbar weakness"
+  },
+  {
+    "sctid": "398446008",
+    "preferred_name": "Human rabies"
+  },
+  {
+    "sctid": "399041003",
+    "preferred_name": "Chastek paralysis"
+  },
+  {
+    "sctid": "399100005",
+    "preferred_name": "Disorder of hypothalamus"
+  },
+  {
+    "sctid": "39912006",
+    "preferred_name": "Hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "399244003",
+    "preferred_name": "Disorder of pituitary gland"
+  },
+  {
+    "sctid": "39925003",
+    "preferred_name": "Juvenile myopathy, encephalopathy, lactic acidosis AND stroke"
+  },
+  {
+    "sctid": "39951000119105",
+    "preferred_name": "Pervasive developmental disorder of residual state"
+  },
+  {
+    "sctid": "39951001",
+    "preferred_name": "Cannabis-induced anxiety disorder"
+  },
+  {
+    "sctid": "40083003",
+    "preferred_name": "Stereotypic movement disorder with self-injurious behavior"
+  },
+  {
+    "sctid": "40099009",
+    "preferred_name": "Mumps meningoencephalitis"
+  },
+  {
+    "sctid": "40230002",
+    "preferred_name": "Encephalitis due to Langat virus"
+  },
+  {
+    "sctid": "40259002",
+    "preferred_name": "Progressive sensory ataxia of Charolais"
+  },
+  {
+    "sctid": "402732001",
+    "preferred_name": "Habit tic"
+  },
+  {
+    "sctid": "402733006",
+    "preferred_name": "Habit tic affecting skin"
+  },
+  {
+    "sctid": "402735004",
+    "preferred_name": "Habit tic affecting hair"
+  },
+  {
+    "sctid": "403578003",
+    "preferred_name": "Factitious blistering"
+  },
+  {
+    "sctid": "403579006",
+    "preferred_name": "Factitious lymphedema"
+  },
+  {
+    "sctid": "403590001",
+    "preferred_name": "Cutaneous Munchausen syndrome by proxy"
+  },
+  {
+    "sctid": "403593004",
+    "preferred_name": "Phobic fear of skin cancer"
+  },
+  {
+    "sctid": "403594005",
+    "preferred_name": "Psychogenic formication"
+  },
+  {
+    "sctid": "403595006",
+    "preferred_name": "Pinocchio syndrome"
+  },
+  {
+    "sctid": "40379007",
+    "preferred_name": "Mild recurrent major depression"
+  },
+  {
+    "sctid": "40405003",
+    "preferred_name": "Illegal termination of pregnancy with cerebral anoxia"
+  },
+  {
+    "sctid": "404233006",
+    "preferred_name": "West Nile meningitis"
+  },
+  {
+    "sctid": "404234000",
+    "preferred_name": "St. Louis meningitis"
+  },
+  {
+    "sctid": "404235004",
+    "preferred_name": "Jamestown Canyon virus encephalitis"
+  },
+  {
+    "sctid": "404238002",
+    "preferred_name": "Jamestown Canyon virus meningitis"
+  },
+  {
+    "sctid": "404239005",
+    "preferred_name": "California serogroup viral meningitis"
+  },
+  {
+    "sctid": "404240007",
+    "preferred_name": "La Crosse meningitis"
+  },
+  {
+    "sctid": "404241006",
+    "preferred_name": "Snowshoe hare meningitis"
+  },
+  {
+    "sctid": "404243009",
+    "preferred_name": "Keystone virus meningitis"
+  },
+  {
+    "sctid": "40425004",
+    "preferred_name": "Postconcussion syndrome"
+  },
+  {
+    "sctid": "40450001",
+    "preferred_name": "Embolism of superior sagittal sinus"
+  },
+  {
+    "sctid": "404653000",
+    "preferred_name": "Chiasmal glioma"
+  },
+  {
+    "sctid": "404654006",
+    "preferred_name": "Riddoch phenomenon"
+  },
+  {
+    "sctid": "404658009",
+    "preferred_name": "Papillophlebitis"
+  },
+  {
+    "sctid": "404659001",
+    "preferred_name": "Anterior ischemic optic neuropathy"
+  },
+  {
+    "sctid": "404660006",
+    "preferred_name": "Acute compressive optic neuropathy"
+  },
+  {
+    "sctid": "404664002",
+    "preferred_name": "Malignant optic glioma"
+  },
+  {
+    "sctid": "404676002",
+    "preferred_name": "Bruns nystagmus"
+  },
+  {
+    "sctid": "404689008",
+    "preferred_name": "Alternating hemiplegia"
+  },
+  {
+    "sctid": "404906000",
+    "preferred_name": "Postoperative confusion"
+  },
+  {
+    "sctid": "40568001",
+    "preferred_name": "Recurrent brief depressive disorder"
+  },
+  {
+    "sctid": "40571009",
+    "preferred_name": "Hallucinogen intoxication delirium"
+  },
+  {
+    "sctid": "405754008",
+    "preferred_name": "Cervical spinal cord injury"
+  },
+  {
+    "sctid": "405755009",
+    "preferred_name": "Anterior cervical spinal cord injury at C1-C4 level without spinal bone injury"
+  },
+  {
+    "sctid": "405756005",
+    "preferred_name": "Anterior cervical spinal cord injury, without spinal bone injury, C5-7"
+  },
+  {
+    "sctid": "405757001",
+    "preferred_name": "Central cervical cord injury, without spinal bony injury, C1-4"
+  },
+  {
+    "sctid": "405758006",
+    "preferred_name": "Central cervical cord injury, without spinal bony injury, C5-7"
+  },
+  {
+    "sctid": "405759003",
+    "preferred_name": "Cervical spinal cord injury without spinal bone injury"
+  },
+  {
+    "sctid": "405760008",
+    "preferred_name": "Complete cervical cord injury, without spinal bone injury, C1-4"
+  },
+  {
+    "sctid": "405761007",
+    "preferred_name": "Complete cervical cord injury, without spinal bone injury, C5-7"
+  },
+  {
+    "sctid": "405764004",
+    "preferred_name": "Posterior cervical spinal cord injury without spinal bone injury, C5-7"
+  },
+  {
+    "sctid": "405765003",
+    "preferred_name": "Posterior cervical spinal cord injury, without spinal bone injury, C1-4"
+  },
+  {
+    "sctid": "4061000119104",
+    "preferred_name": "Myelomeningocele without hydrocephalus"
+  },
+  {
+    "sctid": "406506008",
+    "preferred_name": "Attention deficit hyperactivity disorder"
+  },
+  {
+    "sctid": "406559005",
+    "preferred_name": "Amebic infection of central nervous system"
+  },
+  {
+    "sctid": "406562008",
+    "preferred_name": "Blastomyces infection of central nervous system"
+  },
+  {
+    "sctid": "406563003",
+    "preferred_name": "Borrelia infection of central nervous system"
+  },
+  {
+    "sctid": "406564009",
+    "preferred_name": "Brucella infection of the central nervous system"
+  },
+  {
+    "sctid": "406566006",
+    "preferred_name": "Chlamydial infection of the central nervous system"
+  },
+  {
+    "sctid": "406567002",
+    "preferred_name": "Coccidioides infection of the central nervous system"
+  },
+  {
+    "sctid": "406568007",
+    "preferred_name": "Coxsackievirus infection of the central nervous system"
+  },
+  {
+    "sctid": "406569004",
+    "preferred_name": "Cryptococcus infection of the central nervous system"
+  },
+  {
+    "sctid": "406570003",
+    "preferred_name": "Cytomegalovirus infection of the central nervous system"
+  },
+  {
+    "sctid": "406571004",
+    "preferred_name": "Echovirus infection of the central nervous system"
+  },
+  {
+    "sctid": "406572006",
+    "preferred_name": "Ehrlichia infection of the central nervous system"
+  },
+  {
+    "sctid": "406573001",
+    "preferred_name": "Primary encephalitis"
+  },
+  {
+    "sctid": "406578005",
+    "preferred_name": "Enterovirus infection of the central nervous system"
+  },
+  {
+    "sctid": "406579002",
+    "preferred_name": "Epstein Barr virus infection of the central nervous system"
+  },
+  {
+    "sctid": "406580004",
+    "preferred_name": "Escherichia coli infection of the central nervous system"
+  },
+  {
+    "sctid": "406581000",
+    "preferred_name": "Gonococcal infection of the central nervous system"
+  },
+  {
+    "sctid": "406582007",
+    "preferred_name": "Haemophilus infection of the central nervous system"
+  },
+  {
+    "sctid": "406586005",
+    "preferred_name": "Herpes virus infection of the central nervous system"
+  },
+  {
+    "sctid": "406587001",
+    "preferred_name": "Histoplasma infection of central nervous system"
+  },
+  {
+    "sctid": "406589003",
+    "preferred_name": "Leptospira infection of the central nervous system"
+  },
+  {
+    "sctid": "406590007",
+    "preferred_name": "Listeria infection of the central nervous system"
+  },
+  {
+    "sctid": "406592004",
+    "preferred_name": "Measles of the central nervous system"
+  },
+  {
+    "sctid": "406594003",
+    "preferred_name": "Mycobacterial infection of the central nervous system"
+  },
+  {
+    "sctid": "406596001",
+    "preferred_name": "Naegleria infection of the central nervous system"
+  },
+  {
+    "sctid": "406598000",
+    "preferred_name": "Parasitic infection of the central nervous system"
+  },
+  {
+    "sctid": "406599008",
+    "preferred_name": "Parvovirus infection of the central nervous system"
+  },
+  {
+    "sctid": "406616008",
+    "preferred_name": "Streptococcus infection of the central nervous system"
+  },
+  {
+    "sctid": "406620007",
+    "preferred_name": "Toxicariasis of the central nervous system"
+  },
+  {
+    "sctid": "40673001",
+    "preferred_name": "Post-encephalitic syndrome"
+  },
+  {
+    "sctid": "4069002",
+    "preferred_name": "Anoxic brain damage during AND/OR resulting from a procedure"
+  },
+  {
+    "sctid": "40700009",
+    "preferred_name": "Severe intellectual disability"
+  },
+  {
+    "sctid": "40720005",
+    "preferred_name": "Cerebral cyst"
+  },
+  {
+    "sctid": "407472000",
+    "preferred_name": "Nairoviral encephalitis"
+  },
+  {
+    "sctid": "407675009",
+    "preferred_name": "Complex partial epileptic seizure"
+  },
+  {
+    "sctid": "40781006",
+    "preferred_name": "Hypopituitarism due to pituitary tumor"
+  },
+  {
+    "sctid": "40816002",
+    "preferred_name": "Retropulsion petit mal"
+  },
+  {
+    "sctid": "4088009",
+    "preferred_name": "Acquired hydrocephalus"
+  },
+  {
+    "sctid": "408856003",
+    "preferred_name": "Autistic disorder"
+  },
+  {
+    "sctid": "408857007",
+    "preferred_name": "Infantile autism"
+  },
+  {
+    "sctid": "408858002",
+    "preferred_name": "Infantile psychosis"
+  },
+  {
+    "sctid": "40926005",
+    "preferred_name": "Moderate mixed bipolar I disorder"
+  },
+  {
+    "sctid": "40946000",
+    "preferred_name": "Hepatic coma due to viral hepatitis"
+  },
+  {
+    "sctid": "40950007",
+    "preferred_name": "Zar"
+  },
+  {
+    "sctid": "409501004",
+    "preferred_name": "Hemorrhagic meningitis"
+  },
+  {
+    "sctid": "409555000",
+    "preferred_name": "Q fever aseptic meningitis"
+  },
+  {
+    "sctid": "409556004",
+    "preferred_name": "Q fever encephalitis"
+  },
+  {
+    "sctid": "40980002",
+    "preferred_name": "Spastic paralysis due to birth injury"
+  },
+  {
+    "sctid": "40987004",
+    "preferred_name": "Intermittent explosive disorder"
+  },
+  {
+    "sctid": "410014007",
+    "preferred_name": "Post-traumatic communicating hydrocephalus"
+  },
+  {
+    "sctid": "410015008",
+    "preferred_name": "Post-traumatic non-communicating hydrocephalus"
+  },
+  {
+    "sctid": "41009006",
+    "preferred_name": "Progressive cerebellar tremor"
+  },
+  {
+    "sctid": "41021005",
+    "preferred_name": "Psychologic dyspareunia"
+  },
+  {
+    "sctid": "41022003",
+    "preferred_name": "Intervertebral disc disorder of thoracic region with myelopathy"
+  },
+  {
+    "sctid": "4103001",
+    "preferred_name": "Complex partial seizure with impairment of consciousness"
+  },
+  {
+    "sctid": "410471004",
+    "preferred_name": "Neuroretinitis"
+  },
+  {
+    "sctid": "410472006",
+    "preferred_name": "Bartonella henselae neuroretinitis"
+  },
+  {
+    "sctid": "41075004",
+    "preferred_name": "Fungal infection of brain"
+  },
+  {
+    "sctid": "41083005",
+    "preferred_name": "Alcohol-induced sleep disorder"
+  },
+  {
+    "sctid": "4113009",
+    "preferred_name": "Arrested hydrocephalus"
+  },
+  {
+    "sctid": "41133002",
+    "preferred_name": "Closed fracture of T7-T12 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "41142009",
+    "preferred_name": "Globoid cell leukodystrophy, late-onset"
+  },
+  {
+    "sctid": "41196008",
+    "preferred_name": "Dhat"
+  },
+  {
+    "sctid": "41222005",
+    "preferred_name": "Brain stem laceration with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "412787009",
+    "preferred_name": "Intellectual disability, congenital heart disease, blepharophimosis, blepharoptosis and hypoplastic teeth"
+  },
+  {
+    "sctid": "413099000",
+    "preferred_name": "Cyst of pineal gland"
+  },
+  {
+    "sctid": "413100008",
+    "preferred_name": "Akinetic rigid syndrome"
+  },
+  {
+    "sctid": "413101007",
+    "preferred_name": "Stress-induced epilepsy"
+  },
+  {
+    "sctid": "413102000",
+    "preferred_name": "Infarction of basal ganglia"
+  },
+  {
+    "sctid": "41362007",
+    "preferred_name": "Ossifying pachymeningitis"
+  },
+  {
+    "sctid": "41370002",
+    "preferred_name": "Myelitis"
+  },
+  {
+    "sctid": "413758000",
+    "preferred_name": "Cardioembolic stroke"
+  },
+  {
+    "sctid": "413807008",
+    "preferred_name": "Cerebellar hernia"
+  },
+  {
+    "sctid": "413808003",
+    "preferred_name": "Cerebral ventriculomegaly"
+  },
+  {
+    "sctid": "413924001",
+    "preferred_name": "Cortical visual impairment"
+  },
+  {
+    "sctid": "414400006",
+    "preferred_name": "Tonsillar hernia into foramen magnum"
+  },
+  {
+    "sctid": "41454003",
+    "preferred_name": "Chronic benign lymphocytic meningitis"
+  },
+  {
+    "sctid": "414667000",
+    "preferred_name": "Meningomyelocele"
+  },
+  {
+    "sctid": "414950005",
+    "preferred_name": "Optic nerve glioma of orbit"
+  },
+  {
+    "sctid": "415035006",
+    "preferred_name": "Paralytic rabies"
+  },
+  {
+    "sctid": "415147002",
+    "preferred_name": "Posterior ischemic optic neuropathy"
+  },
+  {
+    "sctid": "41524005",
+    "preferred_name": "Flagellantism"
+  },
+  {
+    "sctid": "41526007",
+    "preferred_name": "Reactive attachment disorder"
+  },
+  {
+    "sctid": "415347009",
+    "preferred_name": "Rio Bravo viral encephalitis"
+  },
+  {
+    "sctid": "41552001",
+    "preferred_name": "Mild bipolar I disorder, single manic episode"
+  },
+  {
+    "sctid": "415525005",
+    "preferred_name": "Siberian tick-borne encephalitis"
+  },
+  {
+    "sctid": "416073003",
+    "preferred_name": "Long duration flashbacks"
+  },
+  {
+    "sctid": "416154000",
+    "preferred_name": "Measles inclusion body encephalitis"
+  },
+  {
+    "sctid": "416265003",
+    "preferred_name": "Tuberculoma of brain"
+  },
+  {
+    "sctid": "416340002",
+    "preferred_name": "Late onset schizophrenia"
+  },
+  {
+    "sctid": "416351002",
+    "preferred_name": "Intraocular optic nerve glioma"
+  },
+  {
+    "sctid": "416659006",
+    "preferred_name": "Neuroinvasive Venezuelan equine encephalitis virus infection"
+  },
+  {
+    "sctid": "416714005",
+    "preferred_name": "Episodic flashbacks"
+  },
+  {
+    "sctid": "41673007",
+    "preferred_name": "Ataque de nervios"
+  },
+  {
+    "sctid": "416780008",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset"
+  },
+  {
+    "sctid": "416792008",
+    "preferred_name": "Vein of Galen malformation"
+  },
+  {
+    "sctid": "416813006",
+    "preferred_name": "Compressive optic neuropathy due to thyroid eye disease"
+  },
+  {
+    "sctid": "416903004",
+    "preferred_name": "Tuberculoma of spinal cord"
+  },
+  {
+    "sctid": "416913007",
+    "preferred_name": "Toxoplasma neuroretinitis"
+  },
+  {
+    "sctid": "416975007",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset"
+  },
+  {
+    "sctid": "417017003",
+    "preferred_name": "Acute cerebellar syndrome"
+  },
+  {
+    "sctid": "417075004",
+    "preferred_name": "California encephalitis virus infection neuroinvasive disease"
+  },
+  {
+    "sctid": "41713005",
+    "preferred_name": "Benedikt's syndrome"
+  },
+  {
+    "sctid": "417143004",
+    "preferred_name": "Short duration flashbacks"
+  },
+  {
+    "sctid": "417294004",
+    "preferred_name": "Factitious keratitis"
+  },
+  {
+    "sctid": "417360004",
+    "preferred_name": "Duplicative flashbacks"
+  },
+  {
+    "sctid": "417484006",
+    "preferred_name": "Tuberculous abscess of spinal cord"
+  },
+  {
+    "sctid": "417496004",
+    "preferred_name": "Eastern equine encephalitis virus neuroinvasive disease"
+  },
+  {
+    "sctid": "417607009",
+    "preferred_name": "Neuroinvasive St. Louis encephalitis virus infection"
+  },
+  {
+    "sctid": "417619001",
+    "preferred_name": "Intracranial optic nerve glioma"
+  },
+  {
+    "sctid": "417658006",
+    "preferred_name": "Holoanencephaly"
+  },
+  {
+    "sctid": "417872000",
+    "preferred_name": "Neuroinvasive Cache Valley encephalitis virus infection"
+  },
+  {
+    "sctid": "418072004",
+    "preferred_name": "Central nervous system depression"
+  },
+  {
+    "sctid": "418143002",
+    "preferred_name": "Cerebral degeneration"
+  },
+  {
+    "sctid": "41832009",
+    "preferred_name": "Severe bipolar I disorder, single manic episode with psychotic features"
+  },
+  {
+    "sctid": "41836007",
+    "preferred_name": "Bipolar disorder in full remission"
+  },
+  {
+    "sctid": "418455000",
+    "preferred_name": "Encephalitis due to protozoa"
+  },
+  {
+    "sctid": "418480000",
+    "preferred_name": "Eosinophilic meningoencephalitis due to Angiostrongylus cantonensis"
+  },
+  {
+    "sctid": "418531007",
+    "preferred_name": "California serogroup virus neuroinvasive disease"
+  },
+  {
+    "sctid": "41870008",
+    "preferred_name": "Cortex laceration with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "418856006",
+    "preferred_name": "Paraneoplastic optic neuropathy"
+  },
+  {
+    "sctid": "418944009",
+    "preferred_name": "Drug-induced central nervous system depression"
+  },
+  {
+    "sctid": "41932008",
+    "preferred_name": "Amok"
+  },
+  {
+    "sctid": "419868009",
+    "preferred_name": "Encephalitis due to rickettsia"
+  },
+  {
+    "sctid": "420030000",
+    "preferred_name": "Serous macular detachment"
+  },
+  {
+    "sctid": "420090003",
+    "preferred_name": "Neuroinvasive Cache Valley virus disease"
+  },
+  {
+    "sctid": "420146005",
+    "preferred_name": "Cerebral degeneration associated with generalized lipidosis"
+  },
+  {
+    "sctid": "42021008",
+    "preferred_name": "Familial diabetes insipidus"
+  },
+  {
+    "sctid": "420244003",
+    "preferred_name": "Encephalitis associated with AIDS"
+  },
+  {
+    "sctid": "420351005",
+    "preferred_name": "Adult-onset growth hormone deficiency"
+  },
+  {
+    "sctid": "420452002",
+    "preferred_name": "Myelopathy associated with AIDS"
+  },
+  {
+    "sctid": "420499009",
+    "preferred_name": "Hypogonadotropic hypogonadism due to isolated gonadotropin deficiency"
+  },
+  {
+    "sctid": "420554003",
+    "preferred_name": "Progressive multifocal leukoencephalopathy associated with AIDS"
+  },
+  {
+    "sctid": "420585007",
+    "preferred_name": "Meningitis caused by Klebsiella aerogenes"
+  },
+  {
+    "sctid": "420614009",
+    "preferred_name": "Organic dementia associated with AIDS"
+  },
+  {
+    "sctid": "420662003",
+    "preferred_name": "Coma due to diabetes mellitus"
+  },
+  {
+    "sctid": "420675003",
+    "preferred_name": "Supranuclear gaze palsy"
+  },
+  {
+    "sctid": "420718004",
+    "preferred_name": "Central nervous system demyelinating disease associated with AIDS"
+  },
+  {
+    "sctid": "420774007",
+    "preferred_name": "Organic brain syndrome associated with AIDS"
+  },
+  {
+    "sctid": "420788006",
+    "preferred_name": "Primary intraocular non-Hodgkin malignant lymphoma"
+  },
+  {
+    "sctid": "420920007",
+    "preferred_name": "Vitamin B12 deficiency optic neuropathy"
+  },
+  {
+    "sctid": "420996007",
+    "preferred_name": "Coma due to malnutrition-related diabetes mellitus"
+  },
+  {
+    "sctid": "421019006",
+    "preferred_name": "Hypogonadotropic hypogonadism due to follicle-stimulating hormone deficiency"
+  },
+  {
+    "sctid": "421023003",
+    "preferred_name": "Presenile dementia associated with AIDS"
+  },
+  {
+    "sctid": "421075007",
+    "preferred_name": "Ketoacidotic coma due to type 1 diabetes mellitus"
+  },
+  {
+    "sctid": "421283008",
+    "preferred_name": "Primary lymphoma of brain associated with AIDS"
+  },
+  {
+    "sctid": "421315006",
+    "preferred_name": "Myelitis associated with AIDS"
+  },
+  {
+    "sctid": "421415007",
+    "preferred_name": "Subacute adenoviral encephalitis associated with AIDS"
+  },
+  {
+    "sctid": "421437000",
+    "preferred_name": "Hypoglycemic coma due to type 1 diabetes mellitus"
+  },
+  {
+    "sctid": "421529006",
+    "preferred_name": "Dementia associated with AIDS"
+  },
+  {
+    "sctid": "421684006",
+    "preferred_name": "Adult growth hormone deficiency"
+  },
+  {
+    "sctid": "421725003",
+    "preferred_name": "Hypoglycemic coma due to diabetes mellitus"
+  },
+  {
+    "sctid": "421731000",
+    "preferred_name": "Hypertensive optic neuropathy"
+  },
+  {
+    "sctid": "421821002",
+    "preferred_name": "Hypogonadotropic hypogonadism due to luteinizing hormone deficiency"
+  },
+  {
+    "sctid": "421827003",
+    "preferred_name": "Encephalopathy associated with AIDS"
+  },
+  {
+    "sctid": "421847006",
+    "preferred_name": "Ketoacidotic coma due to type 2 diabetes mellitus"
+  },
+  {
+    "sctid": "421931005",
+    "preferred_name": "Adult growth hormone deficiency with onset in childhood"
+  },
+  {
+    "sctid": "421966007",
+    "preferred_name": "Non-ketotic non-hyperosmolar coma due to diabetes mellitus"
+  },
+  {
+    "sctid": "421998001",
+    "preferred_name": "Central nervous disorder associated with AIDS"
+  },
+  {
+    "sctid": "422089004",
+    "preferred_name": "Encephalomyelitis associated with AIDS"
+  },
+  {
+    "sctid": "422126006",
+    "preferred_name": "Hyperosmolar coma due to diabetes mellitus"
+  },
+  {
+    "sctid": "422240004",
+    "preferred_name": "Gonadotropin releasing factor deficiency"
+  },
+  {
+    "sctid": "4223005",
+    "preferred_name": "Parkinsonism due to drug"
+  },
+  {
+    "sctid": "422437002",
+    "preferred_name": "X-linked intellectual disability with marfanoid habitus"
+  },
+  {
+    "sctid": "422474003",
+    "preferred_name": "Partial absence of septum pellucidum"
+  },
+  {
+    "sctid": "422504002",
+    "preferred_name": "Ischemic stroke"
+  },
+  {
+    "sctid": "422513000",
+    "preferred_name": "Epilepsy, not refractory"
+  },
+  {
+    "sctid": "422527005",
+    "preferred_name": "Refractory infantile spasms"
+  },
+  {
+    "sctid": "422724001",
+    "preferred_name": "Refractory localization-related epilepsy"
+  },
+  {
+    "sctid": "422873003",
+    "preferred_name": "Refractory epilepsia partialis continua"
+  },
+  {
+    "sctid": "423086004",
+    "preferred_name": "Simple partial status epilepticus"
+  },
+  {
+    "sctid": "423144007",
+    "preferred_name": "Multifactorial encephalopathy"
+  },
+  {
+    "sctid": "423279000",
+    "preferred_name": "Refractory migraine without aura"
+  },
+  {
+    "sctid": "423341008",
+    "preferred_name": "Optic disc edema"
+  },
+  {
+    "sctid": "423361002",
+    "preferred_name": "Lipoma of dorsal spinal cord"
+  },
+  {
+    "sctid": "42344001",
+    "preferred_name": "Alcohol-induced psychosis"
+  },
+  {
+    "sctid": "423488006",
+    "preferred_name": "Papilledema - optic disc edema due to raised intracranial pressure"
+  },
+  {
+    "sctid": "423582009",
+    "preferred_name": "Traumatic arachnoid cyst"
+  },
+  {
+    "sctid": "42365007",
+    "preferred_name": "Atonic seizure"
+  },
+  {
+    "sctid": "423683008",
+    "preferred_name": "Refractory migraine with aura"
+  },
+  {
+    "sctid": "42369001",
+    "preferred_name": "Pallidopontonigral degeneration"
+  },
+  {
+    "sctid": "423753005",
+    "preferred_name": "Reflex blepharospasm"
+  },
+  {
+    "sctid": "42376006",
+    "preferred_name": "Occipital encephalocele"
+  },
+  {
+    "sctid": "424099008",
+    "preferred_name": "Hepatic coma due to acute hepatitis B"
+  },
+  {
+    "sctid": "424151006",
+    "preferred_name": "Anaplastic glioma of brain"
+  },
+  {
+    "sctid": "424271007",
+    "preferred_name": "Hysterical cataplexy"
+  },
+  {
+    "sctid": "424276002",
+    "preferred_name": "Malignant glioma of brainstem"
+  },
+  {
+    "sctid": "42429001",
+    "preferred_name": "Cerebromeningeal hemorrhage"
+  },
+  {
+    "sctid": "424334007",
+    "preferred_name": "Malignant tumor of spinal cord, intramedullary"
+  },
+  {
+    "sctid": "424340000",
+    "preferred_name": "Hepatic coma due to chronic hepatitis B"
+  },
+  {
+    "sctid": "42440009",
+    "preferred_name": "Partial seizure with illusions and hallucinations"
+  },
+  {
+    "sctid": "424497004",
+    "preferred_name": "Optic disc edema due to hypotony"
+  },
+  {
+    "sctid": "424549003",
+    "preferred_name": "Malignant tumor of spinal cord, extramedullary"
+  },
+  {
+    "sctid": "424669003",
+    "preferred_name": "Optic disc edema associated with retinal disorder"
+  },
+  {
+    "sctid": "424699007",
+    "preferred_name": "Migraine variants, not intractable"
+  },
+  {
+    "sctid": "424728002",
+    "preferred_name": "Prepapillary vascular loop"
+  },
+  {
+    "sctid": "424761009",
+    "preferred_name": "Paraneoplastic encephalomyelitis"
+  },
+  {
+    "sctid": "424911007",
+    "preferred_name": "Paraneoplastic encephalitis"
+  },
+  {
+    "sctid": "425007008",
+    "preferred_name": "Migraine without aura, not refractory"
+  },
+  {
+    "sctid": "425054007",
+    "preferred_name": "Refractory occipital lobe epilepsy"
+  },
+  {
+    "sctid": "425219008",
+    "preferred_name": "Progressive spinal ataxia"
+  },
+  {
+    "sctid": "425237009",
+    "preferred_name": "Refractory frontal lobe epilepsy"
+  },
+  {
+    "sctid": "425349008",
+    "preferred_name": "Refractory parietal lobe epilepsy"
+  },
+  {
+    "sctid": "425365009",
+    "preferred_name": "Refractory migraine variants"
+  },
+  {
+    "sctid": "425390006",
+    "preferred_name": "Dementia associated with Parkinson's Disease"
+  },
+  {
+    "sctid": "425476007",
+    "preferred_name": "Non-organic parasomnia"
+  },
+  {
+    "sctid": "425492002",
+    "preferred_name": "Generalized dystonia"
+  },
+  {
+    "sctid": "425500002",
+    "preferred_name": "Secondary progressive multiple sclerosis"
+  },
+  {
+    "sctid": "425522009",
+    "preferred_name": "Hyperammonemic encephalopathy"
+  },
+  {
+    "sctid": "425561001",
+    "preferred_name": "Neurogenic bladder as late effect of poliomyelitis"
+  },
+  {
+    "sctid": "425576009",
+    "preferred_name": "Traumatic cyst of leptomeninges"
+  },
+  {
+    "sctid": "425687007",
+    "preferred_name": "Spina bifida aperta of cervical spine"
+  },
+  {
+    "sctid": "425756000",
+    "preferred_name": "Idiopathic transverse myelitis"
+  },
+  {
+    "sctid": "425805004",
+    "preferred_name": "Cognitive developmental delay"
+  },
+  {
+    "sctid": "425868004",
+    "preferred_name": "Benign papilloma of choroid plexus"
+  },
+  {
+    "sctid": "425887005",
+    "preferred_name": "Bacterial meningitis due to Gram-negative bacteria"
+  },
+  {
+    "sctid": "425914008",
+    "preferred_name": "Adjustment reaction to medical therapy"
+  },
+  {
+    "sctid": "425919003",
+    "preferred_name": "Chronic organic mental disorder"
+  },
+  {
+    "sctid": "425936006",
+    "preferred_name": "Intractable ophthalmic migraine"
+  },
+  {
+    "sctid": "42594001",
+    "preferred_name": "Organic mood disorder of depressed type"
+  },
+  {
+    "sctid": "425957003",
+    "preferred_name": "Non-traumatic intracerebral ventricular hemorrhage"
+  },
+  {
+    "sctid": "4260009",
+    "preferred_name": "Sacral spinal cord injury without bone injury"
+  },
+  {
+    "sctid": "426055002",
+    "preferred_name": "Spinal arachnoiditis"
+  },
+  {
+    "sctid": "426107000",
+    "preferred_name": "Acute lacunar infarction"
+  },
+  {
+    "sctid": "426128009",
+    "preferred_name": "Lymphomatous meningitis"
+  },
+  {
+    "sctid": "426174008",
+    "preferred_name": "Chronic stress disorder"
+  },
+  {
+    "sctid": "4262001",
+    "preferred_name": "Phlebitis of superior sagittal sinus"
+  },
+  {
+    "sctid": "426266003",
+    "preferred_name": "Post-infective myelitis"
+  },
+  {
+    "sctid": "426373005",
+    "preferred_name": "Relapsing remitting multiple sclerosis"
+  },
+  {
+    "sctid": "426399003",
+    "preferred_name": "Epidural lipomatosis"
+  },
+  {
+    "sctid": "426470009",
+    "preferred_name": "Lipoma of terminal spinal cord"
+  },
+  {
+    "sctid": "426510004",
+    "preferred_name": "Schwannoma of spinal cord"
+  },
+  {
+    "sctid": "426566004",
+    "preferred_name": "Central pain syndrome"
+  },
+  {
+    "sctid": "426578000",
+    "preferred_name": "Premenstrual dysphoric disorder in remission"
+  },
+  {
+    "sctid": "426599002",
+    "preferred_name": "Myelitis due to herpes simplex"
+  },
+  {
+    "sctid": "426881004",
+    "preferred_name": "Developmental delay in feeding"
+  },
+  {
+    "sctid": "426983002",
+    "preferred_name": "Infarction of medulla oblongata"
+  },
+  {
+    "sctid": "427086003",
+    "preferred_name": "Bickerstaff's brainstem encephalitis"
+  },
+  {
+    "sctid": "427145007",
+    "preferred_name": "Articulation disorder due to hyperkinesis"
+  },
+  {
+    "sctid": "427216002",
+    "preferred_name": "Spina bifida aperta of thoracic spine"
+  },
+  {
+    "sctid": "427232004",
+    "preferred_name": "Hemidystonia"
+  },
+  {
+    "sctid": "427296003",
+    "preferred_name": "Thalamic infarction"
+  },
+  {
+    "sctid": "427411009",
+    "preferred_name": "Acquired pseudomeningocele"
+  },
+  {
+    "sctid": "427469003",
+    "preferred_name": "Eating disorder in remission"
+  },
+  {
+    "sctid": "427488005",
+    "preferred_name": "On - off phenomenon"
+  },
+  {
+    "sctid": "42769004",
+    "preferred_name": "Diffuse Lewy body disease with spongiform cortical change"
+  },
+  {
+    "sctid": "427758000",
+    "preferred_name": "Cerebrospinal fluid leak from mouth"
+  },
+  {
+    "sctid": "427787004",
+    "preferred_name": "Abscess in epidural space of cervical spine"
+  },
+  {
+    "sctid": "427796004",
+    "preferred_name": "Encephalitis due to human herpes simplex virus"
+  },
+  {
+    "sctid": "427916006",
+    "preferred_name": "Abscess in epidural space of thoracic spine"
+  },
+  {
+    "sctid": "427939000",
+    "preferred_name": "Benign neoplasm of spinal extradural space"
+  },
+  {
+    "sctid": "427945008",
+    "preferred_name": "Segmental dystonia"
+  },
+  {
+    "sctid": "427975003",
+    "preferred_name": "Drug-induced delusional disorder"
+  },
+  {
+    "sctid": "428051000124108",
+    "preferred_name": "Mild dementia"
+  },
+  {
+    "sctid": "428061005",
+    "preferred_name": "Malignant neoplasm of brain"
+  },
+  {
+    "sctid": "42810003",
+    "preferred_name": "Major depression in remission"
+  },
+  {
+    "sctid": "428175000",
+    "preferred_name": "Primary amebic encephalitis due to Naegleria fowleri"
+  },
+  {
+    "sctid": "428241007",
+    "preferred_name": "Intraventricular hemorrhage of fetus"
+  },
+  {
+    "sctid": "428259005",
+    "preferred_name": "Acquired tethered cord syndrome"
+  },
+  {
+    "sctid": "428268007",
+    "preferred_name": "Extradural intracranial hematoma"
+  },
+  {
+    "sctid": "428351000124105",
+    "preferred_name": "Severe dementia"
+  },
+  {
+    "sctid": "428544003",
+    "preferred_name": "Abscess of medulla oblongata"
+  },
+  {
+    "sctid": "428561000",
+    "preferred_name": "Occipital subdural hematoma"
+  },
+  {
+    "sctid": "428635007",
+    "preferred_name": "Primary viral encephalitis"
+  },
+  {
+    "sctid": "428638009",
+    "preferred_name": "Encephalitis due to Herpesviridae"
+  },
+  {
+    "sctid": "42868002",
+    "preferred_name": "Subchronic catatonic schizophrenia"
+  },
+  {
+    "sctid": "428687006",
+    "preferred_name": "Nightmares associated with chronic post-traumatic stress disorder"
+  },
+  {
+    "sctid": "428700003",
+    "preferred_name": "Primary progressive multiple sclerosis"
+  },
+  {
+    "sctid": "428703001",
+    "preferred_name": "Transient organic mental disorder"
+  },
+  {
+    "sctid": "428753007",
+    "preferred_name": "Low grade glioma of cerebellum"
+  },
+  {
+    "sctid": "428960009",
+    "preferred_name": "Low grade glioma of brainstem"
+  },
+  {
+    "sctid": "428964000",
+    "preferred_name": "Low grade glioma of cerebrum"
+  },
+  {
+    "sctid": "428965004",
+    "preferred_name": "Low grade glioma of thalamus"
+  },
+  {
+    "sctid": "429033009",
+    "preferred_name": "Malignant neoplasm of cerebrum"
+  },
+  {
+    "sctid": "429161000124103",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset, with behavioral disturbance"
+  },
+  {
+    "sctid": "429171000124105",
+    "preferred_name": "Seizures in the newborn, refractory"
+  },
+  {
+    "sctid": "42925002",
+    "preferred_name": "Major depressive disorder, single episode with atypical features"
+  },
+  {
+    "sctid": "429271000124103",
+    "preferred_name": "Chronic hypoxic-ischemic brain injury"
+  },
+  {
+    "sctid": "429297003",
+    "preferred_name": "Acute nonparalytic poliomyelitis due to human poliovirus 1"
+  },
+  {
+    "sctid": "429306002",
+    "preferred_name": "Benign neoplasm of spinal intradural intramedullary space"
+  },
+  {
+    "sctid": "429408002",
+    "preferred_name": "Low grade glioma of brain"
+  },
+  {
+    "sctid": "429436007",
+    "preferred_name": "Post-immunization myelitis"
+  },
+  {
+    "sctid": "429437003",
+    "preferred_name": "Abscess in epidural space of lumbar spine"
+  },
+  {
+    "sctid": "429458009",
+    "preferred_name": "Dementia due to Creutzfeldt Jakob disease"
+  },
+  {
+    "sctid": "429466000",
+    "preferred_name": "Spina bifida aperta of lumbar spine"
+  },
+  {
+    "sctid": "429514007",
+    "preferred_name": "Growth hormone deficiency after bone marrow transplant"
+  },
+  {
+    "sctid": "429565004",
+    "preferred_name": "Germ cell tumor of the brain"
+  },
+  {
+    "sctid": "429571005",
+    "preferred_name": "Sleep-related dissociative disorder"
+  },
+  {
+    "sctid": "429672007",
+    "preferred_name": "Mood disorder caused by drug"
+  },
+  {
+    "sctid": "429691007",
+    "preferred_name": "Benign neoplasm of intradural space of spine"
+  },
+  {
+    "sctid": "429741000124103",
+    "preferred_name": "Basilar meningitis"
+  },
+  {
+    "sctid": "429743002",
+    "preferred_name": "Occipital extradural hematoma"
+  },
+  {
+    "sctid": "429759002",
+    "preferred_name": "Cerebrospinal fluid leak from nose and mouth"
+  },
+  {
+    "sctid": "429765002",
+    "preferred_name": "Benign neoplasm of medulla oblongata"
+  },
+  {
+    "sctid": "429831000124100",
+    "preferred_name": "Cerebellar artery embolism"
+  },
+  {
+    "sctid": "429841000124105",
+    "preferred_name": "Superior cerebellar artery embolism"
+  },
+  {
+    "sctid": "429851000124107",
+    "preferred_name": "Anterior inferior cerebellar artery embolism"
+  },
+  {
+    "sctid": "429861000124109",
+    "preferred_name": "Posterior inferior cerebellar artery embolism"
+  },
+  {
+    "sctid": "429998004",
+    "preferred_name": "Vascular dementia"
+  },
+  {
+    "sctid": "430051000124107",
+    "preferred_name": "Meningoencephalitis caused by virus"
+  },
+  {
+    "sctid": "430061000124109",
+    "preferred_name": "Early myoclonic encephalopathy, refractory"
+  },
+  {
+    "sctid": "430071000124102",
+    "preferred_name": "Early myoclonic encephalopathy, non-refractory"
+  },
+  {
+    "sctid": "43019009",
+    "preferred_name": "Nelson syndrome"
+  },
+  {
+    "sctid": "430399004",
+    "preferred_name": "Histoplasmosis of spinal cord"
+  },
+  {
+    "sctid": "430404002",
+    "preferred_name": "Intramedullary abscess of spinal cord due to Histoplasma"
+  },
+  {
+    "sctid": "4306003",
+    "preferred_name": "Cluster B personality disorder"
+  },
+  {
+    "sctid": "430744005",
+    "preferred_name": "Factitious disorder with predominantly physical signs and symptoms"
+  },
+  {
+    "sctid": "430751001",
+    "preferred_name": "Factitious disorder with predominantly psychological signs and symptoms"
+  },
+  {
+    "sctid": "430771000124100",
+    "preferred_name": "Moderate dementia"
+  },
+  {
+    "sctid": "430811000124100",
+    "preferred_name": "Benign familial neonatal seizures, refractory"
+  },
+  {
+    "sctid": "430821000124108",
+    "preferred_name": "Benign familial neonatal seizures, non-refractory"
+  },
+  {
+    "sctid": "430852001",
+    "preferred_name": "Severe major depression, single episode, with psychotic features"
+  },
+  {
+    "sctid": "430871000124109",
+    "preferred_name": "Seizures in the newborn, non-refractory"
+  },
+  {
+    "sctid": "430909002",
+    "preferred_name": "Conduct disorder"
+  },
+  {
+    "sctid": "430947007",
+    "preferred_name": "Paralytic syndrome of nondominant side as late effect of stroke"
+  },
+  {
+    "sctid": "430959006",
+    "preferred_name": "Paralytic syndrome of dominant side as late effect of stroke"
+  },
+  {
+    "sctid": "43100002",
+    "preferred_name": "Late cortical cerebellar atrophy"
+  },
+  {
+    "sctid": "431034009",
+    "preferred_name": "Torsion dystonia"
+  },
+  {
+    "sctid": "43105007",
+    "preferred_name": "Choreoathetosis"
+  },
+  {
+    "sctid": "431071000124107",
+    "preferred_name": "Early infantile epileptic encephalopathy, refractory"
+  },
+  {
+    "sctid": "431081000124105",
+    "preferred_name": "Early infantile epileptic encephalopathy, non-refractory"
+  },
+  {
+    "sctid": "431091000124108",
+    "preferred_name": "Benign myoclonic epilepsy in infancy, refractory"
+  },
+  {
+    "sctid": "431101000124102",
+    "preferred_name": "Benign myoclonic epilepsy in infancy, non-refractory"
+  },
+  {
+    "sctid": "431111000124104",
+    "preferred_name": "Lennox-Gastaut syndrome, refractory"
+  },
+  {
+    "sctid": "431121000124107",
+    "preferred_name": "Lennox-Gastaut syndrome, non-refractory"
+  },
+  {
+    "sctid": "431131000124105",
+    "preferred_name": "Myoclonic absence epilepsy, refractory"
+  },
+  {
+    "sctid": "431141000124100",
+    "preferred_name": "Myoclonic absence epilepsy, non-refractory"
+  },
+  {
+    "sctid": "431151000124103",
+    "preferred_name": "Childhood absence epilepsy, refractory"
+  },
+  {
+    "sctid": "431161000124101",
+    "preferred_name": "Childhood absence epilepsy, non-refractory"
+  },
+  {
+    "sctid": "431266005",
+    "preferred_name": "Intraparenchymal hematoma of brain"
+  },
+  {
+    "sctid": "431461000124109",
+    "preferred_name": "Juvenile absence epilepsy, refractory"
+  },
+  {
+    "sctid": "431468008",
+    "preferred_name": "Slit ventricle syndrome"
+  },
+  {
+    "sctid": "431471000124102",
+    "preferred_name": "Juvenile absence epilepsy, non-refractory"
+  },
+  {
+    "sctid": "43150009",
+    "preferred_name": "Panic disorder without agoraphobia with severe panic attacks"
+  },
+  {
+    "sctid": "431520004",
+    "preferred_name": "Inflammation of spinal cord due to toxin"
+  },
+  {
+    "sctid": "431641000124107",
+    "preferred_name": "Hereditary cerebellar atrophy"
+  },
+  {
+    "sctid": "431769004",
+    "preferred_name": "Disorder of optic chiasm due to neoplasm"
+  },
+  {
+    "sctid": "431961000124104",
+    "preferred_name": "Benign occipital epilepsy of childhood - late onset, refractory"
+  },
+  {
+    "sctid": "431971000124106",
+    "preferred_name": "Benign occipital epilepsy of childhood - late onset, non-refractory"
+  },
+  {
+    "sctid": "431991000124107",
+    "preferred_name": "Petit mal status, non-refractory"
+  },
+  {
+    "sctid": "432001000124109",
+    "preferred_name": "Migrating partial seizures in infancy"
+  },
+  {
+    "sctid": "432011000124107",
+    "preferred_name": "Migrating partial seizures in infancy, refractory"
+  },
+  {
+    "sctid": "432021000124104",
+    "preferred_name": "Migrating partial seizures in infancy, non-refractory"
+  },
+  {
+    "sctid": "432031000124101",
+    "preferred_name": "Infantile spasms, non-refractory"
+  },
+  {
+    "sctid": "432091002",
+    "preferred_name": "Savant syndrome"
+  },
+  {
+    "sctid": "432141000124105",
+    "preferred_name": "Central visual impairment"
+  },
+  {
+    "sctid": "432151000124107",
+    "preferred_name": "Myoclonic seizure, non-refractory"
+  },
+  {
+    "sctid": "432161000124109",
+    "preferred_name": "Severe myoclonic epilepsy in infancy, non-refractory"
+  },
+  {
+    "sctid": "432171000124102",
+    "preferred_name": "Severe myoclonic epilepsy in infancy, refractory"
+  },
+  {
+    "sctid": "432241000124101",
+    "preferred_name": "Typical absence seizure"
+  },
+  {
+    "sctid": "432249006",
+    "preferred_name": "Infarction of spinal cord"
+  },
+  {
+    "sctid": "432271000124109",
+    "preferred_name": "Tonic seizures, refractory"
+  },
+  {
+    "sctid": "432281000124107",
+    "preferred_name": "Tonic seizures, non-refractory"
+  },
+  {
+    "sctid": "432291000124105",
+    "preferred_name": "Temporal lobe epilepsy, non-refractory"
+  },
+  {
+    "sctid": "432451000124103",
+    "preferred_name": "Multiphasic acute disseminated encephalomyelitis"
+  },
+  {
+    "sctid": "432461000124101",
+    "preferred_name": "Post-traumatic epilepsy, refractory"
+  },
+  {
+    "sctid": "432471000124108",
+    "preferred_name": "Post-traumatic epilepsy, non-refractory"
+  },
+  {
+    "sctid": "432501000124101",
+    "preferred_name": "Atonic seizure, refractory"
+  },
+  {
+    "sctid": "432504007",
+    "preferred_name": "Cerebral infarction"
+  },
+  {
+    "sctid": "432511000124103",
+    "preferred_name": "Atonic seizure, non-refractory"
+  },
+  {
+    "sctid": "432521000124106",
+    "preferred_name": "Bilateral optic neuritis"
+  },
+  {
+    "sctid": "432541000124104",
+    "preferred_name": "Epilepsia partialis continua, non-refractory"
+  },
+  {
+    "sctid": "432561000124100",
+    "preferred_name": "Typical absence seizure, non-refractory"
+  },
+  {
+    "sctid": "432571000124107",
+    "preferred_name": "Typical absence seizure, refractory"
+  },
+  {
+    "sctid": "432616009",
+    "preferred_name": "Infection of ventriculoperitoneal shunt"
+  },
+  {
+    "sctid": "43262000",
+    "preferred_name": "Subdural hemorrhage following injury with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "433493000",
+    "preferred_name": "Acquired torsion dystonia"
+  },
+  {
+    "sctid": "433691000124104",
+    "preferred_name": "Intracranial hypotension"
+  },
+  {
+    "sctid": "433891000124100",
+    "preferred_name": "Cerebral infarction due to cerebral artery occlusion"
+  },
+  {
+    "sctid": "433911000124103",
+    "preferred_name": "Cerebral infarction due to posterior cerebral artery occlusion"
+  },
+  {
+    "sctid": "433931000124109",
+    "preferred_name": "Cerebral infarction due to internal carotid artery occlusion"
+  },
+  {
+    "sctid": "433961000124100",
+    "preferred_name": "Cerebral infarction due to cerebral venous thrombosis"
+  },
+  {
+    "sctid": "43405004",
+    "preferred_name": "Open fracture of C5-C7 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "434141000124103",
+    "preferred_name": "Chronic cerebrovascular accident"
+  },
+  {
+    "sctid": "434151000124101",
+    "preferred_name": "Cerebral infarction due to anterior cerebral artery occlusion"
+  },
+  {
+    "sctid": "434201000124105",
+    "preferred_name": "Grand mal status epilepticus, refractory"
+  },
+  {
+    "sctid": "434211000124108",
+    "preferred_name": "Grand mal status epilepticus, non-refractory"
+  },
+  {
+    "sctid": "43427008",
+    "preferred_name": "Ectopic glial tissue"
+  },
+  {
+    "sctid": "434291000124103",
+    "preferred_name": "Myoclonic seizure, refractory"
+  },
+  {
+    "sctid": "434311000124104",
+    "preferred_name": "Acute cerebellar ataxia"
+  },
+  {
+    "sctid": "434321000124107",
+    "preferred_name": "Clinically isolated syndrome of brainstem"
+  },
+  {
+    "sctid": "434371000124108",
+    "preferred_name": "Chronic myelopathy"
+  },
+  {
+    "sctid": "434451000124105",
+    "preferred_name": "Acute tic disorder"
+  },
+  {
+    "sctid": "434491000124104",
+    "preferred_name": "Idiopathic generalized epilepsy, non-refractory"
+  },
+  {
+    "sctid": "434501000124107",
+    "preferred_name": "Complex partial status epilepticus, refractory"
+  },
+  {
+    "sctid": "434511000124105",
+    "preferred_name": "Complex partial status epilepticus, non-refractory"
+  },
+  {
+    "sctid": "434521000124102",
+    "preferred_name": "Atypical absence seizure, refractory"
+  },
+  {
+    "sctid": "434531000124104",
+    "preferred_name": "Atypical absence seizure, non-refractory"
+  },
+  {
+    "sctid": "434541000124109",
+    "preferred_name": "Benign childhood epilepsy with centrotemporal spikes, refractory"
+  },
+  {
+    "sctid": "434551000124106",
+    "preferred_name": "Benign childhood epilepsy with centrotemporal spikes, non-refractory"
+  },
+  {
+    "sctid": "43486001",
+    "preferred_name": "Hemiplegic cerebral palsy"
+  },
+  {
+    "sctid": "434961000124102",
+    "preferred_name": "Cerebral infarction due to middle cerebral artery occlusion"
+  },
+  {
+    "sctid": "43497001",
+    "preferred_name": "Amphetamine-induced mood disorder"
+  },
+  {
+    "sctid": "434991000124105",
+    "preferred_name": "Cerebral infarction due to basilar artery stenosis"
+  },
+  {
+    "sctid": "435091000124105",
+    "preferred_name": "Hepatitis with hepatic coma"
+  },
+  {
+    "sctid": "435101000124104",
+    "preferred_name": "Chronic viral hepatitis C with hepatic coma"
+  },
+  {
+    "sctid": "43532007",
+    "preferred_name": "Hereditary oculoleptomeningeal amyloid angiopathy"
+  },
+  {
+    "sctid": "435321000124106",
+    "preferred_name": "Acquired epileptic aphasia, non-refractory"
+  },
+  {
+    "sctid": "435331000124109",
+    "preferred_name": "Acquired epileptic aphasia, refractory"
+  },
+  {
+    "sctid": "435341000124104",
+    "preferred_name": "Rasmussen syndrome, refractory"
+  },
+  {
+    "sctid": "435361000124100",
+    "preferred_name": "Juvenile myoclonic epilepsy, non-refractory"
+  },
+  {
+    "sctid": "43568002",
+    "preferred_name": "Bipolar II disorder, most recent episode major depressive with atypical features"
+  },
+  {
+    "sctid": "436001000124105",
+    "preferred_name": "Insomnia due to anxiety and fear"
+  },
+  {
+    "sctid": "436011000124108",
+    "preferred_name": "Petit mal status, refractory"
+  },
+  {
+    "sctid": "43602006",
+    "preferred_name": "Subdural hemorrhage in fetus or newborn"
+  },
+  {
+    "sctid": "436031000124102",
+    "preferred_name": "Anterior inferior cerebellar artery occlusion with infarction"
+  },
+  {
+    "sctid": "436041000124107",
+    "preferred_name": "Posterior inferior cerebellar artery occlusion with infarction"
+  },
+  {
+    "sctid": "436051000124109",
+    "preferred_name": "Simple partial status epilepticus, non-refractory"
+  },
+  {
+    "sctid": "43614003",
+    "preferred_name": "Autistic disorder of childhood onset"
+  },
+  {
+    "sctid": "43647007",
+    "preferred_name": "Juvenile paralysis agitans of Hunt"
+  },
+  {
+    "sctid": "436591000124109",
+    "preferred_name": "Thrombophlebitis of superior anastomotic vein"
+  },
+  {
+    "sctid": "436601000124101",
+    "preferred_name": "Simple partial seizure with motor dysfunction, refractory"
+  },
+  {
+    "sctid": "436611000124103",
+    "preferred_name": "Simple partial seizure with motor dysfunction, non-refractory"
+  },
+  {
+    "sctid": "436771000124102",
+    "preferred_name": "Basilar artery migraine, refractory"
+  },
+  {
+    "sctid": "43769008",
+    "preferred_name": "Mild mixed bipolar I disorder"
+  },
+  {
+    "sctid": "437931000124100",
+    "preferred_name": "Chronic migraine without aura, non-refractory"
+  },
+  {
+    "sctid": "438411000124101",
+    "preferred_name": "Myoclonic astatic epilepsy, refractory"
+  },
+  {
+    "sctid": "438421000124109",
+    "preferred_name": "Myoclonic astatic epilepsy, non-refractory"
+  },
+  {
+    "sctid": "438481007",
+    "preferred_name": "Postoperative tethered cord syndrome"
+  },
+  {
+    "sctid": "438511000",
+    "preferred_name": "Benign multiple sclerosis"
+  },
+  {
+    "sctid": "438513002",
+    "preferred_name": "Cerebral degeneration due to Parkinson's disease"
+  },
+  {
+    "sctid": "438583008",
+    "preferred_name": "Congenital bilateral perisylvian syndrome"
+  },
+  {
+    "sctid": "439567002",
+    "preferred_name": "Malignant multiple sclerosis"
+  },
+  {
+    "sctid": "439732004",
+    "preferred_name": "Myoclonic dystonia"
+  },
+  {
+    "sctid": "43977004",
+    "preferred_name": "Corticostriatal-spinal degeneration"
+  },
+  {
+    "sctid": "440211000124100",
+    "preferred_name": "Generalized convulsive epilepsy, non-refractory"
+  },
+  {
+    "sctid": "44031002",
+    "preferred_name": "Postseizure confusion"
+  },
+  {
+    "sctid": "44124003",
+    "preferred_name": "Reactive attachment disorder of early childhood"
+  },
+  {
+    "sctid": "44145005",
+    "preferred_name": "Benign Rolandic epilepsy"
+  },
+  {
+    "sctid": "441460004",
+    "preferred_name": "Cysticercosis of brain"
+  },
+  {
+    "sctid": "441512004",
+    "preferred_name": "Encephalitis due to human herpesvirus 6 infection"
+  },
+  {
+    "sctid": "441526008",
+    "preferred_name": "Infarct of cerebrum due to iatrogenic cerebrovascular accident"
+  },
+  {
+    "sctid": "441678004",
+    "preferred_name": "Refractory generalized nonconvulsive epilepsy"
+  },
+  {
+    "sctid": "441704009",
+    "preferred_name": "Affective psychosis"
+  },
+  {
+    "sctid": "441711008",
+    "preferred_name": "Chronic psychogenic pain"
+  },
+  {
+    "sctid": "441716003",
+    "preferred_name": "Residual childhood psychosis"
+  },
+  {
+    "sctid": "441717007",
+    "preferred_name": "Hemiplegia of nondominant side"
+  },
+  {
+    "sctid": "441719005",
+    "preferred_name": "Speech and language developmental delay due to hearing loss"
+  },
+  {
+    "sctid": "441722007",
+    "preferred_name": "Spastic hemiplegia of nondominant side"
+  },
+  {
+    "sctid": "441806004",
+    "preferred_name": "Abscess of brain"
+  },
+  {
+    "sctid": "441833000",
+    "preferred_name": "Lethal catatonia"
+  },
+  {
+    "sctid": "441892008",
+    "preferred_name": "Spastic hemiplegia of dominant side"
+  },
+  {
+    "sctid": "441991000",
+    "preferred_name": "Hemiparesis as late effect of cerebrovascular accident"
+  },
+  {
+    "sctid": "442001",
+    "preferred_name": "Secondary hypopituitarism"
+  },
+  {
+    "sctid": "44201003",
+    "preferred_name": "Mumps meningitis"
+  },
+  {
+    "sctid": "442020005",
+    "preferred_name": "Flaccid hemiplegia of dominant side"
+  },
+  {
+    "sctid": "442024001",
+    "preferred_name": "Hemiplegia as late effect of cerebrovascular disease"
+  },
+  {
+    "sctid": "442057004",
+    "preferred_name": "Chronic depressive personality disorder"
+  },
+  {
+    "sctid": "442077006",
+    "preferred_name": "Flaccid hemiplegia of nondominant side"
+  },
+  {
+    "sctid": "442151000124108",
+    "preferred_name": "Autosomal dominant nocturnal frontal lobe epilepsy, refractory"
+  },
+  {
+    "sctid": "442155009",
+    "preferred_name": "Hemiplegia of dominant side"
+  },
+  {
+    "sctid": "442161000124105",
+    "preferred_name": "Autosomal dominant nocturnal frontal lobe epilepsy, non-refractory"
+  },
+  {
+    "sctid": "442212003",
+    "preferred_name": "Residual cognitive deficit as late effect of cerebrovascular accident"
+  },
+  {
+    "sctid": "442243005",
+    "preferred_name": "Psychosexual dysfunction associated with inhibited libido"
+  },
+  {
+    "sctid": "442245003",
+    "preferred_name": "Chronic hypomanic personality disorder"
+  },
+  {
+    "sctid": "442300000",
+    "preferred_name": "Rhombencephalosynapsis"
+  },
+  {
+    "sctid": "442314000",
+    "preferred_name": "Active but odd autism"
+  },
+  {
+    "sctid": "442344002",
+    "preferred_name": "Dementia due to Huntington chorea"
+  },
+  {
+    "sctid": "442351006",
+    "preferred_name": "Mental disorder due to drug"
+  },
+  {
+    "sctid": "44248001",
+    "preferred_name": "Raymond-Cestan syndrome"
+  },
+  {
+    "sctid": "442481002",
+    "preferred_name": "Epilepsy characterized by intractable complex partial seizures"
+  },
+  {
+    "sctid": "442511009",
+    "preferred_name": "Progressive encephalopathy with edema, hypsarrhythmia and optic atrophy syndrome"
+  },
+  {
+    "sctid": "442512002",
+    "preferred_name": "Nonconvulsive status epilepticus"
+  },
+  {
+    "sctid": "442536003",
+    "preferred_name": "Fungal infection of cerebrum"
+  },
+  {
+    "sctid": "442668000",
+    "preferred_name": "Hemiplegia of nondominant side as late effect of cerebrovascular disease"
+  },
+  {
+    "sctid": "442676003",
+    "preferred_name": "Hemiplegia of dominant side as late effect of cerebrovascular disease"
+  },
+  {
+    "sctid": "442733008",
+    "preferred_name": "Hemiplegia as late effect of cerebrovascular accident"
+  },
+  {
+    "sctid": "44295002",
+    "preferred_name": "Congenital coloboma of optic disc"
+  },
+  {
+    "sctid": "442964000",
+    "preferred_name": "Conus medullaris syndrome"
+  },
+  {
+    "sctid": "443153007",
+    "preferred_name": "Toxic encephalomyelitis"
+  },
+  {
+    "sctid": "443265004",
+    "preferred_name": "Cognitive disorder"
+  },
+  {
+    "sctid": "443333004",
+    "preferred_name": "Medulloblastoma"
+  },
+  {
+    "sctid": "443352005",
+    "preferred_name": "Cranial dystonia"
+  },
+  {
+    "sctid": "443735008",
+    "preferred_name": "Nonverbal learning disorder"
+  },
+  {
+    "sctid": "44376007",
+    "preferred_name": "Dissociative disorder"
+  },
+  {
+    "sctid": "443853005",
+    "preferred_name": "Psychogenic tremor"
+  },
+  {
+    "sctid": "443919007",
+    "preferred_name": "Complex posttraumatic stress disorder"
+  },
+  {
+    "sctid": "44395000",
+    "preferred_name": "Spastic tetraplegia with rigidity syndrome"
+  },
+  {
+    "sctid": "444024002",
+    "preferred_name": "Multiple system atrophy, cerebellar variant"
+  },
+  {
+    "sctid": "4441000",
+    "preferred_name": "Severe bipolar disorder with psychotic features"
+  },
+  {
+    "sctid": "444197004",
+    "preferred_name": "Multiple system atrophy, Parkinson's variant"
+  },
+  {
+    "sctid": "44423001",
+    "preferred_name": "Early myoclonic encephalopathy"
+  },
+  {
+    "sctid": "44433009",
+    "preferred_name": "Recurrent transient tic disorder"
+  },
+  {
+    "sctid": "44434003",
+    "preferred_name": "Closed fracture of thoracic region with spinal cord injury"
+  },
+  {
+    "sctid": "444441000124109",
+    "preferred_name": "Generalized epilepsy with febrile seizures plus, refractory"
+  },
+  {
+    "sctid": "444451000124106",
+    "preferred_name": "Generalized epilepsy with febrile seizures plus, non-refractory"
+  },
+  {
+    "sctid": "444545003",
+    "preferred_name": "Glioma of brainstem"
+  },
+  {
+    "sctid": "444613000",
+    "preferred_name": "Adult attention deficit hyperactivity disorder"
+  },
+  {
+    "sctid": "444657001",
+    "preferred_name": "Superior cerebellar artery syndrome"
+  },
+  {
+    "sctid": "444860006",
+    "preferred_name": "Meningomyelocele of lumbosacral spine"
+  },
+  {
+    "sctid": "444957003",
+    "preferred_name": "Bacterial meningomyelitis"
+  },
+  {
+    "sctid": "444978000",
+    "preferred_name": "Meningocele of vertex"
+  },
+  {
+    "sctid": "444980006",
+    "preferred_name": "Sporadic olivopontocerebellar atrophy"
+  },
+  {
+    "sctid": "445006008",
+    "preferred_name": "Focal dystonia"
+  },
+  {
+    "sctid": "445014002",
+    "preferred_name": "Paraneoplastic limbic encephalitis"
+  },
+  {
+    "sctid": "445059005",
+    "preferred_name": "Meningitis due to anaerobic bacteria"
+  },
+  {
+    "sctid": "445116003",
+    "preferred_name": "Encephalocele of vertex"
+  },
+  {
+    "sctid": "445135003",
+    "preferred_name": "Angiomatosis of meninges"
+  },
+  {
+    "sctid": "445151006",
+    "preferred_name": "Subarachnoid intracranial abscess"
+  },
+  {
+    "sctid": "445158000",
+    "preferred_name": "Colloid cyst of pituitary gland"
+  },
+  {
+    "sctid": "445166009",
+    "preferred_name": "Cystic degeneration of brain"
+  },
+  {
+    "sctid": "445198003",
+    "preferred_name": "Meningitis due to Haemophilus influenzae type B"
+  },
+  {
+    "sctid": "445252005",
+    "preferred_name": "Glucose transporter protein type 1 deficiency syndrome"
+  },
+  {
+    "sctid": "445308004",
+    "preferred_name": "Split cord malformation"
+  },
+  {
+    "sctid": "445322004",
+    "preferred_name": "Migraine variant with headache"
+  },
+  {
+    "sctid": "445355009",
+    "preferred_name": "Refractory epilepsy"
+  },
+  {
+    "sctid": "445359003",
+    "preferred_name": "Bacterial meningoencephalitis"
+  },
+  {
+    "sctid": "445423005",
+    "preferred_name": "Paraneoplastic subacute necrotic myelopathy"
+  },
+  {
+    "sctid": "445468002",
+    "preferred_name": "Occipital meningocele"
+  },
+  {
+    "sctid": "445779008",
+    "preferred_name": "Traumatic injury of spinal cord at T7-T12 level"
+  },
+  {
+    "sctid": "445897006",
+    "preferred_name": "Incomplete transverse lesion of thoracic spinal cord"
+  },
+  {
+    "sctid": "445967004",
+    "preferred_name": "Clinically isolated syndrome"
+  },
+  {
+    "sctid": "446175003",
+    "preferred_name": "Acute posttraumatic stress disorder following military combat"
+  },
+  {
+    "sctid": "446180007",
+    "preferred_name": "Delayed posttraumatic stress disorder following military combat"
+  },
+  {
+    "sctid": "44621005",
+    "preferred_name": "Congenital anomaly of organ of Corti"
+  },
+  {
+    "sctid": "446311006",
+    "preferred_name": "Acute bulbar poliomyelitis due to Human poliovirus 2"
+  },
+  {
+    "sctid": "446312004",
+    "preferred_name": "Acute poliomyelitis due to Human poliovirus 1"
+  },
+  {
+    "sctid": "446495002",
+    "preferred_name": "Ependymal cyst of spinal meninges"
+  },
+  {
+    "sctid": "446531000124106",
+    "preferred_name": "Meningioma of cerebellum"
+  },
+  {
+    "sctid": "446644006",
+    "preferred_name": "Traumatic injury of spinal cord at T1-T6 level"
+  },
+  {
+    "sctid": "446835008",
+    "preferred_name": "Traumatic injury of sacral spinal cord"
+  },
+  {
+    "sctid": "446940004",
+    "preferred_name": "Ependymal cyst of spinal cord"
+  },
+  {
+    "sctid": "446957000",
+    "preferred_name": "Acute bulbar poliomyelitis due to Human poliovirus 1"
+  },
+  {
+    "sctid": "446958005",
+    "preferred_name": "Acute paralytic poliomyelitis due to Human poliovirus 1"
+  },
+  {
+    "sctid": "447012002",
+    "preferred_name": "Tuberculosis of spinal cord"
+  },
+  {
+    "sctid": "447232008",
+    "preferred_name": "Ependymal cyst of ventricle of brain"
+  },
+  {
+    "sctid": "447253004",
+    "preferred_name": "Tuberculous arachnoiditis"
+  },
+  {
+    "sctid": "447262002",
+    "preferred_name": "Acute paralytic poliomyelitis due to Human poliovirus 2"
+  },
+  {
+    "sctid": "447292006",
+    "preferred_name": "Mitochondrial encephalomyopathy"
+  },
+  {
+    "sctid": "4473006",
+    "preferred_name": "Migraine with aura"
+  },
+  {
+    "sctid": "447332005",
+    "preferred_name": "Tuberculous abscess of epidural space"
+  },
+  {
+    "sctid": "447351004",
+    "preferred_name": "Vanishing white matter disease"
+  },
+  {
+    "sctid": "447378002",
+    "preferred_name": "Acute paralytic poliomyelitis due to Human poliovirus 3"
+  },
+  {
+    "sctid": "447396006",
+    "preferred_name": "Concussion injury of cerebrum"
+  },
+  {
+    "sctid": "447464004",
+    "preferred_name": "Complete spinal cord injury at T7-T12 level"
+  },
+  {
+    "sctid": "447575003",
+    "preferred_name": "Complete spinal cord injury at T1-T6 level"
+  },
+  {
+    "sctid": "447655002",
+    "preferred_name": "Benign neoplastic cyst of brain"
+  },
+  {
+    "sctid": "448045004",
+    "preferred_name": "Fragile X associated tremor ataxia syndrome"
+  },
+  {
+    "sctid": "448054001",
+    "preferred_name": "Adult onset autosomal dominant leukodystrophy"
+  },
+  {
+    "sctid": "448135004",
+    "preferred_name": "Benign teratoma of pineal region"
+  },
+  {
+    "sctid": "448148000",
+    "preferred_name": "Functioning pituitary neoplasm"
+  },
+  {
+    "sctid": "448218008",
+    "preferred_name": "Malignant neoplasm of cerebellopontine angle"
+  },
+  {
+    "sctid": "448227009",
+    "preferred_name": "X-linked periventricular heterotopia"
+  },
+  {
+    "sctid": "448248006",
+    "preferred_name": "Malignant neoplasm of axial suprasellar region of brain"
+  },
+  {
+    "sctid": "448250003",
+    "preferred_name": "Malignant teratoma of pineal region"
+  },
+  {
+    "sctid": "448254007",
+    "preferred_name": "Non-Hodgkin's lymphoma of central nervous system"
+  },
+  {
+    "sctid": "448314007",
+    "preferred_name": "Carcinoma of spinal cord"
+  },
+  {
+    "sctid": "448563005",
+    "preferred_name": "Functionless pituitary neoplasm"
+  },
+  {
+    "sctid": "448705004",
+    "preferred_name": "Mesial temporal lobe sclerosis"
+  },
+  {
+    "sctid": "448788000",
+    "preferred_name": "Open fracture of lumbar spine with incomplete lesion of lumbar spinal cord"
+  },
+  {
+    "sctid": "448863000",
+    "preferred_name": "Carcinoma of pineal gland"
+  },
+  {
+    "sctid": "448989001",
+    "preferred_name": "Carcinoma of brain"
+  },
+  {
+    "sctid": "448995000",
+    "preferred_name": "Follicular non-Hodgkin's lymphoma of central nervous system"
+  },
+  {
+    "sctid": "449020009",
+    "preferred_name": "Intraparenchymal hemorrhage of brain"
+  },
+  {
+    "sctid": "44913001",
+    "preferred_name": "Athetosis"
+  },
+  {
+    "sctid": "449203004",
+    "preferred_name": "Focal seizure with experiential sensory symptoms"
+  },
+  {
+    "sctid": "449221001",
+    "preferred_name": "Diffuse non-Hodgkin's lymphoma of central nervous system"
+  },
+  {
+    "sctid": "449253005",
+    "preferred_name": "Carcinoma of hypothalamus"
+  },
+  {
+    "sctid": "449420002",
+    "preferred_name": "Malignant neoplasm of cerebellum"
+  },
+  {
+    "sctid": "44966003",
+    "preferred_name": "Passive aggressive personality disorder"
+  },
+  {
+    "sctid": "449793009",
+    "preferred_name": "Hemorrhage into subdural space of neuraxis"
+  },
+  {
+    "sctid": "449794003",
+    "preferred_name": "Hematoma of subdural space of neuraxis"
+  },
+  {
+    "sctid": "449795002",
+    "preferred_name": "Hemorrhage into subdural space of spine"
+  },
+  {
+    "sctid": "449796001",
+    "preferred_name": "Traumatic hematoma of subdural space of neuraxis"
+  },
+  {
+    "sctid": "449797005",
+    "preferred_name": "Non-traumatic hematoma of subdural space of neuraxis"
+  },
+  {
+    "sctid": "449799008",
+    "preferred_name": "Subependymal giant cell astrocytoma"
+  },
+  {
+    "sctid": "44983007",
+    "preferred_name": "Intervertebral disc disorder with myelopathy"
+  },
+  {
+    "sctid": "449901005",
+    "preferred_name": "Hepatic encephalopathy in fulminant hepatic failure"
+  },
+  {
+    "sctid": "449902003",
+    "preferred_name": "Portal systemic encephalopathy"
+  },
+  {
+    "sctid": "449903008",
+    "preferred_name": "Type I arteriovenous malformation of spinal cord"
+  },
+  {
+    "sctid": "449904002",
+    "preferred_name": "Type II arteriovenous malformation of spinal cord"
+  },
+  {
+    "sctid": "449905001",
+    "preferred_name": "Type III arteriovenous malformation of spinal cord"
+  },
+  {
+    "sctid": "449906000",
+    "preferred_name": "Type IV arteriovenous malformation of spinal cord"
+  },
+  {
+    "sctid": "45021001",
+    "preferred_name": "Candidal meningitis"
+  },
+  {
+    "sctid": "450362008",
+    "preferred_name": "Hemorrhage into subarachnoid space of neuraxis"
+  },
+  {
+    "sctid": "450363003",
+    "preferred_name": "Hemorrhage into subarachnoid space of spine"
+  },
+  {
+    "sctid": "450376009",
+    "preferred_name": "Hemorrhage of intracranial meningeal space"
+  },
+  {
+    "sctid": "450377000",
+    "preferred_name": "Hemorrhage into meningeal space of neuraxis"
+  },
+  {
+    "sctid": "450378005",
+    "preferred_name": "Hemorrhage into extradural space of neuraxis"
+  },
+  {
+    "sctid": "450379002",
+    "preferred_name": "Hemorrhage into epidural space of spine"
+  },
+  {
+    "sctid": "450418003",
+    "preferred_name": "Cerebral hemorrhage following injury"
+  },
+  {
+    "sctid": "450714000",
+    "preferred_name": "Severe major depression"
+  },
+  {
+    "sctid": "450886002",
+    "preferred_name": "Posterior reversible encephalopathy syndrome"
+  },
+  {
+    "sctid": "4510004",
+    "preferred_name": "Streptococcal meningitis"
+  },
+  {
+    "sctid": "451034003",
+    "preferred_name": "Hemorrhage into subpial space of neuraxis"
+  },
+  {
+    "sctid": "451035002",
+    "preferred_name": "Subpial intracranial hemorrhage"
+  },
+  {
+    "sctid": "451036001",
+    "preferred_name": "Hemorrhage into subpial space of spinal cord"
+  },
+  {
+    "sctid": "451037005",
+    "preferred_name": "Hemorrhage in globus pallidus"
+  },
+  {
+    "sctid": "451038000",
+    "preferred_name": "Hemorrhage in caudate nucleus"
+  },
+  {
+    "sctid": "451039008",
+    "preferred_name": "Hemorrhage in putamen"
+  },
+  {
+    "sctid": "45163000",
+    "preferred_name": "Congenital pontocerebellar hypoplasia"
+  },
+  {
+    "sctid": "45170000",
+    "preferred_name": "Encephalitis"
+  },
+  {
+    "sctid": "451971000124105",
+    "preferred_name": "Acute myelopathy"
+  },
+  {
+    "sctid": "452281000124106",
+    "preferred_name": "Autoimmune encephalitis caused by N-methyl D-aspartate receptor antibody"
+  },
+  {
+    "sctid": "4523006",
+    "preferred_name": "Babinski-Nageotte syndrome"
+  },
+  {
+    "sctid": "45369008",
+    "preferred_name": "Neurohypophyseal diabetes insipidus"
+  },
+  {
+    "sctid": "454041000124101",
+    "preferred_name": "Cerebellar infarction due to occlusion of superior cerebellar artery"
+  },
+  {
+    "sctid": "45479006",
+    "preferred_name": "Manic bipolar I disorder in remission"
+  },
+  {
+    "sctid": "45639009",
+    "preferred_name": "Hereditary cerebral amyloid angiopathy, Icelandic type"
+  },
+  {
+    "sctid": "45659008",
+    "preferred_name": "Subdural hemorrhage following injury with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "45677003",
+    "preferred_name": "Developmental expressive writing disorder"
+  },
+  {
+    "sctid": "45740001",
+    "preferred_name": "Diencephalic syndrome of infancy"
+  },
+  {
+    "sctid": "457551000124104",
+    "preferred_name": "Acute stroke"
+  },
+  {
+    "sctid": "45814002",
+    "preferred_name": "Birnbaum's syndrome"
+  },
+  {
+    "sctid": "45864009",
+    "preferred_name": "Senile degeneration of brain"
+  },
+  {
+    "sctid": "45897005",
+    "preferred_name": "Jervis' syndrome"
+  },
+  {
+    "sctid": "45912004",
+    "preferred_name": "Organic hallucinosis"
+  },
+  {
+    "sctid": "45924006",
+    "preferred_name": "Necrophilia"
+  },
+  {
+    "sctid": "45994004",
+    "preferred_name": "Erotic vomiting"
+  },
+  {
+    "sctid": "46023009",
+    "preferred_name": "Pedophilia, same AND opposite sex"
+  },
+  {
+    "sctid": "460731000124105",
+    "preferred_name": "Recurrent seizure"
+  },
+  {
+    "sctid": "460880006",
+    "preferred_name": "Arteriovenous fistula of great cerebral vein of Galen"
+  },
+  {
+    "sctid": "46138007",
+    "preferred_name": "Tropical ataxic neuropathy"
+  },
+  {
+    "sctid": "4619009",
+    "preferred_name": "Generalized-onset seizures"
+  },
+  {
+    "sctid": "46206005",
+    "preferred_name": "Mood disorder"
+  },
+  {
+    "sctid": "462165005",
+    "preferred_name": "Fetal choroid plexus cyst"
+  },
+  {
+    "sctid": "46229002",
+    "preferred_name": "Severe mixed bipolar I disorder without psychotic features"
+  },
+  {
+    "sctid": "46244001",
+    "preferred_name": "Recurrent major depression in full remission"
+  },
+  {
+    "sctid": "46251005",
+    "preferred_name": "Corticospinal motor disease"
+  },
+  {
+    "sctid": "46263000",
+    "preferred_name": "Cataplexy"
+  },
+  {
+    "sctid": "46303000",
+    "preferred_name": "Coccidioidal meningitis"
+  },
+  {
+    "sctid": "46432001",
+    "preferred_name": "Lecherism"
+  },
+  {
+    "sctid": "4645000",
+    "preferred_name": "Senile brain amyloidosis"
+  },
+  {
+    "sctid": "46549005",
+    "preferred_name": "Multiple spinal cord injuries without spinal bone injury"
+  },
+  {
+    "sctid": "46721000",
+    "preferred_name": "Psychoactive substance-induced organic personality disorder"
+  },
+  {
+    "sctid": "46762006",
+    "preferred_name": "Sexual desire disorder"
+  },
+  {
+    "sctid": "46963008",
+    "preferred_name": "Compression of brain"
+  },
+  {
+    "sctid": "46966000",
+    "preferred_name": "Cerebral compression due to injury"
+  },
+  {
+    "sctid": "46975003",
+    "preferred_name": "Cocaine-induced organic mental disorder"
+  },
+  {
+    "sctid": "46995009",
+    "preferred_name": "Closed fracture of C5-C7 level with spinal cord injury"
+  },
+  {
+    "sctid": "47000000",
+    "preferred_name": "Acute transverse myelitis"
+  },
+  {
+    "sctid": "47032000",
+    "preferred_name": "Congenital hydrocephalus"
+  },
+  {
+    "sctid": "471971000124108",
+    "preferred_name": "Anxiety disorder due to severe acute respiratory syndrome coronavirus 2"
+  },
+  {
+    "sctid": "472916000",
+    "preferred_name": "Toxic metabolic encephalopathy"
+  },
+  {
+    "sctid": "472981000",
+    "preferred_name": "Fetishistic transvestism"
+  },
+  {
+    "sctid": "47311000119103",
+    "preferred_name": "Static encephalopathy"
+  },
+  {
+    "sctid": "473429002",
+    "preferred_name": "Tuberculoma of spinal cord confirmed"
+  },
+  {
+    "sctid": "473452003",
+    "preferred_name": "Atypical psychosis"
+  },
+  {
+    "sctid": "473456000",
+    "preferred_name": "Compulsive personality disorder"
+  },
+  {
+    "sctid": "473457009",
+    "preferred_name": "Obsessional personality disorder"
+  },
+  {
+    "sctid": "47372000",
+    "preferred_name": "Adjustment disorder with anxious mood"
+  },
+  {
+    "sctid": "47391000119107",
+    "preferred_name": "Primary generalized absence epilepsy"
+  },
+  {
+    "sctid": "47447001",
+    "preferred_name": "Grandiose delusion disorder"
+  },
+  {
+    "sctid": "47505003",
+    "preferred_name": "Posttraumatic stress disorder"
+  },
+  {
+    "sctid": "47664006",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "47916000",
+    "preferred_name": "Developmental arithmetic disorder"
+  },
+  {
+    "sctid": "47924005",
+    "preferred_name": "Motor cortical disorder"
+  },
+  {
+    "sctid": "48046002",
+    "preferred_name": "Symptomatic sexual masochism"
+  },
+  {
+    "sctid": "48090007",
+    "preferred_name": "Neurologic adductor spastic dysphonia"
+  },
+  {
+    "sctid": "4817008",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset, with delirium"
+  },
+  {
+    "sctid": "48233004",
+    "preferred_name": "Traumatic optic nerve injury"
+  },
+  {
+    "sctid": "48248005",
+    "preferred_name": "Thrombophlebitis of inferior sagittal sinus"
+  },
+  {
+    "sctid": "48309007",
+    "preferred_name": "Pedophilia, nonexclusive type"
+  },
+  {
+    "sctid": "48376004",
+    "preferred_name": "Congenital pseudoporencephaly"
+  },
+  {
+    "sctid": "48500005",
+    "preferred_name": "Delusional disorder"
+  },
+  {
+    "sctid": "48518008",
+    "preferred_name": "Subarachnoid hemorrhage following injury with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "48522003",
+    "preferred_name": "Spinal cord disease"
+  },
+  {
+    "sctid": "48589009",
+    "preferred_name": "Minor depressive disorder"
+  },
+  {
+    "sctid": "4863002",
+    "preferred_name": "PCP mood disorder"
+  },
+  {
+    "sctid": "48721008",
+    "preferred_name": "Tetraplegic cerebral palsy"
+  },
+  {
+    "sctid": "48826008",
+    "preferred_name": "Conduct disorder, adolescent-onset type"
+  },
+  {
+    "sctid": "48937005",
+    "preferred_name": "Bipolar II disorder, most recent episode hypomanic"
+  },
+  {
+    "sctid": "48956000",
+    "preferred_name": "Open fracture of lumbar vertebra with spinal cord injury"
+  },
+  {
+    "sctid": "49049000",
+    "preferred_name": "Parkinson's disease"
+  },
+  {
+    "sctid": "4926007",
+    "preferred_name": "Schizophrenia in remission"
+  },
+  {
+    "sctid": "49271002",
+    "preferred_name": "Deferred diagnosis on Axis II"
+  },
+  {
+    "sctid": "4932002",
+    "preferred_name": "Panic disorder with agoraphobia, moderate agoraphobic avoidance AND mild panic attacks"
+  },
+  {
+    "sctid": "49386006",
+    "preferred_name": "Orofacial dyskinesia"
+  },
+  {
+    "sctid": "49422009",
+    "preferred_name": "Cortical hemorrhage"
+  },
+  {
+    "sctid": "4945003",
+    "preferred_name": "Microgyria"
+  },
+  {
+    "sctid": "49453006",
+    "preferred_name": "Cerebral herniation"
+  },
+  {
+    "sctid": "49468007",
+    "preferred_name": "Depressed bipolar I disorder"
+  },
+  {
+    "sctid": "49481000",
+    "preferred_name": "Postseizure delirium"
+  },
+  {
+    "sctid": "4949009",
+    "preferred_name": "Motor skill disorder"
+  },
+  {
+    "sctid": "49497005",
+    "preferred_name": "Open fracture of T1-T6 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "49512000",
+    "preferred_name": "Depressed bipolar I disorder in partial remission"
+  },
+  {
+    "sctid": "4952001",
+    "preferred_name": "Cerebral irritability in newborn"
+  },
+  {
+    "sctid": "49564006",
+    "preferred_name": "Panic disorder with agoraphobia, mild agoraphobic avoidance AND moderate panic attacks"
+  },
+  {
+    "sctid": "496369931000119104",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of right cerebellar artery"
+  },
+  {
+    "sctid": "49644006",
+    "preferred_name": "Simple partial onset seizure followed by impaired consciousness"
+  },
+  {
+    "sctid": "49692006",
+    "preferred_name": "Schilder's disease"
+  },
+  {
+    "sctid": "49747005",
+    "preferred_name": "Closed fracture of lumbar vertebra with spinal cord injury"
+  },
+  {
+    "sctid": "49776008",
+    "preferred_name": "Centrencephalic epilepsy"
+  },
+  {
+    "sctid": "49823009",
+    "preferred_name": "Internuclear ophthalmoplegia"
+  },
+  {
+    "sctid": "49949003",
+    "preferred_name": "Paroxysmal choreoathetosis"
+  },
+  {
+    "sctid": "4997005",
+    "preferred_name": "Thyrotoxicosis factitia"
+  },
+  {
+    "sctid": "50026000",
+    "preferred_name": "Psychoactive substance-induced organic anxiety disorder"
+  },
+  {
+    "sctid": "50122000",
+    "preferred_name": "Metabolic encephalopathy"
+  },
+  {
+    "sctid": "50143004",
+    "preferred_name": "Kernicterus of newborn"
+  },
+  {
+    "sctid": "50299009",
+    "preferred_name": "Paraphilia"
+  },
+  {
+    "sctid": "50429003",
+    "preferred_name": "Congenital stenosis of aqueduct of Sylvius"
+  },
+  {
+    "sctid": "50490005",
+    "preferred_name": "Hypertensive encephalopathy"
+  },
+  {
+    "sctid": "50541007",
+    "preferred_name": "Bruns' syndrome"
+  },
+  {
+    "sctid": "50582007",
+    "preferred_name": "Hemiplegia"
+  },
+  {
+    "sctid": "50643003",
+    "preferred_name": "Latah"
+  },
+  {
+    "sctid": "50705009",
+    "preferred_name": "Factitious disorder"
+  },
+  {
+    "sctid": "50722006",
+    "preferred_name": "PCP delusional disorder"
+  },
+  {
+    "sctid": "50776006",
+    "preferred_name": "Allergic encephalomyelitis"
+  },
+  {
+    "sctid": "508171000000105",
+    "preferred_name": "Severe learning disability"
+  },
+  {
+    "sctid": "50866000",
+    "preferred_name": "Childhood absence epilepsy"
+  },
+  {
+    "sctid": "50888000",
+    "preferred_name": "Closed fracture of C1-C4 level with central cord syndrome"
+  },
+  {
+    "sctid": "50933003",
+    "preferred_name": "Hallucinogen delusional disorder"
+  },
+  {
+    "sctid": "509341000000107",
+    "preferred_name": "Petit-mal epilepsy"
+  },
+  {
+    "sctid": "5095008",
+    "preferred_name": "Gender identity disorder of childhood"
+  },
+  {
+    "sctid": "50983008",
+    "preferred_name": "Panic disorder with agoraphobia, mild agoraphobic avoidance AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "51004007",
+    "preferred_name": "Herniation under falx cerebri"
+  },
+  {
+    "sctid": "5102002",
+    "preferred_name": "Agenesis of corpus callosum"
+  },
+  {
+    "sctid": "51075009",
+    "preferred_name": "Complex partial seizure evolving to generalized seizure"
+  },
+  {
+    "sctid": "51133006",
+    "preferred_name": "Residual schizophrenia in remission"
+  },
+  {
+    "sctid": "511452481000119102",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of right vertebral artery"
+  },
+  {
+    "sctid": "51169003",
+    "preferred_name": "Pneumococcal meningitis"
+  },
+  {
+    "sctid": "51239001",
+    "preferred_name": "Sexual masochism"
+  },
+  {
+    "sctid": "51258005",
+    "preferred_name": "Open fracture of T7-T12 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "51371005",
+    "preferred_name": "Pituitary dwarfism with normal somatotropin level AND low somatomedin"
+  },
+  {
+    "sctid": "51399001",
+    "preferred_name": "Toxic encephalopathy due to lead"
+  },
+  {
+    "sctid": "51443000",
+    "preferred_name": "Amphetamine-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "51493001",
+    "preferred_name": "Cocaine-induced anxiety disorder"
+  },
+  {
+    "sctid": "51495008",
+    "preferred_name": "Cerebral anoxia following anesthesia AND/OR sedation in labor AND/OR delivery"
+  },
+  {
+    "sctid": "51514006",
+    "preferred_name": "Closed fracture of C1-C4 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "51568001",
+    "preferred_name": "Brain stem vertigo"
+  },
+  {
+    "sctid": "5158005",
+    "preferred_name": "Gilles de la Tourette's syndrome"
+  },
+  {
+    "sctid": "51604006",
+    "preferred_name": "Acute retrobulbar neuritis"
+  },
+  {
+    "sctid": "51637008",
+    "preferred_name": "Chronic bipolar I disorder, most recent episode depressed"
+  },
+  {
+    "sctid": "51638003",
+    "preferred_name": "Thogoto virus disease"
+  },
+  {
+    "sctid": "517253051000119105",
+    "preferred_name": "Cerebrovascular accident due to embolism of left vertebral artery"
+  },
+  {
+    "sctid": "51742006",
+    "preferred_name": "Disorder of anterior pituitary"
+  },
+  {
+    "sctid": "51887003",
+    "preferred_name": "Tonic seizure"
+  },
+  {
+    "sctid": "51928006",
+    "preferred_name": "General paresis - neurosyphilis"
+  },
+  {
+    "sctid": "51946000",
+    "preferred_name": "Susto"
+  },
+  {
+    "sctid": "51978008",
+    "preferred_name": "Head lag in the newborn"
+  },
+  {
+    "sctid": "52002008",
+    "preferred_name": "Serous detachment of retinal pigment epithelium"
+  },
+  {
+    "sctid": "52008007",
+    "preferred_name": "Organic writer's cramp"
+  },
+  {
+    "sctid": "5202009",
+    "preferred_name": "Brain injury with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "52072009",
+    "preferred_name": "Heat stroke"
+  },
+  {
+    "sctid": "52125007",
+    "preferred_name": "Gustatory seizure"
+  },
+  {
+    "sctid": "5217008",
+    "preferred_name": "Stiff-man syndrome"
+  },
+  {
+    "sctid": "52201006",
+    "preferred_name": "Internal capsule hemorrhage"
+  },
+  {
+    "sctid": "52274002",
+    "preferred_name": "Dystonia lenticularis"
+  },
+  {
+    "sctid": "52281009",
+    "preferred_name": "Meningoencephalitis due to Naegleria"
+  },
+  {
+    "sctid": "52289006",
+    "preferred_name": "Closed fracture of T1-T6 level with central cord syndrome"
+  },
+  {
+    "sctid": "52330001",
+    "preferred_name": "Meningoencephalocele"
+  },
+  {
+    "sctid": "52448006",
+    "preferred_name": "Dementia"
+  },
+  {
+    "sctid": "5251007",
+    "preferred_name": "Subarachnoid hemorrhage following injury with open intracranial wound"
+  },
+  {
+    "sctid": "52522001",
+    "preferred_name": "Degenerative brain disorder"
+  },
+  {
+    "sctid": "52713000",
+    "preferred_name": "Infantile neuroaxonal dystrophy"
+  },
+  {
+    "sctid": "52824009",
+    "preferred_name": "Developmental reading disorder"
+  },
+  {
+    "sctid": "52859009",
+    "preferred_name": "Rathke's pouch cyst"
+  },
+  {
+    "sctid": "52866005",
+    "preferred_name": "Opioid intoxication delirium"
+  },
+  {
+    "sctid": "52888005",
+    "preferred_name": "Brain stem contusion without open intracranial wound"
+  },
+  {
+    "sctid": "52910006",
+    "preferred_name": "Anxiety disorder due to a general medical condition"
+  },
+  {
+    "sctid": "52947006",
+    "preferred_name": "Japanese encephalitis virus disease"
+  },
+  {
+    "sctid": "52954000",
+    "preferred_name": "Schizoid personality disorder"
+  },
+  {
+    "sctid": "53049002",
+    "preferred_name": "Severe bipolar disorder without psychotic features"
+  },
+  {
+    "sctid": "53050002",
+    "preferred_name": "Hallucinogen-induced organic mental disorder"
+  },
+  {
+    "sctid": "53194005",
+    "preferred_name": "Posthemiplegic athetosis"
+  },
+  {
+    "sctid": "5321000124109",
+    "preferred_name": "Temporal lobe epilepsy with mesial temporal sclerosis"
+  },
+  {
+    "sctid": "53267002",
+    "preferred_name": "Brain injury without open intracranial wound AND with loss of consciousness"
+  },
+  {
+    "sctid": "53318002",
+    "preferred_name": "Spina bifida with hydrocephalus"
+  },
+  {
+    "sctid": "53467004",
+    "preferred_name": "Anxiety disorder of childhood"
+  },
+  {
+    "sctid": "53521000119106",
+    "preferred_name": "First generalized onset seizure"
+  },
+  {
+    "sctid": "53607008",
+    "preferred_name": "Depressed bipolar I disorder in remission"
+  },
+  {
+    "sctid": "53622003",
+    "preferred_name": "Cerebral malaria"
+  },
+  {
+    "sctid": "53776005",
+    "preferred_name": "Encephalocystocele"
+  },
+  {
+    "sctid": "53810004",
+    "preferred_name": "Injury at T1-T6 level with spinal cord injury AND without bone injury"
+  },
+  {
+    "sctid": "53868003",
+    "preferred_name": "Closed fracture of C1-C4 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "53936005",
+    "preferred_name": "Alcohol-induced mood disorder"
+  },
+  {
+    "sctid": "53956006",
+    "preferred_name": "Panic disorder without agoraphobia with panic attacks in partial remission"
+  },
+  {
+    "sctid": "54304004",
+    "preferred_name": "Progressive bulbar palsy"
+  },
+  {
+    "sctid": "54319003",
+    "preferred_name": "Disruptive behavior disorder"
+  },
+  {
+    "sctid": "54364001",
+    "preferred_name": "Lethal neonatal spasticity"
+  },
+  {
+    "sctid": "54417002",
+    "preferred_name": "Adult gender identity disorder, sexually attracted to females"
+  },
+  {
+    "sctid": "5444000",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic intoxication delirium"
+  },
+  {
+    "sctid": "54502004",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset, with delusions"
+  },
+  {
+    "sctid": "54560009",
+    "preferred_name": "Windigo"
+  },
+  {
+    "sctid": "54587008",
+    "preferred_name": "Simple phobia"
+  },
+  {
+    "sctid": "5464005",
+    "preferred_name": "Brief reactive psychosis"
+  },
+  {
+    "sctid": "5471000124102",
+    "preferred_name": "Ruptured aneurysm of intracranial artery"
+  },
+  {
+    "sctid": "54761006",
+    "preferred_name": "Severe depressed bipolar I disorder with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "54767005",
+    "preferred_name": "Disorder of visual pathways"
+  },
+  {
+    "sctid": "54794009",
+    "preferred_name": "Ectopic gray matter in centrum ovale"
+  },
+  {
+    "sctid": "5491000124101",
+    "preferred_name": "Thrombophlebitis of transverse sinus"
+  },
+  {
+    "sctid": "55004003",
+    "preferred_name": "Syndrome of inappropriate vasopressin secretion"
+  },
+  {
+    "sctid": "55009008",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset, with delusions"
+  },
+  {
+    "sctid": "5507002",
+    "preferred_name": "Stereotypy habit disorder"
+  },
+  {
+    "sctid": "5509004",
+    "preferred_name": "Panic disorder with agoraphobia AND severe panic attacks"
+  },
+  {
+    "sctid": "5510009",
+    "preferred_name": "Organic delusional disorder"
+  },
+  {
+    "sctid": "55234004",
+    "preferred_name": "Pyogranulomatous meningoencephalomyelitis"
+  },
+  {
+    "sctid": "55341008",
+    "preferred_name": "Histrionic personality disorder"
+  },
+  {
+    "sctid": "55481000",
+    "preferred_name": "Limbic disorder"
+  },
+  {
+    "sctid": "55489003",
+    "preferred_name": "Eosinophilic meningoencephalitis"
+  },
+  {
+    "sctid": "55516002",
+    "preferred_name": "Bipolar I disorder, most recent episode manic with postpartum onset"
+  },
+  {
+    "sctid": "55623006",
+    "preferred_name": "Toxic encephalopathy due to mercury"
+  },
+  {
+    "sctid": "55637002",
+    "preferred_name": "Spinal hemiplegia"
+  },
+  {
+    "sctid": "5566009",
+    "preferred_name": "Trypanosomiasis with meningitis"
+  },
+  {
+    "sctid": "55668003",
+    "preferred_name": "Adjustment disorder with mixed emotional features"
+  },
+  {
+    "sctid": "55702009",
+    "preferred_name": "Laceration of brain without open intracranial wound"
+  },
+  {
+    "sctid": "5571000124103",
+    "preferred_name": "Cerebrovascular accident with intracranial hemorrhage"
+  },
+  {
+    "sctid": "55728007",
+    "preferred_name": "Sexual aversion disorder"
+  },
+  {
+    "sctid": "55734000",
+    "preferred_name": "Endophlebitis of basilar sinus"
+  },
+  {
+    "sctid": "55736003",
+    "preferred_name": "Schizophreniform disorder without good prognostic features"
+  },
+  {
+    "sctid": "55776008",
+    "preferred_name": "Symptomatic torsion dystonia"
+  },
+  {
+    "sctid": "5582005",
+    "preferred_name": "Posterior fossa compression syndrome"
+  },
+  {
+    "sctid": "5591000124102",
+    "preferred_name": "Thrombosis of superior anastomotic vein"
+  },
+  {
+    "sctid": "55967005",
+    "preferred_name": "Phencyclidine-induced anxiety disorder"
+  },
+  {
+    "sctid": "55999004",
+    "preferred_name": "Encephalocele"
+  },
+  {
+    "sctid": "5601000124105",
+    "preferred_name": "Thrombosis of posterior inferior cerebellar artery"
+  },
+  {
+    "sctid": "56034001",
+    "preferred_name": "Compulsive exhibitionism"
+  },
+  {
+    "sctid": "56095002",
+    "preferred_name": "Necrosadism"
+  },
+  {
+    "sctid": "56097005",
+    "preferred_name": "Migraine without aura"
+  },
+  {
+    "sctid": "5611000124108",
+    "preferred_name": "Thrombosis of basal vein"
+  },
+  {
+    "sctid": "56155002",
+    "preferred_name": "Hemispheric cerebral agenesis"
+  },
+  {
+    "sctid": "5619004",
+    "preferred_name": "Bardet-Biedl syndrome"
+  },
+  {
+    "sctid": "56194001",
+    "preferred_name": "Caffeine-induced sleep disorder"
+  },
+  {
+    "sctid": "56267009",
+    "preferred_name": "Multi-infarct dementia"
+  },
+  {
+    "sctid": "56271007",
+    "preferred_name": "Hypothermia-sweating syndrome"
+  },
+  {
+    "sctid": "56384000",
+    "preferred_name": "Embolism of inferior sagittal sinus"
+  },
+  {
+    "sctid": "56409008",
+    "preferred_name": "Monoplegic cerebral palsy"
+  },
+  {
+    "sctid": "5645008",
+    "preferred_name": "Nasal glial heterotopia"
+  },
+  {
+    "sctid": "56453003",
+    "preferred_name": "Hereditary cerebral amyloid angiopathy, Dutch type"
+  },
+  {
+    "sctid": "56509006",
+    "preferred_name": "Adductor spastic dysphonia of organic voice tremor"
+  },
+  {
+    "sctid": "56529007",
+    "preferred_name": "Adenoviral encephalitis"
+  },
+  {
+    "sctid": "56531003",
+    "preferred_name": "Ulegyria"
+  },
+  {
+    "sctid": "56573006",
+    "preferred_name": "Transient tic disorder"
+  },
+  {
+    "sctid": "56576003",
+    "preferred_name": "Panic disorder without agoraphobia"
+  },
+  {
+    "sctid": "56627002",
+    "preferred_name": "Psychosexual disorder"
+  },
+  {
+    "sctid": "5664002",
+    "preferred_name": "Situational hypoactive sexual desire disorder"
+  },
+  {
+    "sctid": "56641006",
+    "preferred_name": "Axis II diagnosis"
+  },
+  {
+    "sctid": "568005",
+    "preferred_name": "Tic disorder"
+  },
+  {
+    "sctid": "56882008",
+    "preferred_name": "Anorexia nervosa"
+  },
+  {
+    "sctid": "5703000",
+    "preferred_name": "Bipolar disorder in partial remission"
+  },
+  {
+    "sctid": "57138009",
+    "preferred_name": "Pseudopapilledema"
+  },
+  {
+    "sctid": "57148006",
+    "preferred_name": "Congenital anomaly of brain"
+  },
+  {
+    "sctid": "57194009",
+    "preferred_name": "Adjustment disorder with depressed mood"
+  },
+  {
+    "sctid": "57588009",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced sleep disorder"
+  },
+  {
+    "sctid": "57715001",
+    "preferred_name": "Gender identity disorder of adolescence"
+  },
+  {
+    "sctid": "57739006",
+    "preferred_name": "Cerebellar contusion without open intracranial wound"
+  },
+  {
+    "sctid": "57917004",
+    "preferred_name": "Seckel syndrome"
+  },
+  {
+    "sctid": "5793009",
+    "preferred_name": "Mixed behavior and emotional disorder"
+  },
+  {
+    "sctid": "57981008",
+    "preferred_name": "Progressing stroke"
+  },
+  {
+    "sctid": "58170007",
+    "preferred_name": "Viral meningitis"
+  },
+  {
+    "sctid": "58173271000119101",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral cerebellar arteries"
+  },
+  {
+    "sctid": "58193001",
+    "preferred_name": "Diplegic cerebral palsy"
+  },
+  {
+    "sctid": "58214004",
+    "preferred_name": "Schizophrenia"
+  },
+  {
+    "sctid": "5822000",
+    "preferred_name": "Athetosis with spastic paraplegia"
+  },
+  {
+    "sctid": "58329000",
+    "preferred_name": "Organic mood disorder of manic type"
+  },
+  {
+    "sctid": "58349009",
+    "preferred_name": "Exhibitionism"
+  },
+  {
+    "sctid": "5842009",
+    "preferred_name": "Spinal cord dysplasia"
+  },
+  {
+    "sctid": "58437007",
+    "preferred_name": "Tuberculosis of meninges"
+  },
+  {
+    "sctid": "58535001",
+    "preferred_name": "Physical AND emotional exhaustion state"
+  },
+  {
+    "sctid": "58557008",
+    "preferred_name": "Spina bifida aperta"
+  },
+  {
+    "sctid": "58610003",
+    "preferred_name": "Leber's optic atrophy"
+  },
+  {
+    "sctid": "58638006",
+    "preferred_name": "Pseudoporencephaly"
+  },
+  {
+    "sctid": "58647003",
+    "preferred_name": "Severe mood disorder with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "58703003",
+    "preferred_name": "Postpartum depression"
+  },
+  {
+    "sctid": "58756001",
+    "preferred_name": "Huntington's chorea"
+  },
+  {
+    "sctid": "58762006",
+    "preferred_name": "Encephalomalacia"
+  },
+  {
+    "sctid": "58766009",
+    "preferred_name": "Granulomatous meningoencephalomyelitis"
+  },
+  {
+    "sctid": "58855008",
+    "preferred_name": "Symptomatic exhibitionism"
+  },
+  {
+    "sctid": "5900006",
+    "preferred_name": "Haemophilus influenzae meningitis"
+  },
+  {
+    "sctid": "59026006",
+    "preferred_name": "Blepharospasm"
+  },
+  {
+    "sctid": "59103002",
+    "preferred_name": "Cerebral paralysis with homolateral ataxia"
+  },
+  {
+    "sctid": "59174009",
+    "preferred_name": "Fetishism"
+  },
+  {
+    "sctid": "59216005",
+    "preferred_name": "Adult gender identity disorder, sexually attracted to males"
+  },
+  {
+    "sctid": "59252009",
+    "preferred_name": "Cutis laxa-corneal clouding-oligophrenia syndrome"
+  },
+  {
+    "sctid": "59292006",
+    "preferred_name": "Hemiplegic migraine"
+  },
+  {
+    "sctid": "59394009",
+    "preferred_name": "Sexual sadism"
+  },
+  {
+    "sctid": "59457001",
+    "preferred_name": "Simple partial seizure evolving to secondary generalized seizure"
+  },
+  {
+    "sctid": "59572000",
+    "preferred_name": "Necrosis of pituitary"
+  },
+  {
+    "sctid": "595899961000119100",
+    "preferred_name": "Cerebrovascular accident of basal ganglia"
+  },
+  {
+    "sctid": "596004",
+    "preferred_name": "Premenstrual dysphoric disorder"
+  },
+  {
+    "sctid": "59617007",
+    "preferred_name": "Severe depressed bipolar I disorder with psychotic features"
+  },
+  {
+    "sctid": "59636002",
+    "preferred_name": "Pelizaeus-Merzbacher disease, connatal variant"
+  },
+  {
+    "sctid": "59645001",
+    "preferred_name": "Bulimia nervosa, nonpurging type"
+  },
+  {
+    "sctid": "59651006",
+    "preferred_name": "Sedative, hypnotic AND/OR anxiolytic-induced persisting dementia"
+  },
+  {
+    "sctid": "59671002",
+    "preferred_name": "Derriengue"
+  },
+  {
+    "sctid": "59748008",
+    "preferred_name": "Cortex laceration with open intracranial wound"
+  },
+  {
+    "sctid": "59918000",
+    "preferred_name": "Cerebellar laceration with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "59923000",
+    "preferred_name": "Panic disorder with agoraphobia AND panic attacks in full remission"
+  },
+  {
+    "sctid": "600009",
+    "preferred_name": "Pyromania"
+  },
+  {
+    "sctid": "60099002",
+    "preferred_name": "Severe major depression with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "60103007",
+    "preferred_name": "Inhibited female orgasm"
+  },
+  {
+    "sctid": "60123008",
+    "preferred_name": "Delusional disorder, mixed type"
+  },
+  {
+    "sctid": "60146005",
+    "preferred_name": "Bailey-Cushing syndrome"
+  },
+  {
+    "sctid": "60338000",
+    "preferred_name": "Partial seizure with multiple symptoms"
+  },
+  {
+    "sctid": "60401000119104",
+    "preferred_name": "Postpartum psychosis in remission"
+  },
+  {
+    "sctid": "60404007",
+    "preferred_name": "Cerebral abscess"
+  },
+  {
+    "sctid": "60505005",
+    "preferred_name": "Congenital anomaly of optic disc"
+  },
+  {
+    "sctid": "60576007",
+    "preferred_name": "Subacute combined degeneration of spinal cord"
+  },
+  {
+    "sctid": "60706008",
+    "preferred_name": "Phlebitis of torcular Herophili"
+  },
+  {
+    "sctid": "608817003",
+    "preferred_name": "Pituicytoma"
+  },
+  {
+    "sctid": "609218006",
+    "preferred_name": "Paroxysmal nonkinesigenic dyskinesia"
+  },
+  {
+    "sctid": "609221008",
+    "preferred_name": "Paroxysmal kinesigenic dyskinesia"
+  },
+  {
+    "sctid": "60935008",
+    "preferred_name": "Paramyoclonus multiplex"
+  },
+  {
+    "sctid": "609382000",
+    "preferred_name": "Chronic non-traumatic intracranial subdural hemorrhage"
+  },
+  {
+    "sctid": "609417004",
+    "preferred_name": "Fetal anencephaly"
+  },
+  {
+    "sctid": "609461007",
+    "preferred_name": "Induced termination of pregnancy complicated by cerebral anoxia"
+  },
+  {
+    "sctid": "609528003",
+    "preferred_name": "Posterior fossa arachnoid cyst"
+  },
+  {
+    "sctid": "609529006",
+    "preferred_name": "Persistent Blake's pouch cyst"
+  },
+  {
+    "sctid": "61104008",
+    "preferred_name": "Inhalant-induced organic mental disorder"
+  },
+  {
+    "sctid": "61144001",
+    "preferred_name": "Alcohol-induced psychotic disorder with delusions"
+  },
+  {
+    "sctid": "61152003",
+    "preferred_name": "Moderate intellectual disability"
+  },
+  {
+    "sctid": "61157009",
+    "preferred_name": "Combat fatigue"
+  },
+  {
+    "sctid": "61165007",
+    "preferred_name": "Hereditary nephrogenic diabetes insipidus"
+  },
+  {
+    "sctid": "61180001",
+    "preferred_name": "Adult gender identity disorder, sexually attracted to neither sex"
+  },
+  {
+    "sctid": "6118003",
+    "preferred_name": "Demyelinating disease of central nervous system"
+  },
+  {
+    "sctid": "61200008",
+    "preferred_name": "Pallidonigroluysian degeneration"
+  },
+  {
+    "sctid": "61212007",
+    "preferred_name": "Panic disorder with agoraphobia, severe agoraphobic avoidance AND severe panic attacks"
+  },
+  {
+    "sctid": "61291000119103",
+    "preferred_name": "Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia in remission"
+  },
+  {
+    "sctid": "613003",
+    "preferred_name": "Fragile X syndrome"
+  },
+  {
+    "sctid": "61301000119102",
+    "preferred_name": "Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia"
+  },
+  {
+    "sctid": "61337004",
+    "preferred_name": "Electric chorea"
+  },
+  {
+    "sctid": "61386002",
+    "preferred_name": "Open fracture of C1-C4 level with central cord syndrome"
+  },
+  {
+    "sctid": "61403008",
+    "preferred_name": "Severe depressed bipolar I disorder without psychotic features"
+  },
+  {
+    "sctid": "61407009",
+    "preferred_name": "Protozoal myelitis"
+  },
+  {
+    "sctid": "61484000",
+    "preferred_name": "Simple partial seizure evolving to complex partial seizure evolving to generalized seizure"
+  },
+  {
+    "sctid": "61569007",
+    "preferred_name": "Agoraphobia without history of panic disorder"
+  },
+  {
+    "sctid": "61663001",
+    "preferred_name": "Juvenile neuronal ceroid lipofuscinosis"
+  },
+  {
+    "sctid": "61687004",
+    "preferred_name": "Endophlebitis of inferior sagittal sinus"
+  },
+  {
+    "sctid": "61701006",
+    "preferred_name": "Lymphocytic hypopituitarism"
+  },
+  {
+    "sctid": "61819007",
+    "preferred_name": "Rachischisis"
+  },
+  {
+    "sctid": "61831009",
+    "preferred_name": "Induced psychotic disorder"
+  },
+  {
+    "sctid": "61901004",
+    "preferred_name": "Conduct disorder, undifferentiated type"
+  },
+  {
+    "sctid": "61927004",
+    "preferred_name": "Auditory seizure"
+  },
+  {
+    "sctid": "61974008",
+    "preferred_name": "Epidural abscess"
+  },
+  {
+    "sctid": "6204001",
+    "preferred_name": "Juvenile myoclonic epilepsy"
+  },
+  {
+    "sctid": "62106007",
+    "preferred_name": "Concussion with no loss of consciousness"
+  },
+  {
+    "sctid": "62158001",
+    "preferred_name": "Status marmoratus"
+  },
+  {
+    "sctid": "62206004",
+    "preferred_name": "Abscess of pituitary"
+  },
+  {
+    "sctid": "62211000119103",
+    "preferred_name": "Moderate expressive language delay"
+  },
+  {
+    "sctid": "62221000119105",
+    "preferred_name": "Severe expressive language delay"
+  },
+  {
+    "sctid": "62231000119108",
+    "preferred_name": "Mild expressive language delay"
+  },
+  {
+    "sctid": "62351001",
+    "preferred_name": "Generalized social phobia"
+  },
+  {
+    "sctid": "62491004",
+    "preferred_name": "Frotteurism"
+  },
+  {
+    "sctid": "62564004",
+    "preferred_name": "Concussion with loss of consciousness"
+  },
+  {
+    "sctid": "6267005",
+    "preferred_name": "Congenital syphilitic meningitis"
+  },
+  {
+    "sctid": "62732009",
+    "preferred_name": "Alien limb phenomenon"
+  },
+  {
+    "sctid": "62792007",
+    "preferred_name": "Urophilia"
+  },
+  {
+    "sctid": "62904009",
+    "preferred_name": "Spastic pseudobulbar dysphonia"
+  },
+  {
+    "sctid": "62950007",
+    "preferred_name": "Encephalomyelitis"
+  },
+  {
+    "sctid": "62999006",
+    "preferred_name": "Adiposogenital dystrophy"
+  },
+  {
+    "sctid": "63081009",
+    "preferred_name": "Acute infarction of spinal cord"
+  },
+  {
+    "sctid": "63181006",
+    "preferred_name": "Paranoid schizophrenia in remission"
+  },
+  {
+    "sctid": "63204009",
+    "preferred_name": "Bouff\u00e9e d\u00e9lirante"
+  },
+  {
+    "sctid": "63249007",
+    "preferred_name": "Manic bipolar I disorder in partial remission"
+  },
+  {
+    "sctid": "63362009",
+    "preferred_name": "Disorder of visual pathways associated with vascular disorder"
+  },
+  {
+    "sctid": "63393005",
+    "preferred_name": "Anorexia nervosa, binge-eating purging type"
+  },
+  {
+    "sctid": "63412003",
+    "preferred_name": "Major depression in full remission"
+  },
+  {
+    "sctid": "6348008",
+    "preferred_name": "Cocaine-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "63576006",
+    "preferred_name": "Mixed flaccid-spastic pseudobulbar dysphonia"
+  },
+  {
+    "sctid": "63627007",
+    "preferred_name": "Spinal epidural abscess"
+  },
+  {
+    "sctid": "63649001",
+    "preferred_name": "Cannabis delusional disorder"
+  },
+  {
+    "sctid": "63701002",
+    "preferred_name": "Panic disorder with agoraphobia, mild agoraphobic avoidance AND mild panic attacks"
+  },
+  {
+    "sctid": "63778009",
+    "preferred_name": "Major depressive disorder, single episode with melancholic features"
+  },
+  {
+    "sctid": "63814006",
+    "preferred_name": "Abnormal cerebral signs in the newborn"
+  },
+  {
+    "sctid": "63819001",
+    "preferred_name": "Open fracture of T1-T6 level with central cord syndrome"
+  },
+  {
+    "sctid": "63835008",
+    "preferred_name": "Voyeurism"
+  },
+  {
+    "sctid": "63903007",
+    "preferred_name": "Incomplete spinal cord lesion at T7-T12 level without bone injury"
+  },
+  {
+    "sctid": "63909006",
+    "preferred_name": "Panic disorder with agoraphobia AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "63983005",
+    "preferred_name": "Inhalant-induced psychotic disorder with hallucinations"
+  },
+  {
+    "sctid": "63986002",
+    "preferred_name": "Brain stem herniation"
+  },
+  {
+    "sctid": "63990000",
+    "preferred_name": "Psychogenic urticaria"
+  },
+  {
+    "sctid": "64009001",
+    "preferred_name": "Basilar artery syndrome"
+  },
+  {
+    "sctid": "64060000",
+    "preferred_name": "Panic disorder with agoraphobia, moderate agoraphobic avoidance AND panic attacks in full remission"
+  },
+  {
+    "sctid": "64165008",
+    "preferred_name": "Avoidant disorder of childhood"
+  },
+  {
+    "sctid": "64246009",
+    "preferred_name": "Disorder of optic chiasm associated with non-pituitary neoplasm"
+  },
+  {
+    "sctid": "64624009",
+    "preferred_name": "Hypoglycemic encephalopathy"
+  },
+  {
+    "sctid": "64678009",
+    "preferred_name": "Non-pregnancy related A-G syndrome"
+  },
+  {
+    "sctid": "64731001",
+    "preferred_name": "Severe mixed bipolar I disorder with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "6475002",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset, uncomplicated"
+  },
+  {
+    "sctid": "64764001",
+    "preferred_name": "Acute paralytic poliomyelitis, bulbar"
+  },
+  {
+    "sctid": "64855000",
+    "preferred_name": "Pelizaeus-Merzbacher disease"
+  },
+  {
+    "sctid": "64905009",
+    "preferred_name": "Paranoid schizophrenia"
+  },
+  {
+    "sctid": "65042007",
+    "preferred_name": "Bipolar I disorder, most recent episode mixed with postpartum onset"
+  },
+  {
+    "sctid": "65064003",
+    "preferred_name": "Panic disorder without agoraphobia with moderate panic attacks"
+  },
+  {
+    "sctid": "65096006",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset, with delirium"
+  },
+  {
+    "sctid": "651003",
+    "preferred_name": "Root work"
+  },
+  {
+    "sctid": "65120008",
+    "preferred_name": "Generalized convulsive epilepsy"
+  },
+  {
+    "sctid": "65144005",
+    "preferred_name": "Congenital spinal meningocele"
+  },
+  {
+    "sctid": "65179007",
+    "preferred_name": "Koro"
+  },
+  {
+    "sctid": "65189006",
+    "preferred_name": "Extradural hemorrhage following injury with open intracranial wound"
+  },
+  {
+    "sctid": "65207000",
+    "preferred_name": "Locuru"
+  },
+  {
+    "sctid": "652287331000119104",
+    "preferred_name": "Cerebrovascular accident of brainstem"
+  },
+  {
+    "sctid": "6537000",
+    "preferred_name": "Ectopic pituitary tissue"
+  },
+  {
+    "sctid": "65384007",
+    "preferred_name": "Psychogenic alopecia"
+  },
+  {
+    "sctid": "65410009",
+    "preferred_name": "Compulsive sexual masochism"
+  },
+  {
+    "sctid": "65433005",
+    "preferred_name": "Mechanical complication of ventricular communicating shunt"
+  },
+  {
+    "sctid": "65438001",
+    "preferred_name": "Psychogenic torticollis"
+  },
+  {
+    "sctid": "65455002",
+    "preferred_name": "Nasal encephalocele"
+  },
+  {
+    "sctid": "655081461000119101",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right anterior cerebral artery"
+  },
+  {
+    "sctid": "65605001",
+    "preferred_name": "Edema of spinal cord"
+  },
+  {
+    "sctid": "65705009",
+    "preferred_name": "Porencephalic cyst"
+  },
+  {
+    "sctid": "65971000052100",
+    "preferred_name": "Acute psychosis"
+  },
+  {
+    "sctid": "66010009",
+    "preferred_name": "Supranuclear paralysis"
+  },
+  {
+    "sctid": "66020004",
+    "preferred_name": "Open fracture of C5-C7 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "6607004",
+    "preferred_name": "Syringoencephalomyelia"
+  },
+  {
+    "sctid": "66074005",
+    "preferred_name": "Leptomeningitis"
+  },
+  {
+    "sctid": "66108005",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset, uncomplicated"
+  },
+  {
+    "sctid": "66158003",
+    "preferred_name": "Closed fracture of C5-C7 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "66307007",
+    "preferred_name": "Conduct disorder, group type"
+  },
+  {
+    "sctid": "66344007",
+    "preferred_name": "Recurrent major depression"
+  },
+  {
+    "sctid": "66347000",
+    "preferred_name": "Impulse control disorder"
+  },
+  {
+    "sctid": "66381006",
+    "preferred_name": "Adjustment disorder with mixed disturbance of emotions AND conduct"
+  },
+  {
+    "sctid": "66393002",
+    "preferred_name": "Brain stem contusion with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "66454007",
+    "preferred_name": "Murray Valley encephalitis"
+  },
+  {
+    "sctid": "66590003",
+    "preferred_name": "Alcohol dependence"
+  },
+  {
+    "sctid": "66631006",
+    "preferred_name": "Moderate depressed bipolar I disorder"
+  },
+  {
+    "sctid": "66637005",
+    "preferred_name": "Hemiballism"
+  },
+  {
+    "sctid": "66760008",
+    "preferred_name": "Optic neuritis"
+  },
+  {
+    "sctid": "66881004",
+    "preferred_name": "Choreoacanthocytosis"
+  },
+  {
+    "sctid": "66936004",
+    "preferred_name": "Identity disorder"
+  },
+  {
+    "sctid": "67002003",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive, in partial remission"
+  },
+  {
+    "sctid": "67123006",
+    "preferred_name": "Adult gender identity disorder, sexually attracted to both sexes"
+  },
+  {
+    "sctid": "67155006",
+    "preferred_name": "Gerstmann-Straussler-Scheinker syndrome"
+  },
+  {
+    "sctid": "67195008",
+    "preferred_name": "Acute stress disorder"
+  },
+  {
+    "sctid": "67227000",
+    "preferred_name": "Pedophilia, same sex"
+  },
+  {
+    "sctid": "672441000119103",
+    "preferred_name": "Hemiplegia of nondominant side as sequela of ischemic cerebrovascular accident"
+  },
+  {
+    "sctid": "672451000119101",
+    "preferred_name": "Hemiplegia of nondominant side due to and following hemorrhagic cerebrovascular accident"
+  },
+  {
+    "sctid": "672461000119104",
+    "preferred_name": "Hemiplegia of dominant side as sequela of ischemic cerebrovascular accident"
+  },
+  {
+    "sctid": "672471000119105",
+    "preferred_name": "Hemiplegia of dominant side due to and following hemorrhagic cerebrovascular accident"
+  },
+  {
+    "sctid": "672561000119103",
+    "preferred_name": "Cognitive deficit due to and following ischemic cerebrovascular accident"
+  },
+  {
+    "sctid": "672571000119109",
+    "preferred_name": "Cognitive deficit due to and following hemorrhagic cerebrovascular accident"
+  },
+  {
+    "sctid": "67305007",
+    "preferred_name": "Familial essential myoclonus"
+  },
+  {
+    "sctid": "67437007",
+    "preferred_name": "Lumbar spondylosis with myelopathy"
+  },
+  {
+    "sctid": "674481000119100",
+    "preferred_name": "Spontaneous hematoma of spinal cord"
+  },
+  {
+    "sctid": "67711008",
+    "preferred_name": "Primary dysthymia late onset"
+  },
+  {
+    "sctid": "67761004",
+    "preferred_name": "Olivopontocerebellar degeneration"
+  },
+  {
+    "sctid": "67873006",
+    "preferred_name": "Isolated prolactin deficiency"
+  },
+  {
+    "sctid": "67876003",
+    "preferred_name": "Congenital obstruction of aqueduct of Sylvius"
+  },
+  {
+    "sctid": "67930001",
+    "preferred_name": "Syringoencephalia"
+  },
+  {
+    "sctid": "679691000119100",
+    "preferred_name": "Bilateral retrobulbar optic neuritis of eyes"
+  },
+  {
+    "sctid": "679701000119100",
+    "preferred_name": "Retrobulbar optic neuritis of left eye"
+  },
+  {
+    "sctid": "679711000119102",
+    "preferred_name": "Retrobulbar optic neuritis of right eye"
+  },
+  {
+    "sctid": "67975003",
+    "preferred_name": "Fibrocartilagenous emboli of spinal cord"
+  },
+  {
+    "sctid": "68019004",
+    "preferred_name": "Recurrent major depression in remission"
+  },
+  {
+    "sctid": "68061000119109",
+    "preferred_name": "Partial diabetes insipidus"
+  },
+  {
+    "sctid": "6807001",
+    "preferred_name": "Central pontine myelinolysis"
+  },
+  {
+    "sctid": "68091000119102",
+    "preferred_name": "Intractable absence seizures"
+  },
+  {
+    "sctid": "680991000119108",
+    "preferred_name": "Bilateral atrophy of optic nerves following inflammation"
+  },
+  {
+    "sctid": "68107009",
+    "preferred_name": "Cerebral paresis with homolateral ataxia"
+  },
+  {
+    "sctid": "68116008",
+    "preferred_name": "Dentatorubropallidoluysian degeneration"
+  },
+  {
+    "sctid": "682221000119103",
+    "preferred_name": "Primary anaplastic astrocytoma of cerebrum"
+  },
+  {
+    "sctid": "682231000119100",
+    "preferred_name": "Primary anaplastic astrocytoma of frontal lobe"
+  },
+  {
+    "sctid": "682241000119109",
+    "preferred_name": "Primary anaplastic astrocytoma of occipital lobe"
+  },
+  {
+    "sctid": "682251000119106",
+    "preferred_name": "Primary anaplastic astrocytoma of parietal lobe"
+  },
+  {
+    "sctid": "682261000119108",
+    "preferred_name": "Primary anaplastic astrocytoma of temporal lobe"
+  },
+  {
+    "sctid": "682451000119107",
+    "preferred_name": "Primary astrocytoma of frontal lobe"
+  },
+  {
+    "sctid": "682471000119103",
+    "preferred_name": "Primary astrocytoma of parietal lobe"
+  },
+  {
+    "sctid": "682481000119100",
+    "preferred_name": "Primary astrocytoma of temporal lobe"
+  },
+  {
+    "sctid": "68267002",
+    "preferred_name": "Benign intracranial hypertension"
+  },
+  {
+    "sctid": "683761000119107",
+    "preferred_name": "Primary ependymoma of brain ventricle"
+  },
+  {
+    "sctid": "683791000119100",
+    "preferred_name": "Primary ependymoma of parietal lobe"
+  },
+  {
+    "sctid": "68382005",
+    "preferred_name": "Cerebrospinal fluid otorrhea"
+  },
+  {
+    "sctid": "684901000119107",
+    "preferred_name": "Primary glioblastoma multiforme of cerebrum"
+  },
+  {
+    "sctid": "684911000119105",
+    "preferred_name": "Primary glioblastoma multiforme of frontal lobe"
+  },
+  {
+    "sctid": "684921000119103",
+    "preferred_name": "Primary glioblastoma multiforme of occipital lobe"
+  },
+  {
+    "sctid": "684931000119100",
+    "preferred_name": "Primary glioblastoma multiforme of parietal lobe"
+  },
+  {
+    "sctid": "684941000119109",
+    "preferred_name": "Primary glioblastoma multiforme of temporal lobe"
+  },
+  {
+    "sctid": "68504005",
+    "preferred_name": "Ataxia-telangiectasia syndrome"
+  },
+  {
+    "sctid": "68569003",
+    "preferred_name": "Manic bipolar I disorder"
+  },
+  {
+    "sctid": "68574006",
+    "preferred_name": "Cortical blindness"
+  },
+  {
+    "sctid": "68577004",
+    "preferred_name": "Acute necrotizing myelitis"
+  },
+  {
+    "sctid": "68618008",
+    "preferred_name": "Rett's disorder"
+  },
+  {
+    "sctid": "686431000119100",
+    "preferred_name": "Primary malignant glioma of frontal lobe"
+  },
+  {
+    "sctid": "686441000119109",
+    "preferred_name": "Primary malignant glioma of occipital lobe"
+  },
+  {
+    "sctid": "686451000119106",
+    "preferred_name": "Primary malignant glioma of parietal lobe"
+  },
+  {
+    "sctid": "686461000119108",
+    "preferred_name": "Primary malignant glioma of temporal lobe"
+  },
+  {
+    "sctid": "687331000119109",
+    "preferred_name": "Primary oligodendroglioma of frontal lobe"
+  },
+  {
+    "sctid": "687351000119103",
+    "preferred_name": "Primary oligodendroglioma of parietal lobe"
+  },
+  {
+    "sctid": "687361000119101",
+    "preferred_name": "Primary oligodendroglioma of temporal lobe"
+  },
+  {
+    "sctid": "68761002",
+    "preferred_name": "Epileptic vertigo"
+  },
+  {
+    "sctid": "68764005",
+    "preferred_name": "Juvenile taboparesis"
+  },
+  {
+    "sctid": "68863007",
+    "preferred_name": "Acute syphilitic meningitis"
+  },
+  {
+    "sctid": "68890003",
+    "preferred_name": "Schizoaffective disorder"
+  },
+  {
+    "sctid": "68963006",
+    "preferred_name": "Gender identity disorder of adolescence, previously heterosexual"
+  },
+  {
+    "sctid": "68995007",
+    "preferred_name": "Chronic catatonic schizophrenia"
+  },
+  {
+    "sctid": "69017006",
+    "preferred_name": "Cortical vertigo"
+  },
+  {
+    "sctid": "690271000119104",
+    "preferred_name": "Hemiplegia of nondominant side as sequela of embolic cerebrovascular accident"
+  },
+  {
+    "sctid": "690281000119101",
+    "preferred_name": "Hemiplegia of dominant side due to and following embolic cerebrovascular accident"
+  },
+  {
+    "sctid": "690341000119100",
+    "preferred_name": "Cognitive deficit due to and following embolic cerebrovascular accident"
+  },
+  {
+    "sctid": "69116000",
+    "preferred_name": "Moyamoya disease"
+  },
+  {
+    "sctid": "69131009",
+    "preferred_name": "Spinal ataxia"
+  },
+  {
+    "sctid": "691461000119103",
+    "preferred_name": "Acquired cerebral atrophy"
+  },
+  {
+    "sctid": "69322001",
+    "preferred_name": "Psychotic disorder"
+  },
+  {
+    "sctid": "69361009",
+    "preferred_name": "Kleptomania"
+  },
+  {
+    "sctid": "69392006",
+    "preferred_name": "Major depressive disorder, single episode with catatonic features"
+  },
+  {
+    "sctid": "69479009",
+    "preferred_name": "Anxiety hyperventilation"
+  },
+  {
+    "sctid": "69482004",
+    "preferred_name": "Korsakoff's psychosis"
+  },
+  {
+    "sctid": "6955002",
+    "preferred_name": "Negishi encephalitis"
+  },
+  {
+    "sctid": "698021005",
+    "preferred_name": "Autosomal dominant nocturnal frontal lobe epilepsy"
+  },
+  {
+    "sctid": "69820004",
+    "preferred_name": "Injury of optic chiasm"
+  },
+  {
+    "sctid": "698279003",
+    "preferred_name": "X-linked dystonia parkinsonism"
+  },
+  {
+    "sctid": "698404009",
+    "preferred_name": "Injury at T7 - T12 level with central cord syndrome"
+  },
+  {
+    "sctid": "698500002",
+    "preferred_name": "Spinal cord injury due to birth trauma"
+  },
+  {
+    "sctid": "698617004",
+    "preferred_name": "Closed fracture of vault of skull with concussion"
+  },
+  {
+    "sctid": "698618009",
+    "preferred_name": "Open fracture of vault of skull with loss of consciousness"
+  },
+  {
+    "sctid": "698619001",
+    "preferred_name": "Open fracture of vault of skull with concussion"
+  },
+  {
+    "sctid": "698620007",
+    "preferred_name": "Closed fracture of base of skull with loss of consciousness"
+  },
+  {
+    "sctid": "698621006",
+    "preferred_name": "Closed fracture of base of skull with concussion"
+  },
+  {
+    "sctid": "698624003",
+    "preferred_name": "Dementia associated with cerebral lipidosis"
+  },
+  {
+    "sctid": "698625002",
+    "preferred_name": "Dementia associated with normal pressure hydrocephalus"
+  },
+  {
+    "sctid": "698626001",
+    "preferred_name": "Dementia associated with multiple sclerosis"
+  },
+  {
+    "sctid": "698633001",
+    "preferred_name": "Postoperative meningitis"
+  },
+  {
+    "sctid": "698641001",
+    "preferred_name": "Postoperative aseptic meningitis"
+  },
+  {
+    "sctid": "698687007",
+    "preferred_name": "Post-traumatic dementia with behavioral change"
+  },
+  {
+    "sctid": "698689005",
+    "preferred_name": "Attention deficit hyperactivity disorder, predominantly inattentive type in remission"
+  },
+  {
+    "sctid": "698690001",
+    "preferred_name": "Avoidant personality disorder in remission"
+  },
+  {
+    "sctid": "698691002",
+    "preferred_name": "Cognitive disorder in remission"
+  },
+  {
+    "sctid": "698692009",
+    "preferred_name": "Attention deficit hyperactivity disorder, predominantly hyperactive impulsive type in remission"
+  },
+  {
+    "sctid": "698693004",
+    "preferred_name": "Adjustment disorder with anxious mood in remission"
+  },
+  {
+    "sctid": "698695006",
+    "preferred_name": "Anorexia nervosa in remission"
+  },
+  {
+    "sctid": "698696007",
+    "preferred_name": "Adjustment disorder with depressed mood in remission"
+  },
+  {
+    "sctid": "698697003",
+    "preferred_name": "Adjustment disorder with mixed disturbance of emotions and conduct in remission"
+  },
+  {
+    "sctid": "698698008",
+    "preferred_name": "Bulimia nervosa in remission"
+  },
+  {
+    "sctid": "698699000",
+    "preferred_name": "Antisocial personality disorder in remission"
+  },
+  {
+    "sctid": "698700004",
+    "preferred_name": "Borderline personality disorder in remission"
+  },
+  {
+    "sctid": "698701000",
+    "preferred_name": "Adjustment disorder in remission"
+  },
+  {
+    "sctid": "698725008",
+    "preferred_name": "Dementia associated with neurosyphilis"
+  },
+  {
+    "sctid": "698726009",
+    "preferred_name": "Dementia associated with viral encephalitis"
+  },
+  {
+    "sctid": "698734003",
+    "preferred_name": "Postoperative bacterial meningitis"
+  },
+  {
+    "sctid": "698736001",
+    "preferred_name": "Postoperative communicating hydrocephalus"
+  },
+  {
+    "sctid": "698737005",
+    "preferred_name": "Obstructive hydrocephalus due to and following meningitis"
+  },
+  {
+    "sctid": "698738000",
+    "preferred_name": "Brainstem myoclonus"
+  },
+  {
+    "sctid": "69875006",
+    "preferred_name": "Cortex laceration with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "698760002",
+    "preferred_name": "Generalized non-convulsive absence epilepsy"
+  },
+  {
+    "sctid": "698761003",
+    "preferred_name": "Refractory juvenile myoclonic epilepsy"
+  },
+  {
+    "sctid": "698762005",
+    "preferred_name": "Refractory myoclonic epilepsy"
+  },
+  {
+    "sctid": "698763000",
+    "preferred_name": "Postoperative status epilepticus"
+  },
+  {
+    "sctid": "698764006",
+    "preferred_name": "Post infectious grand mal epilepsy"
+  },
+  {
+    "sctid": "698767004",
+    "preferred_name": "Post-cerebrovascular accident epilepsy"
+  },
+  {
+    "sctid": "698781002",
+    "preferred_name": "Dementia associated with cerebral anoxia"
+  },
+  {
+    "sctid": "698782009",
+    "preferred_name": "Posttraumatic meningitis"
+  },
+  {
+    "sctid": "698783004",
+    "preferred_name": "Injury at T7-T12 level with anterior cord syndrome"
+  },
+  {
+    "sctid": "698835006",
+    "preferred_name": "Cerebral cortex myoclonus"
+  },
+  {
+    "sctid": "698836007",
+    "preferred_name": "Spinal cord myoclonus"
+  },
+  {
+    "sctid": "698837003",
+    "preferred_name": "Posttraumatic porencephalic cyst of brain"
+  },
+  {
+    "sctid": "698838008",
+    "preferred_name": "Benign intracranial hypertension due to drug"
+  },
+  {
+    "sctid": "698839000",
+    "preferred_name": "Benign intracranial hypertension due to hypervitaminosis A"
+  },
+  {
+    "sctid": "698870008",
+    "preferred_name": "2-hydroxyglutaric aciduria"
+  },
+  {
+    "sctid": "698946008",
+    "preferred_name": "Cyclothymia in remission"
+  },
+  {
+    "sctid": "698947004",
+    "preferred_name": "Conduct disorder in remission"
+  },
+  {
+    "sctid": "698948009",
+    "preferred_name": "Vascular dementia in remission"
+  },
+  {
+    "sctid": "698949001",
+    "preferred_name": "Dementia in remission"
+  },
+  {
+    "sctid": "698951002",
+    "preferred_name": "Delusional disorder in remission"
+  },
+  {
+    "sctid": "698952009",
+    "preferred_name": "Dissociative disorder in remission"
+  },
+  {
+    "sctid": "698954005",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, senile onset in remission"
+  },
+  {
+    "sctid": "698955006",
+    "preferred_name": "Primary degenerative dementia of the Alzheimer type, presenile onset in remission"
+  },
+  {
+    "sctid": "698957003",
+    "preferred_name": "Depressive disorder in remission"
+  },
+  {
+    "sctid": "698958008",
+    "preferred_name": "Delirium in remission"
+  },
+  {
+    "sctid": "698999002",
+    "preferred_name": "Atresia of aqueduct of Sylvius"
+  },
+  {
+    "sctid": "69909000",
+    "preferred_name": "Eclampsia added to pre-existing hypertension"
+  },
+  {
+    "sctid": "699184009",
+    "preferred_name": "Perry syndrome"
+  },
+  {
+    "sctid": "699241002",
+    "preferred_name": "Chronic post-traumatic stress disorder following military combat"
+  },
+  {
+    "sctid": "699297004",
+    "preferred_name": "Ohdo syndrome, Maat-Kievit-Brunner type"
+  },
+  {
+    "sctid": "699298009",
+    "preferred_name": "Ohdo syndrome, Say-Barber-Biesecker-Young-Simpson variant"
+  },
+  {
+    "sctid": "699299001",
+    "preferred_name": "Neuroferritinopathy"
+  },
+  {
+    "sctid": "699314009",
+    "preferred_name": "Migraine with persistent visual aura"
+  },
+  {
+    "sctid": "699316006",
+    "preferred_name": "Myhre syndrome"
+  },
+  {
+    "sctid": "699318007",
+    "preferred_name": "Supratentorial primitive neuroectodermal tumor"
+  },
+  {
+    "sctid": "699328003",
+    "preferred_name": "Myoclonic epilepsy myopathy sensory ataxia"
+  },
+  {
+    "sctid": "699331002",
+    "preferred_name": "Granular cell tumor of neurohypophysis"
+  },
+  {
+    "sctid": "699669001",
+    "preferred_name": "Renpenning syndrome"
+  },
+  {
+    "sctid": "699688008",
+    "preferred_name": "Generalized epilepsy with febrile seizures plus"
+  },
+  {
+    "sctid": "699704002",
+    "preferred_name": "Classic medulloblastoma"
+  },
+  {
+    "sctid": "699812002",
+    "preferred_name": "Subependymal nodular heterotopia"
+  },
+  {
+    "sctid": "699813007",
+    "preferred_name": "Xanthogranuloma of choroid plexus"
+  },
+  {
+    "sctid": "699814001",
+    "preferred_name": "Primary angiitis of central nervous system"
+  },
+  {
+    "sctid": "699866005",
+    "preferred_name": "Brown-Vialetto-Van Laere syndrome"
+  },
+  {
+    "sctid": "700063005",
+    "preferred_name": "Megalencephaly capillary malformation"
+  },
+  {
+    "sctid": "700213005",
+    "preferred_name": "Avoidant restrictive food intake disorder"
+  },
+  {
+    "sctid": "700219009",
+    "preferred_name": "Idiopathic intracranial hypotension"
+  },
+  {
+    "sctid": "70043001",
+    "preferred_name": "Severe mood disorder with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "702314005",
+    "preferred_name": "Non-spastic cerebral palsy"
+  },
+  {
+    "sctid": "702315006",
+    "preferred_name": "Dystonic cerebral palsy"
+  },
+  {
+    "sctid": "702316007",
+    "preferred_name": "Choreic cerebral palsy"
+  },
+  {
+    "sctid": "702317003",
+    "preferred_name": "Chorea-athetoid cerebral palsy"
+  },
+  {
+    "sctid": "702318008",
+    "preferred_name": "Mixed cerebral palsy"
+  },
+  {
+    "sctid": "702319000",
+    "preferred_name": "Bilateral cerebral palsy"
+  },
+  {
+    "sctid": "702320006",
+    "preferred_name": "Triplegic cerebral palsy"
+  },
+  {
+    "sctid": "702321005",
+    "preferred_name": "Pentaplegic cerebral palsy"
+  },
+  {
+    "sctid": "702323008",
+    "preferred_name": "Rapid onset dystonia parkinsonism"
+  },
+  {
+    "sctid": "702326000",
+    "preferred_name": "Progressive myoclonus epilepsy with ataxia"
+  },
+  {
+    "sctid": "702344008",
+    "preferred_name": "Pitt-Hopkins syndrome"
+  },
+  {
+    "sctid": "702347001",
+    "preferred_name": "Polycystic lipomembranous osteodysplasia with sclerosing leukoencephalopathy"
+  },
+  {
+    "sctid": "702356009",
+    "preferred_name": "PPM-X syndrome"
+  },
+  {
+    "sctid": "702375004",
+    "preferred_name": "Familial isolated pituitary adenoma"
+  },
+  {
+    "sctid": "702376003",
+    "preferred_name": "Huntington disease-like syndrome"
+  },
+  {
+    "sctid": "702377007",
+    "preferred_name": "Hypermanganesemia with dystonia, polycythemia, and cirrhosis"
+  },
+  {
+    "sctid": "702379005",
+    "preferred_name": "Hypomyelination and congenital cataract"
+  },
+  {
+    "sctid": "702393003",
+    "preferred_name": "CHMP2B-related frontotemporal dementia"
+  },
+  {
+    "sctid": "702412005",
+    "preferred_name": "Partington syndrome"
+  },
+  {
+    "sctid": "702416008",
+    "preferred_name": "Snyder-Robinson syndrome"
+  },
+  {
+    "sctid": "702421006",
+    "preferred_name": "Familial encephalopathy with neuroserpin inclusion bodies"
+  },
+  {
+    "sctid": "702426001",
+    "preferred_name": "GRN-related frontotemporal dementia"
+  },
+  {
+    "sctid": "702427005",
+    "preferred_name": "Hereditary diffuse leukoencephalopathy with spheroids"
+  },
+  {
+    "sctid": "702429008",
+    "preferred_name": "Frontotemporal dementia with parkinsonism-17"
+  },
+  {
+    "sctid": "702437000",
+    "preferred_name": "Amish lethal microcephaly"
+  },
+  {
+    "sctid": "702441001",
+    "preferred_name": "Arts syndrome"
+  },
+  {
+    "sctid": "702448007",
+    "preferred_name": "Dystonia 6"
+  },
+  {
+    "sctid": "702450004",
+    "preferred_name": "FOXG1 syndrome"
+  },
+  {
+    "sctid": "7025000",
+    "preferred_name": "Subchronic undifferentiated schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "702528003",
+    "preferred_name": "Developmental delay in receptive-expressive language"
+  },
+  {
+    "sctid": "702611008",
+    "preferred_name": "Congenital brain aplasia"
+  },
+  {
+    "sctid": "702628006",
+    "preferred_name": "Congenital anomaly of cerebrum"
+  },
+  {
+    "sctid": "702711004",
+    "preferred_name": "Mental disorder in mother complicating pregnancy"
+  },
+  {
+    "sctid": "702732007",
+    "preferred_name": "High-functioning autism"
+  },
+  {
+    "sctid": "702753003",
+    "preferred_name": "Complete partial seizure of uncertain origin"
+  },
+  {
+    "sctid": "702815001",
+    "preferred_name": "Attention deficit hyperactivity disorder, inattentive presentation (restrictive)"
+  },
+  {
+    "sctid": "702816000",
+    "preferred_name": "Methyl-cytosine phosphate guanine binding protein-2 duplication syndrome"
+  },
+  {
+    "sctid": "702949005",
+    "preferred_name": "Proopiomelanocortin deficiency syndrome"
+  },
+  {
+    "sctid": "703041000",
+    "preferred_name": "Dysexecutive syndrome"
+  },
+  {
+    "sctid": "7031000119100",
+    "preferred_name": "Psychogenic fugue co-occurrent and due to stress reaction"
+  },
+  {
+    "sctid": "703156006",
+    "preferred_name": "Deep hemispheric cerebral hemorrhage"
+  },
+  {
+    "sctid": "703166003",
+    "preferred_name": "Dural arteriovenous fistula"
+  },
+  {
+    "sctid": "703174002",
+    "preferred_name": "Subarachnoid hemorrhage from vertebral artery aneurysm"
+  },
+  {
+    "sctid": "703215002",
+    "preferred_name": "Non-aneurysmal subarachnoid intracranial hemorrhage"
+  },
+  {
+    "sctid": "703216001",
+    "preferred_name": "Perimesencephalic subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "703217005",
+    "preferred_name": "Convexal subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "70328006",
+    "preferred_name": "Cocaine intoxication delirium"
+  },
+  {
+    "sctid": "703300001",
+    "preferred_name": "Hypoxic ischemic encephalopathy"
+  },
+  {
+    "sctid": "7033004",
+    "preferred_name": "Petit mal status"
+  },
+  {
+    "sctid": "703301002",
+    "preferred_name": "Mild hypoxic ischemic encephalopathy"
+  },
+  {
+    "sctid": "703302009",
+    "preferred_name": "Moderate hypoxic ischemic encephalopathy"
+  },
+  {
+    "sctid": "703303004",
+    "preferred_name": "Severe hypoxic ischemic encephalopathy"
+  },
+  {
+    "sctid": "703304005",
+    "preferred_name": "Hypoxic ischemic encephalopathy due to strangulation"
+  },
+  {
+    "sctid": "703305006",
+    "preferred_name": "Hypoxic ischemic encephalopathy due to cardiac arrest"
+  },
+  {
+    "sctid": "703369003",
+    "preferred_name": "Microcephaly-capillary malformation syndrome"
+  },
+  {
+    "sctid": "703389002",
+    "preferred_name": "CASK related intellectual disability"
+  },
+  {
+    "sctid": "703429003",
+    "preferred_name": "Malignant optic glioma of adulthood"
+  },
+  {
+    "sctid": "70350007",
+    "preferred_name": "Degenerative myelopathy"
+  },
+  {
+    "sctid": "703522009",
+    "preferred_name": "Biotin-thiamine-responsive basal ganglia disease"
+  },
+  {
+    "sctid": "703524005",
+    "preferred_name": "Spinal muscular atrophy with progressive myoclonic epilepsy"
+  },
+  {
+    "sctid": "703526007",
+    "preferred_name": "Neuronal ceroid lipofuscinosis 8"
+  },
+  {
+    "sctid": "703535000",
+    "preferred_name": "Mowat-Wilson syndrome"
+  },
+  {
+    "sctid": "703536004",
+    "preferred_name": "Megalencephalic leukoencephalopathy with subcortical cysts"
+  },
+  {
+    "sctid": "703537008",
+    "preferred_name": "Leukoencephalopathy with brainstem and spinal cord involvement and lactate elevation"
+  },
+  {
+    "sctid": "703542000",
+    "preferred_name": "Retinal detachment and occipital encephalocele"
+  },
+  {
+    "sctid": "703543005",
+    "preferred_name": "Infantile ascending hereditary spastic paralysis"
+  },
+  {
+    "sctid": "703621006",
+    "preferred_name": "Multifocal clinically isolated syndrome"
+  },
+  {
+    "sctid": "703622004",
+    "preferred_name": "Monofocal clinically isolated syndrome"
+  },
+  {
+    "sctid": "703850002",
+    "preferred_name": "Delirium due to benzodiazepine withdrawal"
+  },
+  {
+    "sctid": "703861005",
+    "preferred_name": "Spinal epidural hematoma"
+  },
+  {
+    "sctid": "703862003",
+    "preferred_name": "Spinal subdural hematoma"
+  },
+  {
+    "sctid": "704079000",
+    "preferred_name": "Non-aneurysmal perimesencephalic subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "70476006",
+    "preferred_name": "Optic chiasm disorder"
+  },
+  {
+    "sctid": "705001007",
+    "preferred_name": "Self-induced vomiting to lose weight"
+  },
+  {
+    "sctid": "705128004",
+    "preferred_name": "Cerebral infarction due to embolism of middle cerebral artery"
+  },
+  {
+    "sctid": "705130002",
+    "preferred_name": "Cerebral infarction due to thrombosis of middle cerebral artery"
+  },
+  {
+    "sctid": "7052005",
+    "preferred_name": "Alcohol hallucinosis"
+  },
+  {
+    "sctid": "70534000",
+    "preferred_name": "Occult spinal dysraphism sequence"
+  },
+  {
+    "sctid": "70546001",
+    "preferred_name": "Severe bipolar disorder with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "70576008",
+    "preferred_name": "Enteroviral encephalomyelitis"
+  },
+  {
+    "sctid": "70611002",
+    "preferred_name": "Perinatal intraventricular hemorrhage"
+  },
+  {
+    "sctid": "70655008",
+    "preferred_name": "Caffeine-induced anxiety disorder"
+  },
+  {
+    "sctid": "70691001",
+    "preferred_name": "Agoraphobia"
+  },
+  {
+    "sctid": "70694009",
+    "preferred_name": "Diabetes mellitus AND insipidus with optic atrophy AND deafness"
+  },
+  {
+    "sctid": "70747007",
+    "preferred_name": "Major depression single episode, in partial remission"
+  },
+  {
+    "sctid": "70764005",
+    "preferred_name": "Depersonalization disorder"
+  },
+  {
+    "sctid": "70784009",
+    "preferred_name": "Meningeal irritation"
+  },
+  {
+    "sctid": "708037001",
+    "preferred_name": "Residual Asperger's disorder"
+  },
+  {
+    "sctid": "70814008",
+    "preferred_name": "Subchronic residual schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "70835005",
+    "preferred_name": "Disorder of basal ganglia"
+  },
+  {
+    "sctid": "708728007",
+    "preferred_name": "Traumatic brain injury of unknown intent"
+  },
+  {
+    "sctid": "70884002",
+    "preferred_name": "Allergic encephalitis"
+  },
+  {
+    "sctid": "709073001",
+    "preferred_name": "Neurocognitive disorder"
+  },
+  {
+    "sctid": "70922000",
+    "preferred_name": "Compulsive pedophilia"
+  },
+  {
+    "sctid": "70932007",
+    "preferred_name": "Amphetamine-induced sexual dysfunction"
+  },
+  {
+    "sctid": "70936005",
+    "preferred_name": "Multi-infarct dementia, uncomplicated"
+  },
+  {
+    "sctid": "70967007",
+    "preferred_name": "Hysterical deafness"
+  },
+  {
+    "sctid": "71003000",
+    "preferred_name": "Ateleiotic dwarfism"
+  },
+  {
+    "sctid": "710046001",
+    "preferred_name": "Refractory idiopathic generalized epilepsy"
+  },
+  {
+    "sctid": "710072005",
+    "preferred_name": "Female athlete triad"
+  },
+  {
+    "sctid": "71103003",
+    "preferred_name": "Chronic residual schizophrenia"
+  },
+  {
+    "sctid": "71105005",
+    "preferred_name": "Ilheus virus encephalitis"
+  },
+  {
+    "sctid": "711158005",
+    "preferred_name": "Spinocerebellar ataxia type 36"
+  },
+  {
+    "sctid": "711403001",
+    "preferred_name": "Cerebral folate transport deficiency"
+  },
+  {
+    "sctid": "711482008",
+    "preferred_name": "Cerebroretinal microangiopathy with calcifications and cysts"
+  },
+  {
+    "sctid": "711487002",
+    "preferred_name": "MECP2-related severe neonatal encephalopathy"
+  },
+  {
+    "sctid": "7125002",
+    "preferred_name": "Meningoencephalitis"
+  },
+  {
+    "sctid": "712637001",
+    "preferred_name": "RNA polymerase III-related leukodystrophy"
+  },
+  {
+    "sctid": "712647003",
+    "preferred_name": "Spasmodic torticollis due to infection"
+  },
+  {
+    "sctid": "712733005",
+    "preferred_name": "Traumatic injury of optic disk"
+  },
+  {
+    "sctid": "712820006",
+    "preferred_name": "Cerebral pseudoatrophy"
+  },
+  {
+    "sctid": "712823008",
+    "preferred_name": "Acute depression"
+  },
+  {
+    "sctid": "712824002",
+    "preferred_name": "Acute polymorphic psychotic disorder without symptoms of schizophrenia"
+  },
+  {
+    "sctid": "712850003",
+    "preferred_name": "Acute polymorphic psychotic disorder co-occurrent with symptoms of schizophrenia"
+  },
+  {
+    "sctid": "71286001",
+    "preferred_name": "Spinal cord compression"
+  },
+  {
+    "sctid": "712884004",
+    "preferred_name": "Pathological demand avoidance"
+  },
+  {
+    "sctid": "71294008",
+    "preferred_name": "Mild bipolar II disorder, most recent episode major depressive"
+  },
+  {
+    "sctid": "712986001",
+    "preferred_name": "Encephalitis caused by tick-borne encephalitis virus"
+  },
+  {
+    "sctid": "713060000",
+    "preferred_name": "Sporadic Creutzfeldt-Jakob disease"
+  },
+  {
+    "sctid": "713260006",
+    "preferred_name": "Subacute adenoviral encephalitis co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "71328000",
+    "preferred_name": "Opioid-induced sexual dysfunction"
+  },
+  {
+    "sctid": "713325002",
+    "preferred_name": "Primary cerebral lymphoma co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713327005",
+    "preferred_name": "Malignant meningioma of meninges of brain"
+  },
+  {
+    "sctid": "713341001",
+    "preferred_name": "Myelitis co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "71336009",
+    "preferred_name": "Recurrent major depressive disorder with postpartum onset"
+  },
+  {
+    "sctid": "713401006",
+    "preferred_name": "Combined D-2-hydroxyglutaric aciduria and L-2-hydroxyglutaric aciduria"
+  },
+  {
+    "sctid": "713417000",
+    "preferred_name": "Optic perineuritis"
+  },
+  {
+    "sctid": "713425003",
+    "preferred_name": "Metastatic spinal cord compression"
+  },
+  {
+    "sctid": "713487008",
+    "preferred_name": "Progressive multifocal leukoencephalopathy co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713488003",
+    "preferred_name": "Presenile dementia co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713491003",
+    "preferred_name": "Organic brain syndrome co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713503007",
+    "preferred_name": "Disorder of spinal cord co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713543002",
+    "preferred_name": "Demyelinating disease of central nervous system co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713571008",
+    "preferred_name": "Disorder of central nervous system co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713583005",
+    "preferred_name": "Mild alcohol dependence"
+  },
+  {
+    "sctid": "713624009",
+    "preferred_name": "Meningitis caused by Histoplasma capsulatum"
+  },
+  {
+    "sctid": "713625005",
+    "preferred_name": "Meningitis caused by Histoplasma duboisii"
+  },
+  {
+    "sctid": "713626006",
+    "preferred_name": "Meningitis caused by Histoplasmosis"
+  },
+  {
+    "sctid": "713844000",
+    "preferred_name": "Dementia co-occurrent with human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "713861002",
+    "preferred_name": "Subdural effusion"
+  },
+  {
+    "sctid": "713862009",
+    "preferred_name": "Severe alcohol dependence"
+  },
+  {
+    "sctid": "713956000",
+    "preferred_name": "Spasmodic torticollis as late effect of trauma"
+  },
+  {
+    "sctid": "714279000",
+    "preferred_name": "Human T-cell lymphotropic virus 1-associated myelopathy"
+  },
+  {
+    "sctid": "71460009",
+    "preferred_name": "Trypanosomiasis with encephalitis"
+  },
+  {
+    "sctid": "714829008",
+    "preferred_name": "Moderate alcohol dependence"
+  },
+  {
+    "sctid": "715338007",
+    "preferred_name": "Fatal infantile lactic acidosis with methylmalonic aciduria"
+  },
+  {
+    "sctid": "715345007",
+    "preferred_name": "Young onset Parkinson disease"
+  },
+  {
+    "sctid": "715366004",
+    "preferred_name": "Autosomal recessive cerebellar ataxia with oculomotor apraxia type 1"
+  },
+  {
+    "sctid": "715369006",
+    "preferred_name": "Autosomal recessive cerebelloparenchymal disorder type 3"
+  },
+  {
+    "sctid": "715371006",
+    "preferred_name": "Cerebellar ataxia and ectodermal dysplasia"
+  },
+  {
+    "sctid": "715374003",
+    "preferred_name": "Autosomal dominant optic atrophy plus syndrome"
+  },
+  {
+    "sctid": "715406003",
+    "preferred_name": "Isolated lissencephaly type 1 without known genetic defect"
+  },
+  {
+    "sctid": "715409005",
+    "preferred_name": "C syndrome"
+  },
+  {
+    "sctid": "715415005",
+    "preferred_name": "Richards-Rundle syndrome"
+  },
+  {
+    "sctid": "715422002",
+    "preferred_name": "Craniotelencephalic dysplasia"
+  },
+  {
+    "sctid": "715425000",
+    "preferred_name": "Benign focal seizure of adolescence"
+  },
+  {
+    "sctid": "715428003",
+    "preferred_name": "Skeletal dysplasia with epilepsy and short stature syndrome"
+  },
+  {
+    "sctid": "715436007",
+    "preferred_name": "Congenital cerebellar hypoplasia co-occurrent with tapetoretinal degeneration"
+  },
+  {
+    "sctid": "715441004",
+    "preferred_name": "McDonough syndrome"
+  },
+  {
+    "sctid": "715462003",
+    "preferred_name": "Microcephaly with cervical spine fusion anomaly"
+  },
+  {
+    "sctid": "715463008",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 2"
+  },
+  {
+    "sctid": "715464002",
+    "preferred_name": "Seemanova Lesny syndrome"
+  },
+  {
+    "sctid": "715465001",
+    "preferred_name": "Bedouin spastic ataxia syndrome"
+  },
+  {
+    "sctid": "715482004",
+    "preferred_name": "Microcephalic primordial dwarfism Toriello type"
+  },
+  {
+    "sctid": "715483009",
+    "preferred_name": "Olivopontocerebellar atrophy and deafness"
+  },
+  {
+    "sctid": "715491000",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 11"
+  },
+  {
+    "sctid": "715504003",
+    "preferred_name": "Spastic paraparesis and deafness"
+  },
+  {
+    "sctid": "715507005",
+    "preferred_name": "Lyme neuroborreliosis"
+  },
+  {
+    "sctid": "715533002",
+    "preferred_name": "MMEP syndrome"
+  },
+  {
+    "sctid": "715534008",
+    "preferred_name": "ICCA syndrome"
+  },
+  {
+    "sctid": "715564000",
+    "preferred_name": "Paroxysmal dystonic choreoathetosis with episodic ataxia and spasticity"
+  },
+  {
+    "sctid": "715574002",
+    "preferred_name": "Posterior cortical atrophy syndrome"
+  },
+  {
+    "sctid": "715628009",
+    "preferred_name": "MORM syndrome"
+  },
+  {
+    "sctid": "715629001",
+    "preferred_name": "Generalized epilepsy and paroxysmal dyskinesia syndrome"
+  },
+  {
+    "sctid": "715662009",
+    "preferred_name": "Iatrogenic Jakob-Creutzfeldt disease"
+  },
+  {
+    "sctid": "715668008",
+    "preferred_name": "Pituitary deficiency due to empty sella turcica syndrome"
+  },
+  {
+    "sctid": "715726000",
+    "preferred_name": "Spinocerebellar ataxia type 7"
+  },
+  {
+    "sctid": "715727009",
+    "preferred_name": "Pituitary stalk interruption syndrome"
+  },
+  {
+    "sctid": "715737004",
+    "preferred_name": "Parkinsonism with dementia of Guadeloupe"
+  },
+  {
+    "sctid": "715748006",
+    "preferred_name": "Spinocerebellar ataxia type 1"
+  },
+  {
+    "sctid": "715751004",
+    "preferred_name": "Spinocerebellar ataxia type 2"
+  },
+  {
+    "sctid": "715752006",
+    "preferred_name": "Spinocerebellar ataxia type 6"
+  },
+  {
+    "sctid": "715753001",
+    "preferred_name": "Spinocerebellar ataxia type 8"
+  },
+  {
+    "sctid": "715754007",
+    "preferred_name": "Spinocerebellar ataxia type 10"
+  },
+  {
+    "sctid": "715755008",
+    "preferred_name": "Spinocerebellar ataxia type 4"
+  },
+  {
+    "sctid": "715768000",
+    "preferred_name": "Autosomal dominant dopa responsive dystonia"
+  },
+  {
+    "sctid": "715776003",
+    "preferred_name": "Spastic paraplegia type 7"
+  },
+  {
+    "sctid": "715777007",
+    "preferred_name": "Primary dystonia type 2"
+  },
+  {
+    "sctid": "715780008",
+    "preferred_name": "Lissencephaly type 1 due to doublecortin gene mutation"
+  },
+  {
+    "sctid": "715794009",
+    "preferred_name": "RAVINE syndrome"
+  },
+  {
+    "sctid": "715807002",
+    "preferred_name": "Familial Creutzfeldt-Jakob"
+  },
+  {
+    "sctid": "715817007",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia"
+  },
+  {
+    "sctid": "715819005",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type B"
+  },
+  {
+    "sctid": "715820004",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type C"
+  },
+  {
+    "sctid": "715821000",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type D"
+  },
+  {
+    "sctid": "715822007",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type F"
+  },
+  {
+    "sctid": "715824008",
+    "preferred_name": "Spinocerebellar ataxia type 28"
+  },
+  {
+    "sctid": "715825009",
+    "preferred_name": "Spinocerebellar ataxia type 29"
+  },
+  {
+    "sctid": "715826005",
+    "preferred_name": "Spinocerebellar ataxia type 31"
+  },
+  {
+    "sctid": "715827001",
+    "preferred_name": "Autosomal recessive dopa responsive dystonia"
+  },
+  {
+    "sctid": "715904005",
+    "preferred_name": "Pineal parenchymal tumor of intermediate differentiation"
+  },
+  {
+    "sctid": "715905006",
+    "preferred_name": "Unilateral polymicrogyria"
+  },
+  {
+    "sctid": "715924009",
+    "preferred_name": "Disruptive mood dysregulation disorder"
+  },
+  {
+    "sctid": "715951007",
+    "preferred_name": "Acrocallosal syndrome"
+  },
+  {
+    "sctid": "715980003",
+    "preferred_name": "Encephalopathy due to sulfite oxidase deficiency"
+  },
+  {
+    "sctid": "715981004",
+    "preferred_name": "Autosomal recessive primary microcephaly"
+  },
+  {
+    "sctid": "715984007",
+    "preferred_name": "Boucher Neuh\u00e4user syndrome"
+  },
+  {
+    "sctid": "715989002",
+    "preferred_name": "Karandikar Maria Kamble syndrome"
+  },
+  {
+    "sctid": "715990006",
+    "preferred_name": "Cerebellum agenesis with hydrocephaly"
+  },
+  {
+    "sctid": "716023007",
+    "preferred_name": "MacDermot Winter syndrome"
+  },
+  {
+    "sctid": "716024001",
+    "preferred_name": "GMS syndrome"
+  },
+  {
+    "sctid": "716051003",
+    "preferred_name": "CVA (cerebrovascular accident) during surgery"
+  },
+  {
+    "sctid": "716089008",
+    "preferred_name": "Harrod syndrome"
+  },
+  {
+    "sctid": "716096005",
+    "preferred_name": "Goldblatt Wallis syndrome"
+  },
+  {
+    "sctid": "716107009",
+    "preferred_name": "Early onset parkinsonism and intellectual disability syndrome"
+  },
+  {
+    "sctid": "716108004",
+    "preferred_name": "Fryns macrocephaly"
+  },
+  {
+    "sctid": "716112005",
+    "preferred_name": "Kawashima Tsuji syndrome"
+  },
+  {
+    "sctid": "716169009",
+    "preferred_name": "Morse Rawnsley Sargent syndrome"
+  },
+  {
+    "sctid": "716191002",
+    "preferred_name": "Perniola Krajewska Carnevale syndrome"
+  },
+  {
+    "sctid": "716198008",
+    "preferred_name": "Game Friedman Paradice syndrome"
+  },
+  {
+    "sctid": "716199000",
+    "preferred_name": "Mehes syndrome"
+  },
+  {
+    "sctid": "716200002",
+    "preferred_name": "Schofer Beetz Bohl syndrome"
+  },
+  {
+    "sctid": "716278005",
+    "preferred_name": "Jeavons syndrome"
+  },
+  {
+    "sctid": "716281000",
+    "preferred_name": "Primary progressive non fluent aphasia"
+  },
+  {
+    "sctid": "716334004",
+    "preferred_name": "Urban Rogers Meyer syndrome"
+  },
+  {
+    "sctid": "716335003",
+    "preferred_name": "Worster Drought syndrome"
+  },
+  {
+    "sctid": "716380002",
+    "preferred_name": "Logopenic progressive aphasia"
+  },
+  {
+    "sctid": "716578009",
+    "preferred_name": "Developmental language comprehension impairment"
+  },
+  {
+    "sctid": "716592003",
+    "preferred_name": "Cerebellar liponeurocytoma"
+  },
+  {
+    "sctid": "716662004",
+    "preferred_name": "Autosomal dominant late onset Parkinson disease"
+  },
+  {
+    "sctid": "716664003",
+    "preferred_name": "Primary dystonia 21"
+  },
+  {
+    "sctid": "716667005",
+    "preferred_name": "Right temporal lobar atrophy"
+  },
+  {
+    "sctid": "716684004",
+    "preferred_name": "Limbic encephalitis with N-methyl-D-aspartate receptor antibodies"
+  },
+  {
+    "sctid": "716706009",
+    "preferred_name": "Female restricted epilepsy with intellectual disability syndrome"
+  },
+  {
+    "sctid": "716709002",
+    "preferred_name": "FRAXE intellectual disability syndrome"
+  },
+  {
+    "sctid": "716724006",
+    "preferred_name": "Spinocerebellar ataxia type 15/16"
+  },
+  {
+    "sctid": "716787002",
+    "preferred_name": "Extraventricular neurocytoma"
+  },
+  {
+    "sctid": "716994006",
+    "preferred_name": "Behavioral variant of frontotemporal dementia"
+  },
+  {
+    "sctid": "716996008",
+    "preferred_name": "L1 syndrome"
+  },
+  {
+    "sctid": "716997004",
+    "preferred_name": "Joubert syndrome"
+  },
+  {
+    "sctid": "716998009",
+    "preferred_name": "Joubert syndrome with ocular defect"
+  },
+  {
+    "sctid": "716999001",
+    "preferred_name": "Joubert syndrome with renal defect"
+  },
+  {
+    "sctid": "717003001",
+    "preferred_name": "Hereditary cavernous hemangioma of brain"
+  },
+  {
+    "sctid": "717042001",
+    "preferred_name": "Pelizaeus Merzbacher like disease"
+  },
+  {
+    "sctid": "717052002",
+    "preferred_name": "Maternally inherited Leigh syndrome"
+  },
+  {
+    "sctid": "717054001",
+    "preferred_name": "Maternally inherited mitochondrial dystonia"
+  },
+  {
+    "sctid": "717157006",
+    "preferred_name": "Trisomy 10p"
+  },
+  {
+    "sctid": "717185008",
+    "preferred_name": "Deficiency of leukotriene C4 synthase"
+  },
+  {
+    "sctid": "717222003",
+    "preferred_name": "Microphthalmia with ankyloblepharon and intellectual disability syndrome"
+  },
+  {
+    "sctid": "717223008",
+    "preferred_name": "X-linked epilepsy with learning disability and behavior disorder syndrome"
+  },
+  {
+    "sctid": "717225001",
+    "preferred_name": "Benign adult familial myoclonic epilepsy"
+  },
+  {
+    "sctid": "717276003",
+    "preferred_name": "Folinic acid responsive seizure syndrome"
+  },
+  {
+    "sctid": "717332007",
+    "preferred_name": "Cerebellar ataxia Cayman type"
+  },
+  {
+    "sctid": "717336005",
+    "preferred_name": "Autosomal dominant optic atrophy classic form"
+  },
+  {
+    "sctid": "717632002",
+    "preferred_name": "X-linked lissencephaly with abnormal genitalia syndrome"
+  },
+  {
+    "sctid": "717822006",
+    "preferred_name": "Goldberg Shprintzen megacolon syndrome"
+  },
+  {
+    "sctid": "717827000",
+    "preferred_name": "Hereditary sensory and autonomic neuropathy with spastic paraplegia"
+  },
+  {
+    "sctid": "717859007",
+    "preferred_name": "Beemer Ertbruggen syndrome"
+  },
+  {
+    "sctid": "71787009",
+    "preferred_name": "Psychologic vaginismus"
+  },
+  {
+    "sctid": "717887003",
+    "preferred_name": "Biemond syndrome type 2"
+  },
+  {
+    "sctid": "717913006",
+    "preferred_name": "Blepharonasofacial malformation syndrome"
+  },
+  {
+    "sctid": "717938001",
+    "preferred_name": "Optic neuropathy due to folate deficiency"
+  },
+  {
+    "sctid": "717939009",
+    "preferred_name": "Anencephaly without rachischisis"
+  },
+  {
+    "sctid": "717942003",
+    "preferred_name": "Brain dopamine-serotonin vesicular transport disease"
+  },
+  {
+    "sctid": "717943008",
+    "preferred_name": "Brain malformation, congenital heart disease, postaxial polydactyly syndrome"
+  },
+  {
+    "sctid": "717945001",
+    "preferred_name": "BRESEK syndrome"
+  },
+  {
+    "sctid": "717960003",
+    "preferred_name": "Central nervous system complication of anesthesia during the puerperium"
+  },
+  {
+    "sctid": "717964007",
+    "preferred_name": "Juvenile primary lateral sclerosis"
+  },
+  {
+    "sctid": "717975006",
+    "preferred_name": "Autosomal dominant optic atrophy and peripheral neuropathy syndrome"
+  },
+  {
+    "sctid": "717977003",
+    "preferred_name": "Lissencephaly syndrome Norman Roberts type"
+  },
+  {
+    "sctid": "7180009",
+    "preferred_name": "Meningitis"
+  },
+  {
+    "sctid": "71802006",
+    "preferred_name": "Astasia-abasia"
+  },
+  {
+    "sctid": "718095000",
+    "preferred_name": "Schisis association syndrome"
+  },
+  {
+    "sctid": "718174008",
+    "preferred_name": "Infantile striatonigral degeneration"
+  },
+  {
+    "sctid": "718182008",
+    "preferred_name": "Combined pituitary hormone deficiency genetic form"
+  },
+  {
+    "sctid": "718212006",
+    "preferred_name": "TMEM70 related mitochondrial encephalo-cardio-myopathy"
+  },
+  {
+    "sctid": "718214007",
+    "preferred_name": "Mitochondrial neurogastrointestinal encephalomyopathy syndrome"
+  },
+  {
+    "sctid": "718219002",
+    "preferred_name": "Congenital lactic acidosis Saguenay-Lac-Saint-Jean type"
+  },
+  {
+    "sctid": "718226002",
+    "preferred_name": "Wolf Hirschhorn syndrome"
+  },
+  {
+    "sctid": "71831005",
+    "preferred_name": "Symptomatic generalized epilepsy"
+  },
+  {
+    "sctid": "718393002",
+    "preferred_name": "Atypical Rett syndrome"
+  },
+  {
+    "sctid": "718551002",
+    "preferred_name": "Moyamoya disease with early onset achalasia"
+  },
+  {
+    "sctid": "718556007",
+    "preferred_name": "3C syndrome"
+  },
+  {
+    "sctid": "718573009",
+    "preferred_name": "Achalasia microcephaly syndrome"
+  },
+  {
+    "sctid": "718576001",
+    "preferred_name": "Aase Smith type 1 syndrome"
+  },
+  {
+    "sctid": "718577005",
+    "preferred_name": "Atkin Flaitz syndrome"
+  },
+  {
+    "sctid": "718605009",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 7"
+  },
+  {
+    "sctid": "718606005",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 6"
+  },
+  {
+    "sctid": "718607001",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 5"
+  },
+  {
+    "sctid": "718608006",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 4"
+  },
+  {
+    "sctid": "718609003",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 3"
+  },
+  {
+    "sctid": "718610008",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 1"
+  },
+  {
+    "sctid": "718611007",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 8"
+  },
+  {
+    "sctid": "718636001",
+    "preferred_name": "Minimal depression"
+  },
+  {
+    "sctid": "718680001",
+    "preferred_name": "Oro-facial digital syndrome type 9"
+  },
+  {
+    "sctid": "718681002",
+    "preferred_name": "Oro-facial digital syndrome type 11"
+  },
+  {
+    "sctid": "718685006",
+    "preferred_name": "Orthostatic hypotension co-occurrent and due to Parkinson's disease"
+  },
+  {
+    "sctid": "718719001",
+    "preferred_name": "Lissencephaly type 3 familial fetal akinesia sequence syndrome"
+  },
+  {
+    "sctid": "718720007",
+    "preferred_name": "Lissencephaly type 3 metacarpal bone dysplasia syndrome"
+  },
+  {
+    "sctid": "718752007",
+    "preferred_name": "Episodic ataxia type 7"
+  },
+  {
+    "sctid": "718753002",
+    "preferred_name": "Episodic ataxia type 6"
+  },
+  {
+    "sctid": "718754008",
+    "preferred_name": "Episodic ataxia type 4"
+  },
+  {
+    "sctid": "718755009",
+    "preferred_name": "Episodic ataxia type 3"
+  },
+  {
+    "sctid": "718756005",
+    "preferred_name": "Episodic ataxia type 5"
+  },
+  {
+    "sctid": "718759003",
+    "preferred_name": "Lissencephaly due to TUBA1A (tubulin alpha 1A) mutation"
+  },
+  {
+    "sctid": "718766002",
+    "preferred_name": "Spondyloepiphyseal dysplasia, craniosynostosis, cleft palate, cataract and intellectual disability syndrome"
+  },
+  {
+    "sctid": "718769009",
+    "preferred_name": "Spinocerebellar ataxia type 26"
+  },
+  {
+    "sctid": "718770005",
+    "preferred_name": "Spinocerebellar ataxia type 25"
+  },
+  {
+    "sctid": "718771009",
+    "preferred_name": "Spinocerebellar ataxia type 20"
+  },
+  {
+    "sctid": "718772002",
+    "preferred_name": "Spinocerebellar ataxia type 23"
+  },
+  {
+    "sctid": "718774001",
+    "preferred_name": "Spinocerebellar ataxia type 21"
+  },
+  {
+    "sctid": "718845002",
+    "preferred_name": "X-linked intellectual disability with ataxia and apraxia syndrome"
+  },
+  {
+    "sctid": "718848000",
+    "preferred_name": "Fried syndrome"
+  },
+  {
+    "sctid": "718896000",
+    "preferred_name": "X-linked recessive intellectual disability and macrocephaly with ciliary dysfunction syndrome"
+  },
+  {
+    "sctid": "718897009",
+    "preferred_name": "X-linked intellectual disability Seemanova type"
+  },
+  {
+    "sctid": "718900002",
+    "preferred_name": "Syndromic X-linked intellectual disability type 11"
+  },
+  {
+    "sctid": "718905007",
+    "preferred_name": "X-linked intellectual disability Shrimpton type"
+  },
+  {
+    "sctid": "718908009",
+    "preferred_name": "X-linked intellectual disability Siderius type"
+  },
+  {
+    "sctid": "718909001",
+    "preferred_name": "X-linked intellectual disability Stevenson type"
+  },
+  {
+    "sctid": "718910006",
+    "preferred_name": "X-linked intellectual disability Stocco Dos Santos type"
+  },
+  {
+    "sctid": "718911005",
+    "preferred_name": "X-linked intellectual disability Stoll type"
+  },
+  {
+    "sctid": "718912003",
+    "preferred_name": "X-linked intellectual disability Turner type"
+  },
+  {
+    "sctid": "718914002",
+    "preferred_name": "X-linked intellectual disability Van Esch type"
+  },
+  {
+    "sctid": "719009006",
+    "preferred_name": "X-linked intellectual disability Wilson type"
+  },
+  {
+    "sctid": "719010001",
+    "preferred_name": "X-linked intellectual disability Schimke type"
+  },
+  {
+    "sctid": "719011002",
+    "preferred_name": "X-linked intellectual disability Pai type"
+  },
+  {
+    "sctid": "719012009",
+    "preferred_name": "X-linked intellectual disability Miles Carpenter type"
+  },
+  {
+    "sctid": "719013004",
+    "preferred_name": "X-linked intellectual disability Cilliers type"
+  },
+  {
+    "sctid": "719016007",
+    "preferred_name": "X-linked intellectual disability Cantagrel type"
+  },
+  {
+    "sctid": "719017003",
+    "preferred_name": "X-linked intellectual disability Armfield type"
+  },
+  {
+    "sctid": "719018008",
+    "preferred_name": "X-linked intellectual disability Abidi type"
+  },
+  {
+    "sctid": "719020006",
+    "preferred_name": "Pallister W syndrome"
+  },
+  {
+    "sctid": "719021005",
+    "preferred_name": "DK phocomelia syndrome"
+  },
+  {
+    "sctid": "719042007",
+    "preferred_name": "Uveal coloboma with cleft lip and palate and intellectual disability syndrome"
+  },
+  {
+    "sctid": "719043002",
+    "preferred_name": "VACTERL syndrome with hydrocephalus"
+  },
+  {
+    "sctid": "719046005",
+    "preferred_name": "12q14 microdeletion syndrome"
+  },
+  {
+    "sctid": "719069008",
+    "preferred_name": "Shprintzen Goldberg craniosynostosis syndrome"
+  },
+  {
+    "sctid": "719097002",
+    "preferred_name": "BSG syndrome"
+  },
+  {
+    "sctid": "719102004",
+    "preferred_name": "Congenital cataract with ataxia and deafness syndrome"
+  },
+  {
+    "sctid": "719103009",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 39"
+  },
+  {
+    "sctid": "719136005",
+    "preferred_name": "X-linked intellectual disability with cerebellar hypoplasia syndrome"
+  },
+  {
+    "sctid": "719138006",
+    "preferred_name": "X-linked intellectual disability with cubitus valgus and dysmorphism syndrome"
+  },
+  {
+    "sctid": "719139003",
+    "preferred_name": "Pettigrew syndrome"
+  },
+  {
+    "sctid": "719140001",
+    "preferred_name": "Prieto Badia Mulas syndrome"
+  },
+  {
+    "sctid": "719155005",
+    "preferred_name": "X-linked intellectual disability and epilepsy with progressive joint contracture and facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "719156006",
+    "preferred_name": "X-linked intellectual disability with hypogammaglobulinemia and progressive neurological deterioration syndrome"
+  },
+  {
+    "sctid": "719157002",
+    "preferred_name": "X-linked intellectual disability and hypotonia with facial dysmorphism and aggressive behavior syndrome"
+  },
+  {
+    "sctid": "719160009",
+    "preferred_name": "Syndromic X-linked intellectual disability type 7"
+  },
+  {
+    "sctid": "719161008",
+    "preferred_name": "Syndromic X-linked intellectual disability due to JARID1C mutation"
+  },
+  {
+    "sctid": "719162001",
+    "preferred_name": "Radioulnar synostosis with microcephaly and scoliosis syndrome"
+  },
+  {
+    "sctid": "719164000",
+    "preferred_name": "Symmetrical thalamic calcification"
+  },
+  {
+    "sctid": "719202006",
+    "preferred_name": "Spondyloepiphyseal dysplasia tarda Kohn type"
+  },
+  {
+    "sctid": "719205008",
+    "preferred_name": "Spondylometaphyseal dysplasia with cone-rod dystrophy syndrome"
+  },
+  {
+    "sctid": "719207000",
+    "preferred_name": "Spinocerebellar ataxia type 11"
+  },
+  {
+    "sctid": "719208005",
+    "preferred_name": "Spinocerebellar ataxia type 12"
+  },
+  {
+    "sctid": "719209002",
+    "preferred_name": "Spinocerebellar ataxia type 13"
+  },
+  {
+    "sctid": "719210007",
+    "preferred_name": "Spinocerebellar ataxia type 14"
+  },
+  {
+    "sctid": "719216001",
+    "preferred_name": "Hypoglycemic coma due to type 2 diabetes mellitus"
+  },
+  {
+    "sctid": "719249005",
+    "preferred_name": "Spinocerebellar ataxia type 17"
+  },
+  {
+    "sctid": "719250005",
+    "preferred_name": "Spinocerebellar ataxia type 18"
+  },
+  {
+    "sctid": "719251009",
+    "preferred_name": "Spinocerebellar ataxia type 19"
+  },
+  {
+    "sctid": "719252002",
+    "preferred_name": "Spinocerebellar ataxia type 27"
+  },
+  {
+    "sctid": "719253007",
+    "preferred_name": "Spinocerebellar ataxia type 30"
+  },
+  {
+    "sctid": "719254001",
+    "preferred_name": "Spinocerebellar ataxia type 32"
+  },
+  {
+    "sctid": "719255000",
+    "preferred_name": "Spinocerebellar ataxia type 34"
+  },
+  {
+    "sctid": "719267003",
+    "preferred_name": "Progressive cavitating leukoencephalopathy"
+  },
+  {
+    "sctid": "719276005",
+    "preferred_name": "Primary dystonia type 4"
+  },
+  {
+    "sctid": "719278006",
+    "preferred_name": "Primary dystonia type 13"
+  },
+  {
+    "sctid": "719300001",
+    "preferred_name": "Spinocerebellar ataxia type 35"
+  },
+  {
+    "sctid": "719301002",
+    "preferred_name": "Spinocerebellar ataxia type 37"
+  },
+  {
+    "sctid": "719302009",
+    "preferred_name": "Spinocerebellar ataxia type 5"
+  },
+  {
+    "sctid": "719377004",
+    "preferred_name": "Microcephalus with albinism and digital anomaly syndrome"
+  },
+  {
+    "sctid": "719378009",
+    "preferred_name": "Microcephalus with brachydactyly and kyphoscoliosis syndrome"
+  },
+  {
+    "sctid": "719379001",
+    "preferred_name": "Microcephalus with cardiac defect and lung malsegmentation syndrome"
+  },
+  {
+    "sctid": "719380003",
+    "preferred_name": "Microcephalus cardiomyopathy syndrome"
+  },
+  {
+    "sctid": "719394002",
+    "preferred_name": "Microcephalus cleft palate syndrome"
+  },
+  {
+    "sctid": "719395001",
+    "preferred_name": "Hadziselimovic syndrome"
+  },
+  {
+    "sctid": "719403003",
+    "preferred_name": "Leukoencephalopathy co-occurrent with bilateral anterior temporal lobe cysts"
+  },
+  {
+    "sctid": "719405005",
+    "preferred_name": "Leukoencephalopathy with metaphyseal chondrodysplasia syndrome"
+  },
+  {
+    "sctid": "719430008",
+    "preferred_name": "Leber plus disease"
+  },
+  {
+    "sctid": "719450007",
+    "preferred_name": "Disorder of sex development with intellectual disability syndrome"
+  },
+  {
+    "sctid": "719466009",
+    "preferred_name": "Cleft palate with short stature and vertebral anomaly syndrome"
+  },
+  {
+    "sctid": "719516000",
+    "preferred_name": "Autosomal dominant focal dystonia DYT25 type"
+  },
+  {
+    "sctid": "719517009",
+    "preferred_name": "Autosomal dominant optic atrophy and cataract"
+  },
+  {
+    "sctid": "719521002",
+    "preferred_name": "Benign paroxysmal torticollis of infancy"
+  },
+  {
+    "sctid": "719583002",
+    "preferred_name": "17q11.2 microduplication syndrome"
+  },
+  {
+    "sctid": "719592004",
+    "preferred_name": "Moderately severe major depression"
+  },
+  {
+    "sctid": "719593009",
+    "preferred_name": "Moderately severe depression"
+  },
+  {
+    "sctid": "719599008",
+    "preferred_name": "19q13.11 microdeletion syndrome"
+  },
+  {
+    "sctid": "719600006",
+    "preferred_name": "1p21.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "71961003",
+    "preferred_name": "Childhood disintegrative disorder"
+  },
+  {
+    "sctid": "719717006",
+    "preferred_name": "Psychosis co-occurrent and due to Parkinson's disease"
+  },
+  {
+    "sctid": "719800009",
+    "preferred_name": "DOORS syndrome"
+  },
+  {
+    "sctid": "719808002",
+    "preferred_name": "Chromosome Xp11.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "719810000",
+    "preferred_name": "X-linked intellectual disability with seizure and psoriasis syndrome"
+  },
+  {
+    "sctid": "71981002",
+    "preferred_name": "Ependymitis"
+  },
+  {
+    "sctid": "719811001",
+    "preferred_name": "X-linked intellectual disability Cabezas type"
+  },
+  {
+    "sctid": "719812008",
+    "preferred_name": "X-linked intellectual disability with plagiocephaly syndrome"
+  },
+  {
+    "sctid": "719816006",
+    "preferred_name": "X-linked sideroblastic anemia with spinocerebellar ataxia"
+  },
+  {
+    "sctid": "719817002",
+    "preferred_name": "X-linked spinocerebellar ataxia type 3"
+  },
+  {
+    "sctid": "719818007",
+    "preferred_name": "X-linked spinocerebellar ataxia type 4"
+  },
+  {
+    "sctid": "719819004",
+    "preferred_name": "Xeroderma pigmentosum and Cockayne syndrome complex"
+  },
+  {
+    "sctid": "719824001",
+    "preferred_name": "Vici syndrome"
+  },
+  {
+    "sctid": "719825000",
+    "preferred_name": "X-linked intellectual disability, macrocephaly, macroorchidism syndrome"
+  },
+  {
+    "sctid": "719826004",
+    "preferred_name": "X-linked intellectual disability with acromegaly and hyperactivity syndrome"
+  },
+  {
+    "sctid": "719833004",
+    "preferred_name": "Visceral neuropathy and brain anomaly with facial dysmorphism and developmental delay syndrome"
+  },
+  {
+    "sctid": "719834005",
+    "preferred_name": "Wilson Turner syndrome"
+  },
+  {
+    "sctid": "71984005",
+    "preferred_name": "Mild manic bipolar I disorder"
+  },
+  {
+    "sctid": "719842006",
+    "preferred_name": "Congenital hypoplasia of ulna and intellectual disability syndrome"
+  },
+  {
+    "sctid": "7199000",
+    "preferred_name": "Tuberous sclerosis syndrome"
+  },
+  {
+    "sctid": "719909009",
+    "preferred_name": "Trisomy Xq28"
+  },
+  {
+    "sctid": "719947004",
+    "preferred_name": "Temtamy syndrome"
+  },
+  {
+    "sctid": "7200002",
+    "preferred_name": "Alcoholism"
+  },
+  {
+    "sctid": "720010009",
+    "preferred_name": "Microphthalmia with brain atrophy syndrome"
+  },
+  {
+    "sctid": "720261501000119107",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral anterior cerebral arteries"
+  },
+  {
+    "sctid": "720401009",
+    "preferred_name": "Cystic fibrosis with gastritis and megaloblastic anemia syndrome"
+  },
+  {
+    "sctid": "720410001",
+    "preferred_name": "Acro-oto-ocular syndrome"
+  },
+  {
+    "sctid": "720451004",
+    "preferred_name": "Minimal recurrent major depression"
+  },
+  {
+    "sctid": "720452006",
+    "preferred_name": "Moderately severe recurrent major depression"
+  },
+  {
+    "sctid": "720453001",
+    "preferred_name": "Moderately severe major depression single episode"
+  },
+  {
+    "sctid": "720454007",
+    "preferred_name": "Minimal major depression single episode"
+  },
+  {
+    "sctid": "720455008",
+    "preferred_name": "Minimal major depression"
+  },
+  {
+    "sctid": "720466001",
+    "preferred_name": "Adult-onset dystonia parkinsonism"
+  },
+  {
+    "sctid": "720468000",
+    "preferred_name": "Aniridia and intellectual disability syndrome"
+  },
+  {
+    "sctid": "720494009",
+    "preferred_name": "Anonychia with microcephaly syndrome"
+  },
+  {
+    "sctid": "720498007",
+    "preferred_name": "Aphalangy and syndactyly with microcephaly syndrome"
+  },
+  {
+    "sctid": "720501007",
+    "preferred_name": "Arachnodactyly with abnormal ossification and intellectual disability syndrome"
+  },
+  {
+    "sctid": "720502000",
+    "preferred_name": "Arachnodactyly and intellectual disability with facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "720517001",
+    "preferred_name": "Ataxia with deafness and intellectual disability syndrome"
+  },
+  {
+    "sctid": "720518006",
+    "preferred_name": "Athabaskan brainstem dysgenesis syndrome"
+  },
+  {
+    "sctid": "720519003",
+    "preferred_name": "Atherosclerosis, deafness, diabetes, epilepsy, nephropathy syndrome"
+  },
+  {
+    "sctid": "720573009",
+    "preferred_name": "Brachymorphism with onychodysplasia and dysphalangism syndrome"
+  },
+  {
+    "sctid": "720576001",
+    "preferred_name": "Brain calcification Rajab type"
+  },
+  {
+    "sctid": "720632004",
+    "preferred_name": "Central bilateral macrogyria"
+  },
+  {
+    "sctid": "720634003",
+    "preferred_name": "Cerebellar ataxia, areflexia, pes cavus, optic atrophy, sensorineural hearing loss syndrome"
+  },
+  {
+    "sctid": "720635002",
+    "preferred_name": "Cerebro-facio-thoracic dysplasia"
+  },
+  {
+    "sctid": "720639008",
+    "preferred_name": "Coloboma, congenital heart disease, ichthyosiform dermatosis, intellectual disability ear anomaly syndrome"
+  },
+  {
+    "sctid": "720746006",
+    "preferred_name": "Contracture with ectodermal dysplasia and orofacial cleft syndrome"
+  },
+  {
+    "sctid": "720748007",
+    "preferred_name": "Cooper Jabs syndrome"
+  },
+  {
+    "sctid": "720750004",
+    "preferred_name": "Corneal cerebellar syndrome"
+  },
+  {
+    "sctid": "720813007",
+    "preferred_name": "Craniosynostosis with Dandy-Walker malformation and hydrocephalus syndrome"
+  },
+  {
+    "sctid": "720815000",
+    "preferred_name": "Capra DeMarco syndrome"
+  },
+  {
+    "sctid": "720816004",
+    "preferred_name": "Craniosynostosis and intracranial calcification syndrome"
+  },
+  {
+    "sctid": "720819006",
+    "preferred_name": "Curry Jones syndrome"
+  },
+  {
+    "sctid": "720825005",
+    "preferred_name": "Cystic leukoencephalopathy without megalencephaly"
+  },
+  {
+    "sctid": "720855003",
+    "preferred_name": "Cerebrooculonasal syndrome"
+  },
+  {
+    "sctid": "720864008",
+    "preferred_name": "Encephalopathy due to prosaposin deficiency"
+  },
+  {
+    "sctid": "720954000",
+    "preferred_name": "Filippi syndrome"
+  },
+  {
+    "sctid": "720955004",
+    "preferred_name": "Fine Lubinsky syndrome"
+  },
+  {
+    "sctid": "720957007",
+    "preferred_name": "Fountain syndrome"
+  },
+  {
+    "sctid": "720979002",
+    "preferred_name": "Alopecia, contracture, dwarfism, intellectual disability syndrome"
+  },
+  {
+    "sctid": "720981000",
+    "preferred_name": "Alopecia and intellectual disability with hypergonadotropic hypogonadism syndrome"
+  },
+  {
+    "sctid": "720982007",
+    "preferred_name": "Alport syndrome, intellectual disability, midface hypoplasia, elliptocytosis syndrome"
+  },
+  {
+    "sctid": "720990007",
+    "preferred_name": "Meningitis caused by Bacillus anthracis"
+  },
+  {
+    "sctid": "721007005",
+    "preferred_name": "Hair defect with photosensitivity and intellectual disability syndrome"
+  },
+  {
+    "sctid": "721008000",
+    "preferred_name": "Hall Riggs syndrome"
+  },
+  {
+    "sctid": "721015008",
+    "preferred_name": "Hydrocephalus with endocardial fibroelastosis and cataract syndrome"
+  },
+  {
+    "sctid": "721017000",
+    "preferred_name": "Oliver syndrome"
+  },
+  {
+    "sctid": "72103000",
+    "preferred_name": "Simple partial seizure with special sensory symptoms"
+  },
+  {
+    "sctid": "721072003",
+    "preferred_name": "Short stature, pituitary and cerebellar defect and small sella turcica syndrome"
+  },
+  {
+    "sctid": "721073008",
+    "preferred_name": "Short stature with webbed neck and congenital heart disease syndrome"
+  },
+  {
+    "sctid": "721086004",
+    "preferred_name": "Deafness, genital anomaly, metacarpal and metatarsal synostosis syndrome"
+  },
+  {
+    "sctid": "721087008",
+    "preferred_name": "Deafness and intellectual disability Martin Probst type syndrome"
+  },
+  {
+    "sctid": "721088003",
+    "preferred_name": "DEND syndrome"
+  },
+  {
+    "sctid": "721089006",
+    "preferred_name": "Dentinogenesis imperfecta, short stature, hearing loss, intellectual disability syndrome"
+  },
+  {
+    "sctid": "721092005",
+    "preferred_name": "Developmental malformation, deafness, dystonia syndrome"
+  },
+  {
+    "sctid": "721146009",
+    "preferred_name": "Intellectual disability, epilepsy, bulbous nose syndrome"
+  },
+  {
+    "sctid": "721165001",
+    "preferred_name": "Variably protease sensitive prionopathy"
+  },
+  {
+    "sctid": "721200000",
+    "preferred_name": "Early-onset X-linked optic atrophy"
+  },
+  {
+    "sctid": "721207002",
+    "preferred_name": "Seizure, sensorineural deafness, ataxia, intellectual disability, electrolyte imbalance syndrome"
+  },
+  {
+    "sctid": "721208007",
+    "preferred_name": "Ectodermal dysplasia with blindness syndrome"
+  },
+  {
+    "sctid": "721219005",
+    "preferred_name": "Familial Alzheimer-like prion disease"
+  },
+  {
+    "sctid": "721228006",
+    "preferred_name": "Huntington disease-like 2"
+  },
+  {
+    "sctid": "721229003",
+    "preferred_name": "Hydrocephalus, costovertebral dysplasia, Sprengel anomaly syndrome"
+  },
+  {
+    "sctid": "721231007",
+    "preferred_name": "Hydrocephalus with obesity and hypogonadism syndrome"
+  },
+  {
+    "sctid": "721240006",
+    "preferred_name": "Meningitis caused by gram-negative aerobic coccus"
+  },
+  {
+    "sctid": "721241005",
+    "preferred_name": "Meningitis caused by gram-negative aerobic bacillus"
+  },
+  {
+    "sctid": "721242003",
+    "preferred_name": "Meningitis caused by Spirochaetes"
+  },
+  {
+    "sctid": "721243008",
+    "preferred_name": "Meningitis caused by Paramyxovirus"
+  },
+  {
+    "sctid": "721244002",
+    "preferred_name": "Infection causing myelitis"
+  },
+  {
+    "sctid": "721245001",
+    "preferred_name": "Myelitis caused by bacterium"
+  },
+  {
+    "sctid": "721246000",
+    "preferred_name": "Myelitis caused by fungus"
+  },
+  {
+    "sctid": "721247009",
+    "preferred_name": "Parasitic infection causing myelitis"
+  },
+  {
+    "sctid": "721248004",
+    "preferred_name": "Myelitis caused by virus"
+  },
+  {
+    "sctid": "721249007",
+    "preferred_name": "Infection causing encephalomyelitis"
+  },
+  {
+    "sctid": "721250007",
+    "preferred_name": "Abscess of spinal cord caused by bacterium"
+  },
+  {
+    "sctid": "721252004",
+    "preferred_name": "Infection causing spinal subdural cyst"
+  },
+  {
+    "sctid": "721253009",
+    "preferred_name": "Infection causing spinal epidural cyst"
+  },
+  {
+    "sctid": "721255002",
+    "preferred_name": "Acquired prion disease"
+  },
+  {
+    "sctid": "721261004",
+    "preferred_name": "Infection causing inflammation of optic nerve"
+  },
+  {
+    "sctid": "721288009",
+    "preferred_name": "Hypopituitarism following procedure"
+  },
+  {
+    "sctid": "721297008",
+    "preferred_name": "Galloway Mowat syndrome"
+  },
+  {
+    "sctid": "721330006",
+    "preferred_name": "Diffuse injury of cerebrum"
+  },
+  {
+    "sctid": "721331005",
+    "preferred_name": "Diffuse injury of cerebellum"
+  },
+  {
+    "sctid": "721332003",
+    "preferred_name": "Diffuse injury of brainstem"
+  },
+  {
+    "sctid": "721333008",
+    "preferred_name": "Crush injury of brain"
+  },
+  {
+    "sctid": "721362009",
+    "preferred_name": "Complete lesion of cervical spinal cord"
+  },
+  {
+    "sctid": "721363004",
+    "preferred_name": "Complete lesion of cervical spinal cord at C1 level"
+  },
+  {
+    "sctid": "721364005",
+    "preferred_name": "Complete lesion of cervical spinal cord at C2 level"
+  },
+  {
+    "sctid": "721365006",
+    "preferred_name": "Complete lesion of cervical spinal cord at C3 level"
+  },
+  {
+    "sctid": "721366007",
+    "preferred_name": "Complete lesion of cervical spinal cord at C4 level"
+  },
+  {
+    "sctid": "721367003",
+    "preferred_name": "Complete lesion of cervical spinal cord at C5 level"
+  },
+  {
+    "sctid": "721368008",
+    "preferred_name": "Complete lesion of cervical spinal cord at C6 level"
+  },
+  {
+    "sctid": "721369000",
+    "preferred_name": "Complete lesion of cervical spinal cord at C7 level"
+  },
+  {
+    "sctid": "721370004",
+    "preferred_name": "Complete lesion of cervical spinal cord at C8 level"
+  },
+  {
+    "sctid": "721371000",
+    "preferred_name": "Central cord syndrome of cervical spinal cord"
+  },
+  {
+    "sctid": "721372007",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C1 level"
+  },
+  {
+    "sctid": "721373002",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C2 level"
+  },
+  {
+    "sctid": "721374008",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C3 level"
+  },
+  {
+    "sctid": "721375009",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C4 level"
+  },
+  {
+    "sctid": "721376005",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C5 level"
+  },
+  {
+    "sctid": "721377001",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C6 level"
+  },
+  {
+    "sctid": "721378006",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C7 level"
+  },
+  {
+    "sctid": "721379003",
+    "preferred_name": "Central cord syndrome of cervical spinal cord at C8 level"
+  },
+  {
+    "sctid": "721380000",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord"
+  },
+  {
+    "sctid": "721381001",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C1 level"
+  },
+  {
+    "sctid": "721382008",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C2 level"
+  },
+  {
+    "sctid": "721383003",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C3 level"
+  },
+  {
+    "sctid": "721384009",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C4 level"
+  },
+  {
+    "sctid": "721385005",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C5 level"
+  },
+  {
+    "sctid": "721386006",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C6 level"
+  },
+  {
+    "sctid": "721387002",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C7 level"
+  },
+  {
+    "sctid": "721388007",
+    "preferred_name": "Anterior cord syndrome of cervical spinal cord at C8 level"
+  },
+  {
+    "sctid": "721389004",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord"
+  },
+  {
+    "sctid": "721390008",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C1 level"
+  },
+  {
+    "sctid": "721391007",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C2 level"
+  },
+  {
+    "sctid": "721392000",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C3 level"
+  },
+  {
+    "sctid": "721393005",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C4 level"
+  },
+  {
+    "sctid": "721394004",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C5 level"
+  },
+  {
+    "sctid": "721395003",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C6 level"
+  },
+  {
+    "sctid": "721396002",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C7 level"
+  },
+  {
+    "sctid": "721397006",
+    "preferred_name": "Posterior cord syndrome of cervical spinal cord at C8 level"
+  },
+  {
+    "sctid": "721398001",
+    "preferred_name": "Brown-Sequard syndrome of cervical spinal cord"
+  },
+  {
+    "sctid": "721399009",
+    "preferred_name": "Brown-Sequard syndrome at C1 level"
+  },
+  {
+    "sctid": "721400002",
+    "preferred_name": "Brown-Sequard syndrome at C2 level"
+  },
+  {
+    "sctid": "721401003",
+    "preferred_name": "Brown-Sequard syndrome at C3 level"
+  },
+  {
+    "sctid": "721402005",
+    "preferred_name": "Brown-Sequard syndrome at C4 level"
+  },
+  {
+    "sctid": "721403000",
+    "preferred_name": "Brown-Sequard syndrome at C5 level"
+  },
+  {
+    "sctid": "721404006",
+    "preferred_name": "Brown-Sequard syndrome at C6 level"
+  },
+  {
+    "sctid": "721405007",
+    "preferred_name": "Brown-Sequard syndrome at C7 level"
+  },
+  {
+    "sctid": "721406008",
+    "preferred_name": "Brown-Sequard syndrome at C8 level"
+  },
+  {
+    "sctid": "721428008",
+    "preferred_name": "Injury of thoracic spinal cord"
+  },
+  {
+    "sctid": "721429000",
+    "preferred_name": "Complete lesion of thoracic spinal cord"
+  },
+  {
+    "sctid": "721430005",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T1 level"
+  },
+  {
+    "sctid": "721431009",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T2 level"
+  },
+  {
+    "sctid": "721432002",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T3 level"
+  },
+  {
+    "sctid": "721433007",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T4 level"
+  },
+  {
+    "sctid": "721434001",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T5 level"
+  },
+  {
+    "sctid": "721435000",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T6 level"
+  },
+  {
+    "sctid": "721436004",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T7 level"
+  },
+  {
+    "sctid": "721437008",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T8 level"
+  },
+  {
+    "sctid": "721438003",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T9 level"
+  },
+  {
+    "sctid": "721439006",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T10 level"
+  },
+  {
+    "sctid": "721440008",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T11 level"
+  },
+  {
+    "sctid": "721441007",
+    "preferred_name": "Complete lesion of thoracic spinal cord at T12 level"
+  },
+  {
+    "sctid": "721442000",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord"
+  },
+  {
+    "sctid": "721443005",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T1 level"
+  },
+  {
+    "sctid": "721444004",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T2 level"
+  },
+  {
+    "sctid": "721445003",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T3 level"
+  },
+  {
+    "sctid": "721446002",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T4 level"
+  },
+  {
+    "sctid": "721447006",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T5 level"
+  },
+  {
+    "sctid": "721448001",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T6 level"
+  },
+  {
+    "sctid": "721449009",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T7 level"
+  },
+  {
+    "sctid": "721450009",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T8 level"
+  },
+  {
+    "sctid": "721451008",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T9 level"
+  },
+  {
+    "sctid": "721452001",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T10 level"
+  },
+  {
+    "sctid": "721453006",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T11 level"
+  },
+  {
+    "sctid": "721454000",
+    "preferred_name": "Central cord syndrome of thoracic spinal cord at T12 level"
+  },
+  {
+    "sctid": "721455004",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord"
+  },
+  {
+    "sctid": "721456003",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T1 level"
+  },
+  {
+    "sctid": "721457007",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T2 level"
+  },
+  {
+    "sctid": "721458002",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T3 level"
+  },
+  {
+    "sctid": "721459005",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T4 level"
+  },
+  {
+    "sctid": "721460000",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T5 level"
+  },
+  {
+    "sctid": "721461001",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T6 level"
+  },
+  {
+    "sctid": "721462008",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T7 level"
+  },
+  {
+    "sctid": "721463003",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T8 level"
+  },
+  {
+    "sctid": "721464009",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T9 level"
+  },
+  {
+    "sctid": "721465005",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T10 level"
+  },
+  {
+    "sctid": "721466006",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T11 level"
+  },
+  {
+    "sctid": "721467002",
+    "preferred_name": "Anterior cord syndrome of thoracic spinal cord at T12 level"
+  },
+  {
+    "sctid": "721468007",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord"
+  },
+  {
+    "sctid": "721469004",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T1 level"
+  },
+  {
+    "sctid": "721470003",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T2 level"
+  },
+  {
+    "sctid": "721471004",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T3 level"
+  },
+  {
+    "sctid": "721472006",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T4 level"
+  },
+  {
+    "sctid": "721473001",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T5 level"
+  },
+  {
+    "sctid": "721474007",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T6 level"
+  },
+  {
+    "sctid": "721475008",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T7 level"
+  },
+  {
+    "sctid": "721476009",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T8 level"
+  },
+  {
+    "sctid": "721477000",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T9 level"
+  },
+  {
+    "sctid": "721478005",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T10 level"
+  },
+  {
+    "sctid": "721479002",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T11 level"
+  },
+  {
+    "sctid": "721480004",
+    "preferred_name": "Posterior cord syndrome of thoracic spinal cord at T12 level"
+  },
+  {
+    "sctid": "721481000",
+    "preferred_name": "Brown-S\u00e9quard syndrome of thoracic spinal cord"
+  },
+  {
+    "sctid": "721482007",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T1 level"
+  },
+  {
+    "sctid": "721483002",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T2 level"
+  },
+  {
+    "sctid": "721484008",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T3 level"
+  },
+  {
+    "sctid": "721485009",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T4 level"
+  },
+  {
+    "sctid": "721486005",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T5 level"
+  },
+  {
+    "sctid": "721487001",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T6 level"
+  },
+  {
+    "sctid": "721488006",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T7 level"
+  },
+  {
+    "sctid": "721489003",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T8 level"
+  },
+  {
+    "sctid": "721490007",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T9 level"
+  },
+  {
+    "sctid": "721491006",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T10 level"
+  },
+  {
+    "sctid": "721492004",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T11 level"
+  },
+  {
+    "sctid": "721493009",
+    "preferred_name": "Brown-S\u00e9quard syndrome at T12 level"
+  },
+  {
+    "sctid": "721499008",
+    "preferred_name": "Complete lesion of lumbar spinal cord"
+  },
+  {
+    "sctid": "721500004",
+    "preferred_name": "Complete lesion of lumbar spinal cord at L1 level"
+  },
+  {
+    "sctid": "721501000",
+    "preferred_name": "Complete lesion of lumbar spinal cord at L2 level"
+  },
+  {
+    "sctid": "721502007",
+    "preferred_name": "Complete lesion of lumbar spinal cord at L3 level"
+  },
+  {
+    "sctid": "721503002",
+    "preferred_name": "Complete lesion of lumbar spinal cord at L4 level"
+  },
+  {
+    "sctid": "721504008",
+    "preferred_name": "Complete lesion of lumbar spinal cord at L5 level"
+  },
+  {
+    "sctid": "721505009",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord"
+  },
+  {
+    "sctid": "721506005",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord at L1 level"
+  },
+  {
+    "sctid": "721507001",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord at L2 level"
+  },
+  {
+    "sctid": "721508006",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord at L3 level"
+  },
+  {
+    "sctid": "721509003",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord at L4 level"
+  },
+  {
+    "sctid": "721510008",
+    "preferred_name": "Central cord syndrome of lumbar spinal cord at L5 level"
+  },
+  {
+    "sctid": "721511007",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord"
+  },
+  {
+    "sctid": "721512000",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord at L1 level"
+  },
+  {
+    "sctid": "721513005",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord at L2 level"
+  },
+  {
+    "sctid": "721514004",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord at L3 level"
+  },
+  {
+    "sctid": "721515003",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord at L4 level"
+  },
+  {
+    "sctid": "721516002",
+    "preferred_name": "Anterior cord syndrome of lumbar spinal cord at L5 level"
+  },
+  {
+    "sctid": "721517006",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord"
+  },
+  {
+    "sctid": "721518001",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord at L1 level"
+  },
+  {
+    "sctid": "721519009",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord at L2 level"
+  },
+  {
+    "sctid": "721520003",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord at L3 level"
+  },
+  {
+    "sctid": "721521004",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord at L4 level"
+  },
+  {
+    "sctid": "721522006",
+    "preferred_name": "Posterior cord syndrome of lumbar spinal cord at L5 level"
+  },
+  {
+    "sctid": "721523001",
+    "preferred_name": "Brown-S\u00e9quard syndrome of lumbar spinal cord"
+  },
+  {
+    "sctid": "721524007",
+    "preferred_name": "Brown-S\u00e9quard syndrome at L1 level"
+  },
+  {
+    "sctid": "721525008",
+    "preferred_name": "Brown-S\u00e9quard syndrome at L2 level"
+  },
+  {
+    "sctid": "721526009",
+    "preferred_name": "Brown-S\u00e9quard syndrome at L3 level"
+  },
+  {
+    "sctid": "721527000",
+    "preferred_name": "Brown-S\u00e9quard syndrome at L4 level"
+  },
+  {
+    "sctid": "721528005",
+    "preferred_name": "Brown-S\u00e9quard syndrome at L5 level"
+  },
+  {
+    "sctid": "721529002",
+    "preferred_name": "Complete injury of sacral spinal cord"
+  },
+  {
+    "sctid": "721535002",
+    "preferred_name": "Central neurocytoma of brain"
+  },
+  {
+    "sctid": "721729004",
+    "preferred_name": "Meningitis caused by Enterobacter"
+  },
+  {
+    "sctid": "721746001",
+    "preferred_name": "Meningitis caused by Streptococcus agalactiae"
+  },
+  {
+    "sctid": "721748000",
+    "preferred_name": "Meningitis caused by Enterococcus"
+  },
+  {
+    "sctid": "721749008",
+    "preferred_name": "Meningitis caused by methicillin resistant Staphylococcus aureus"
+  },
+  {
+    "sctid": "721752000",
+    "preferred_name": "Meningitis caused by Actinomycetales"
+  },
+  {
+    "sctid": "721753005",
+    "preferred_name": "Meningitis caused by Nocardia"
+  },
+  {
+    "sctid": "721754004",
+    "preferred_name": "Meningitis caused by Tropheryma whipplei"
+  },
+  {
+    "sctid": "721765009",
+    "preferred_name": "Meningitis caused by Human poliovirus"
+  },
+  {
+    "sctid": "721766005",
+    "preferred_name": "Encephalitis caused by Alphavirus"
+  },
+  {
+    "sctid": "721768006",
+    "preferred_name": "Infection of central nervous system caused by Herpes simplex virus"
+  },
+  {
+    "sctid": "721769003",
+    "preferred_name": "Meningitis caused by Epstein-Barr virus"
+  },
+  {
+    "sctid": "721770002",
+    "preferred_name": "Meningitis caused by Human cytomegalovirus 5"
+  },
+  {
+    "sctid": "721776008",
+    "preferred_name": "Encephalitis caused by Polyoma virus"
+  },
+  {
+    "sctid": "721788005",
+    "preferred_name": "Encephalitis caused by Rubulavirus"
+  },
+  {
+    "sctid": "721790006",
+    "preferred_name": "Encephalitis caused by Hendra virus"
+  },
+  {
+    "sctid": "721791005",
+    "preferred_name": "Encephalitis caused by Nipah virus"
+  },
+  {
+    "sctid": "721792003",
+    "preferred_name": "Meningitis caused by Mucorales"
+  },
+  {
+    "sctid": "721814006",
+    "preferred_name": "Meningitis caused by Trypanosoma brucei"
+  },
+  {
+    "sctid": "721815007",
+    "preferred_name": "Encephalitis caused by Trypanosoma brucei"
+  },
+  {
+    "sctid": "721818009",
+    "preferred_name": "Encephalitis caused by Schistosoma"
+  },
+  {
+    "sctid": "721819001",
+    "preferred_name": "Encephalitis caused by Schistosoma haematobium"
+  },
+  {
+    "sctid": "721820007",
+    "preferred_name": "Encephalitis caused by Schistosoma mansoni"
+  },
+  {
+    "sctid": "721821006",
+    "preferred_name": "Encephalitis caused by Schistosoma japonicum"
+  },
+  {
+    "sctid": "721823009",
+    "preferred_name": "Encephalitis caused by Echinococcus granulosus"
+  },
+  {
+    "sctid": "721824003",
+    "preferred_name": "Meningitis caused by Taenia solium"
+  },
+  {
+    "sctid": "721825002",
+    "preferred_name": "Encephalitis caused by Taenia solium"
+  },
+  {
+    "sctid": "721826001",
+    "preferred_name": "Encephalitis caused by Coenurus cerebralis"
+  },
+  {
+    "sctid": "721841001",
+    "preferred_name": "Hypogonadism with mitral valve prolapse and intellectual disability syndrome"
+  },
+  {
+    "sctid": "721842008",
+    "preferred_name": "Hypogonadotropic hypogonadism with frontoparietal alopecia syndrome"
+  },
+  {
+    "sctid": "721843003",
+    "preferred_name": "GAPO syndrome"
+  },
+  {
+    "sctid": "721846006",
+    "preferred_name": "Hypomyelination, hypogonadotropic hypogonadism, hypodontia syndrome"
+  },
+  {
+    "sctid": "721847002",
+    "preferred_name": "Joubert syndrome with congenital hepatic fibrosis"
+  },
+  {
+    "sctid": "721862000",
+    "preferred_name": "Joubert syndrome with oculorenal defect"
+  },
+  {
+    "sctid": "721873007",
+    "preferred_name": "Joubert syndrome with orofaciodigital defect"
+  },
+  {
+    "sctid": "721875000",
+    "preferred_name": "Juberg Marsidi syndrome"
+  },
+  {
+    "sctid": "721883006",
+    "preferred_name": "Radioulnar synostosis with developmental delay and hypotonia syndrome"
+  },
+  {
+    "sctid": "721903007",
+    "preferred_name": "Microcephaly, hypogammaglobulinemia, abnormal immunity syndrome"
+  },
+  {
+    "sctid": "721973006",
+    "preferred_name": "Lipodystrophy, intellectual disability, deafness syndrome"
+  },
+  {
+    "sctid": "721974000",
+    "preferred_name": "Lowry MacLean syndrome"
+  },
+  {
+    "sctid": "721975004",
+    "preferred_name": "Epiphyseal dysplasia, microcephalus, nystagmus syndrome"
+  },
+  {
+    "sctid": "722002002",
+    "preferred_name": "Scholte syndrome"
+  },
+  {
+    "sctid": "722003007",
+    "preferred_name": "Intellectual disability with cataract and kyphosis syndrome"
+  },
+  {
+    "sctid": "722006004",
+    "preferred_name": "Isotretinoin-like syndrome"
+  },
+  {
+    "sctid": "722027009",
+    "preferred_name": "Kallman syndrome with heart disease"
+  },
+  {
+    "sctid": "722031003",
+    "preferred_name": "Kapur Toriello syndrome"
+  },
+  {
+    "sctid": "722033000",
+    "preferred_name": "Macrocephaly, short stature, paraplegia syndrome"
+  },
+  {
+    "sctid": "722035007",
+    "preferred_name": "MEDNIK syndrome"
+  },
+  {
+    "sctid": "722036008",
+    "preferred_name": "Megalencephaly, polymicrogyria, postaxial polydactyly, hydrocephalus syndrome"
+  },
+  {
+    "sctid": "722037004",
+    "preferred_name": "MEHMO syndrome"
+  },
+  {
+    "sctid": "722055008",
+    "preferred_name": "Oculopalatocerebral syndrome"
+  },
+  {
+    "sctid": "722056009",
+    "preferred_name": "Oculocerebrofacial syndrome Kaufman type"
+  },
+  {
+    "sctid": "722064003",
+    "preferred_name": "Odontoleukodystrophy"
+  },
+  {
+    "sctid": "722065002",
+    "preferred_name": "Okamoto syndrome"
+  },
+  {
+    "sctid": "722075004",
+    "preferred_name": "Oro-facial digital syndrome type 10"
+  },
+  {
+    "sctid": "722105002",
+    "preferred_name": "Oro-facial digital syndrome type 5"
+  },
+  {
+    "sctid": "722106001",
+    "preferred_name": "Oro-facial digital syndrome type 8"
+  },
+  {
+    "sctid": "722107005",
+    "preferred_name": "Ossification anomaly with psychomotor developmental delay syndrome"
+  },
+  {
+    "sctid": "722110003",
+    "preferred_name": "Osteogenesis imperfecta, retinopathy, seizures, intellectual disability syndrome"
+  },
+  {
+    "sctid": "722111004",
+    "preferred_name": "Osteopenia, myopia, hearing loss, intellectual disability, facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "722201004",
+    "preferred_name": "Pai syndrome"
+  },
+  {
+    "sctid": "722209002",
+    "preferred_name": "Spastic paraplegia, intellectual disability, palmoplantar hyperkeratosis syndrome"
+  },
+  {
+    "sctid": "722212004",
+    "preferred_name": "Severe X-linked mitochondrial encephalomyopathy"
+  },
+  {
+    "sctid": "722213009",
+    "preferred_name": "Severe X-linked intellectual disability Gustavson type"
+  },
+  {
+    "sctid": "722281001",
+    "preferred_name": "Agammaglobulinemia, microcephaly, craniosynostosis, severe dermatitis syndrome"
+  },
+  {
+    "sctid": "722282008",
+    "preferred_name": "Agenesis of corpus callosum, intellectual disability, coloboma, micrognathia syndrome"
+  },
+  {
+    "sctid": "722287002",
+    "preferred_name": "Autism and facial port-wine stain syndrome"
+  },
+  {
+    "sctid": "722293005",
+    "preferred_name": "Autosomal dominant cerebellar ataxia, deafness and narcolepsy syndrome"
+  },
+  {
+    "sctid": "722378009",
+    "preferred_name": "Congenital cataract with deafness and hypogonadism syndrome"
+  },
+  {
+    "sctid": "722379001",
+    "preferred_name": "Congenital cataract with hypertrichosis and intellectual disability syndrome"
+  },
+  {
+    "sctid": "722380003",
+    "preferred_name": "Martsolf syndrome"
+  },
+  {
+    "sctid": "722381004",
+    "preferred_name": "Crome syndrome"
+  },
+  {
+    "sctid": "722385008",
+    "preferred_name": "CEDNIK syndrome"
+  },
+  {
+    "sctid": "722386009",
+    "preferred_name": "Celiac disease with epilepsy and cerebral calcification syndrome"
+  },
+  {
+    "sctid": "722390006",
+    "preferred_name": "Congenital intrauterine infection-like syndrome"
+  },
+  {
+    "sctid": "722435003",
+    "preferred_name": "Dystonia 16"
+  },
+  {
+    "sctid": "722451006",
+    "preferred_name": "Gomez Lopez Hernandez syndrome"
+  },
+  {
+    "sctid": "722453009",
+    "preferred_name": "Hennekam Beemer syndrome"
+  },
+  {
+    "sctid": "722454003",
+    "preferred_name": "Intellectual disability, craniofacial dysmorphism, hypogonadism, diabetes mellitus syndrome"
+  },
+  {
+    "sctid": "722455002",
+    "preferred_name": "Intellectual disability, hypoplastic corpus callosum, preauricular tag syndrome"
+  },
+  {
+    "sctid": "722456001",
+    "preferred_name": "Intellectual disability, developmental delay, contracture syndrome"
+  },
+  {
+    "sctid": "722459008",
+    "preferred_name": "Male hypergonadotropic hypogonadism, intellectual disability, skeletal anomaly syndrome"
+  },
+  {
+    "sctid": "722477003",
+    "preferred_name": "Toriello Carey syndrome"
+  },
+  {
+    "sctid": "722478008",
+    "preferred_name": "Skeletal dysplasia with intellectual disability syndrome"
+  },
+  {
+    "sctid": "722488009",
+    "preferred_name": "Neurodegeneration due to 3-hydroxyisobutyryl coenzyme A hydrolase deficiency"
+  },
+  {
+    "sctid": "722547006",
+    "preferred_name": "Meningitis caused by Human enterovirus 71"
+  },
+  {
+    "sctid": "722548001",
+    "preferred_name": "Meningitis caused by Human enterovirus 70"
+  },
+  {
+    "sctid": "722556003",
+    "preferred_name": "Parkinsonism co-occurrent and due to acute infection"
+  },
+  {
+    "sctid": "722557007",
+    "preferred_name": "Parkinsonism due to human immunodeficiency virus infection"
+  },
+  {
+    "sctid": "722558002",
+    "preferred_name": "Parkinsonism following infection"
+  },
+  {
+    "sctid": "722574007",
+    "preferred_name": "Injury of central nervous system due to birth trauma"
+  },
+  {
+    "sctid": "722575008",
+    "preferred_name": "Traumatic hemorrhage of cerebellum due to birth trauma"
+  },
+  {
+    "sctid": "722576009",
+    "preferred_name": "Injury of brain stem due to birth trauma"
+  },
+  {
+    "sctid": "722580004",
+    "preferred_name": "Fetal or neonatal intraventricular non-traumatic hemorrhage grade 4"
+  },
+  {
+    "sctid": "722581000",
+    "preferred_name": "Fetal or neonatal non-traumatic intraventricular hemorrhage"
+  },
+  {
+    "sctid": "722582007",
+    "preferred_name": "Fetal or neonatal intracerebral non-traumatic hemorrhage"
+  },
+  {
+    "sctid": "722583002",
+    "preferred_name": "Fetal or neonatal non-traumatic hemorrhage of subarachnoid space of brain"
+  },
+  {
+    "sctid": "722584008",
+    "preferred_name": "Fetal or neonatal non-traumatic hemorrhage of subdural space of brain"
+  },
+  {
+    "sctid": "722599008",
+    "preferred_name": "Parkinsonism due to hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "722600006",
+    "preferred_name": "Non-amnestic Alzheimer disease"
+  },
+  {
+    "sctid": "722601005",
+    "preferred_name": "White matter disorder caused by infection"
+  },
+  {
+    "sctid": "722602003",
+    "preferred_name": "White matter disorder caused by toxin"
+  },
+  {
+    "sctid": "722604002",
+    "preferred_name": "Optic disc dysplasia"
+  },
+  {
+    "sctid": "722606000",
+    "preferred_name": "Optic neuropathy caused by ionizing radiation following radiotherapy procedure"
+  },
+  {
+    "sctid": "722607009",
+    "preferred_name": "Optic disc swelling co-occurrent with uveitis"
+  },
+  {
+    "sctid": "722614006",
+    "preferred_name": "Focal non-hemorrhagic contusion of cerebrum"
+  },
+  {
+    "sctid": "722615007",
+    "preferred_name": "Focal hemorrhagic contusion of cerebrum"
+  },
+  {
+    "sctid": "722616008",
+    "preferred_name": "Focal laceration of cerebrum"
+  },
+  {
+    "sctid": "722617004",
+    "preferred_name": "Multiple focal injuries of cerebrum"
+  },
+  {
+    "sctid": "722618009",
+    "preferred_name": "Focal non-hemorrhagic contusion of cerebellum"
+  },
+  {
+    "sctid": "722619001",
+    "preferred_name": "Focal traumatic hemorrhage of cerebellum"
+  },
+  {
+    "sctid": "722620007",
+    "preferred_name": "Focal traumatic hematoma of cerebellum"
+  },
+  {
+    "sctid": "722622004",
+    "preferred_name": "Focal non-hemorrhagic contusion of brainstem"
+  },
+  {
+    "sctid": "722623009",
+    "preferred_name": "Focal traumatic hemorrhage of brainstem"
+  },
+  {
+    "sctid": "722624003",
+    "preferred_name": "Focal traumatic hematoma of brainstem"
+  },
+  {
+    "sctid": "722625002",
+    "preferred_name": "Focal laceration of brainstem"
+  },
+  {
+    "sctid": "722626001",
+    "preferred_name": "Multiple focal injuries of cerebellum"
+  },
+  {
+    "sctid": "722627005",
+    "preferred_name": "Focal injury of brainstem"
+  },
+  {
+    "sctid": "722628000",
+    "preferred_name": "Traumatic hemorrhage of subdural space of infratentorial region"
+  },
+  {
+    "sctid": "722630003",
+    "preferred_name": "Traumatic hemorrhage of cerebral white matter"
+  },
+  {
+    "sctid": "722631004",
+    "preferred_name": "Traumatic hemorrhage of cerebellum"
+  },
+  {
+    "sctid": "722632006",
+    "preferred_name": "Traumatic hemorrhage of brainstem"
+  },
+  {
+    "sctid": "722633001",
+    "preferred_name": "Multiple traumatic hemorrhages of brain tissue"
+  },
+  {
+    "sctid": "722653002",
+    "preferred_name": "Injury of lumbar spinal cord"
+  },
+  {
+    "sctid": "722654008",
+    "preferred_name": "Incomplete injury of sacral spinal cord"
+  },
+  {
+    "sctid": "722658006",
+    "preferred_name": "Meningitis following procedure"
+  },
+  {
+    "sctid": "722660008",
+    "preferred_name": "Radiation injury of brain caused by ionizing radiation following radiotherapy procedure"
+  },
+  {
+    "sctid": "722671009",
+    "preferred_name": "Metastatic malignant neoplasm of meninges"
+  },
+  {
+    "sctid": "722702007",
+    "preferred_name": "Focal laceration of cerebellum"
+  },
+  {
+    "sctid": "722703002",
+    "preferred_name": "Traumatic intraventricular hemorrhage"
+  },
+  {
+    "sctid": "722718001",
+    "preferred_name": "Primary malignant meningioma"
+  },
+  {
+    "sctid": "722719009",
+    "preferred_name": "Non-infective meningitis due to inflammatory disorder"
+  },
+  {
+    "sctid": "722762005",
+    "preferred_name": "GM3 synthase deficiency"
+  },
+  {
+    "sctid": "722763000",
+    "preferred_name": "Dopamine transporter deficiency syndrome"
+  },
+  {
+    "sctid": "722795004",
+    "preferred_name": "Meningeal leukemia"
+  },
+  {
+    "sctid": "722877006",
+    "preferred_name": "Adult rumination syndrome of ingested food"
+  },
+  {
+    "sctid": "722907006",
+    "preferred_name": "Contusion of cerebellum due to birth trauma"
+  },
+  {
+    "sctid": "722908001",
+    "preferred_name": "Contusion of brain due to birth trauma"
+  },
+  {
+    "sctid": "722909009",
+    "preferred_name": "Traumatic hemorrhage of intracranial epidural space due to birth trauma"
+  },
+  {
+    "sctid": "722914008",
+    "preferred_name": "Central neonatal apnea"
+  },
+  {
+    "sctid": "722929005",
+    "preferred_name": "Perinatal arterial ischemic stroke"
+  },
+  {
+    "sctid": "722931001",
+    "preferred_name": "Neonatal compression of brain"
+  },
+  {
+    "sctid": "722943000",
+    "preferred_name": "Macroprolactinemia"
+  },
+  {
+    "sctid": "722944006",
+    "preferred_name": "Congenital hypogonadotropic hypogonadism"
+  },
+  {
+    "sctid": "722961009",
+    "preferred_name": "Delirium caused by substance or medication"
+  },
+  {
+    "sctid": "722962002",
+    "preferred_name": "Amnestic disorder caused by substance"
+  },
+  {
+    "sctid": "722964001",
+    "preferred_name": "Atypical Parkinsonism"
+  },
+  {
+    "sctid": "722965000",
+    "preferred_name": "Parkinsonism due to heredodegenerative disorder"
+  },
+  {
+    "sctid": "722972004",
+    "preferred_name": "Secondary tic disorder"
+  },
+  {
+    "sctid": "722973009",
+    "preferred_name": "Tic due to developmental disorder"
+  },
+  {
+    "sctid": "722975002",
+    "preferred_name": "Primary stereotypy"
+  },
+  {
+    "sctid": "722976001",
+    "preferred_name": "Secondary stereotypy"
+  },
+  {
+    "sctid": "722977005",
+    "preferred_name": "Dementia co-occurrent and due to neurocysticercosis"
+  },
+  {
+    "sctid": "722978000",
+    "preferred_name": "Dementia caused by toxin"
+  },
+  {
+    "sctid": "722979008",
+    "preferred_name": "Dementia due to metabolic abnormality"
+  },
+  {
+    "sctid": "722980006",
+    "preferred_name": "Dementia due to chromosomal anomaly"
+  },
+  {
+    "sctid": "722981005",
+    "preferred_name": "Infrequent episodic tension-type headache"
+  },
+  {
+    "sctid": "722982003",
+    "preferred_name": "Frequent episodic tension-type headache"
+  },
+  {
+    "sctid": "722984002",
+    "preferred_name": "Myelopathy due to metabolic disorder"
+  },
+  {
+    "sctid": "722985001",
+    "preferred_name": "Acute venous infarction of spinal cord"
+  },
+  {
+    "sctid": "722986000",
+    "preferred_name": "Chronic venous infarction of spinal cord"
+  },
+  {
+    "sctid": "722989007",
+    "preferred_name": "Aplasia of optic nerve"
+  },
+  {
+    "sctid": "722990003",
+    "preferred_name": "Congenital atrophy of optic nerve"
+  },
+  {
+    "sctid": "722992006",
+    "preferred_name": "Communicating hydrocephalus co-occurrent and due to congenital agenesis of arachnoid villi"
+  },
+  {
+    "sctid": "722995008",
+    "preferred_name": "Concussion of sacral spinal cord"
+  },
+  {
+    "sctid": "723082006",
+    "preferred_name": "Silent cerebral infarct"
+  },
+  {
+    "sctid": "723122006",
+    "preferred_name": "Primary tic disorder"
+  },
+  {
+    "sctid": "723123001",
+    "preferred_name": "Ischemic vascular dementia"
+  },
+  {
+    "sctid": "723124007",
+    "preferred_name": "Primary progressive apraxia of speech"
+  },
+  {
+    "sctid": "723125008",
+    "preferred_name": "Epileptic encephalopathy"
+  },
+  {
+    "sctid": "723129002",
+    "preferred_name": "Spinal cord compression due to degenerative disorder of spinal column"
+  },
+  {
+    "sctid": "723131006",
+    "preferred_name": "Megalopapilla"
+  },
+  {
+    "sctid": "723132004",
+    "preferred_name": "Perioperative secondary non-arteritic ischemic optic neuropathy"
+  },
+  {
+    "sctid": "723138000",
+    "preferred_name": "Primary traumatic hemorrhage of brainstem"
+  },
+  {
+    "sctid": "723139008",
+    "preferred_name": "Secondary traumatic hemorrhage of brainstem"
+  },
+  {
+    "sctid": "723151005",
+    "preferred_name": "Permanent vegetative state"
+  },
+  {
+    "sctid": "723154002",
+    "preferred_name": "Post cerebral ventricular shunt leak"
+  },
+  {
+    "sctid": "723155001",
+    "preferred_name": "Injury of spinal cord caused by ionizing radiation following radiotherapy procedure"
+  },
+  {
+    "sctid": "723304001",
+    "preferred_name": "Microcephaly, seizure, intellectual disability, heart disease syndrome"
+  },
+  {
+    "sctid": "723306004",
+    "preferred_name": "Facial onset sensory and motor neuronopathy syndrome"
+  },
+  {
+    "sctid": "723307008",
+    "preferred_name": "Ethylmalonic encephalopathy"
+  },
+  {
+    "sctid": "723309006",
+    "preferred_name": "Endocrine-cerebro-osteodysplasia syndrome"
+  },
+  {
+    "sctid": "723332005",
+    "preferred_name": "Isodicentric chromosome 15 syndrome"
+  },
+  {
+    "sctid": "723333000",
+    "preferred_name": "Faciocardiorenal syndrome"
+  },
+  {
+    "sctid": "723336008",
+    "preferred_name": "Fallot complex with intellectual disability and growth delay syndrome"
+  },
+  {
+    "sctid": "723359002",
+    "preferred_name": "Familial acute necrotizing encephalopathy"
+  },
+  {
+    "sctid": "723365002",
+    "preferred_name": "Hypotrichosis and intellectual disability syndrome Lopes type"
+  },
+  {
+    "sctid": "723390000",
+    "preferred_name": "Rapidly progressive dementia"
+  },
+  {
+    "sctid": "723403008",
+    "preferred_name": "Microbrachycephaly, ptosis, cleft lip syndrome"
+  },
+  {
+    "sctid": "723404002",
+    "preferred_name": "Microcephalic osteodysplastic dysplasia Saul Wilson type"
+  },
+  {
+    "sctid": "723405001",
+    "preferred_name": "Microlissencephaly micromelia syndrome"
+  },
+  {
+    "sctid": "723441001",
+    "preferred_name": "Non-progressive cerebellar ataxia with intellectual disability"
+  },
+  {
+    "sctid": "723454008",
+    "preferred_name": "Phosphoribosylpyrophosphate synthetase superactivity"
+  },
+  {
+    "sctid": "723504000",
+    "preferred_name": "Ramos Arroyo syndrome"
+  },
+  {
+    "sctid": "723557004",
+    "preferred_name": "Thiamine-responsive encephalopathy"
+  },
+  {
+    "sctid": "723612001",
+    "preferred_name": "Spinal muscular atrophy, Dandy-Walker malformation, cataract syndrome"
+  },
+  {
+    "sctid": "723621000",
+    "preferred_name": "Spastic tetraplegia, retinitis pigmentosa, intellectual disability syndrome"
+  },
+  {
+    "sctid": "723622007",
+    "preferred_name": "X-linked spastic paraplegia type 2"
+  },
+  {
+    "sctid": "72366004",
+    "preferred_name": "Eating disorder"
+  },
+  {
+    "sctid": "723676007",
+    "preferred_name": "Severe intellectual disability, epilepsy, anal anomaly, distal phalangeal hypoplasia syndrome"
+  },
+  {
+    "sctid": "723819007",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 36"
+  },
+  {
+    "sctid": "723820001",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 4"
+  },
+  {
+    "sctid": "723821002",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 44"
+  },
+  {
+    "sctid": "723822009",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 46"
+  },
+  {
+    "sctid": "723823004",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 53"
+  },
+  {
+    "sctid": "723824005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 54"
+  },
+  {
+    "sctid": "723825006",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 55"
+  },
+  {
+    "sctid": "723826007",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 57"
+  },
+  {
+    "sctid": "723830005",
+    "preferred_name": "Keratosis follicularis, dwarfism, cerebral atrophy syndrome"
+  },
+  {
+    "sctid": "723899008",
+    "preferred_name": "Delusional disorder currently symptomatic"
+  },
+  {
+    "sctid": "723900003",
+    "preferred_name": "Delusional disorder currently in partial remission"
+  },
+  {
+    "sctid": "723901004",
+    "preferred_name": "Delusional disorder currently in full remission"
+  },
+  {
+    "sctid": "723903001",
+    "preferred_name": "Bipolar type I disorder currently in full remission"
+  },
+  {
+    "sctid": "723905008",
+    "preferred_name": "Bipolar type II disorder currently in full remission"
+  },
+  {
+    "sctid": "723912004",
+    "preferred_name": "Secondary mood disorder"
+  },
+  {
+    "sctid": "723913009",
+    "preferred_name": "Olfactory reference disorder"
+  },
+  {
+    "sctid": "723915002",
+    "preferred_name": "Secondary dissociative disorder"
+  },
+  {
+    "sctid": "723916001",
+    "preferred_name": "Bodily distress disorder"
+  },
+  {
+    "sctid": "723926008",
+    "preferred_name": "Perceptual disturbances and seizures co-occurrent and due to alcohol withdrawal"
+  },
+  {
+    "sctid": "723927004",
+    "preferred_name": "Psychotic disorder caused by alcohol with schizophreniform symptoms"
+  },
+  {
+    "sctid": "723928009",
+    "preferred_name": "Mood disorder with depressive symptoms caused by alcohol"
+  },
+  {
+    "sctid": "723929001",
+    "preferred_name": "Mood disorder with manic symptoms caused by alcohol"
+  },
+  {
+    "sctid": "723930006",
+    "preferred_name": "Mood disorder with mixed manic and depressive symptoms caused by alcohol"
+  },
+  {
+    "sctid": "723936000",
+    "preferred_name": "Psychotic disorder caused by cannabis"
+  },
+  {
+    "sctid": "723937009",
+    "preferred_name": "Sleep disorder caused by cannabis"
+  },
+  {
+    "sctid": "723992000",
+    "preferred_name": "Kufor Rakeb syndrome"
+  },
+  {
+    "sctid": "723994004",
+    "preferred_name": "Seizures and intellectual disability due to hydroxylysinuria"
+  },
+  {
+    "sctid": "723999009",
+    "preferred_name": "RHYNS syndrome"
+  },
+  {
+    "sctid": "724001005",
+    "preferred_name": "Retinitis pigmentosa, intellectual disability, deafness, hypogenitalism syndrome"
+  },
+  {
+    "sctid": "724002003",
+    "preferred_name": "Rambaud Gallian syndrome"
+  },
+  {
+    "sctid": "724039002",
+    "preferred_name": "Psychomotor retardation due to S-adenosylhomocysteine hydrolase deficiency"
+  },
+  {
+    "sctid": "724065003",
+    "preferred_name": "Autosomal recessive posterior column ataxia and retinitis pigmentosa"
+  },
+  {
+    "sctid": "724067006",
+    "preferred_name": "Permanent neonatal diabetes mellitus with cerebellar agenesis syndrome"
+  },
+  {
+    "sctid": "724072002",
+    "preferred_name": "Paroxysmal exertion-induced dyskinesia"
+  },
+  {
+    "sctid": "724097003",
+    "preferred_name": "Moyamoya angiopathy, short stature, facial dysmorphism, hypergonadotropic hypogonadism syndrome"
+  },
+  {
+    "sctid": "724137002",
+    "preferred_name": "MOMO syndrome"
+  },
+  {
+    "sctid": "724141003",
+    "preferred_name": "Microcephalic primordial dwarfism due to ZNF335 deficiency"
+  },
+  {
+    "sctid": "724146008",
+    "preferred_name": "Metaphyseal chondromatosis co-occurrent with D-2 hydroxyglutaric aciduria"
+  },
+  {
+    "sctid": "724171006",
+    "preferred_name": "Benign meningioma"
+  },
+  {
+    "sctid": "724172004",
+    "preferred_name": "McLeod neuroacanthocytosis syndrome"
+  },
+  {
+    "sctid": "724174003",
+    "preferred_name": "Moebius syndrome, axonal neuropathy, hypogonadotropic hypogonadism syndrome"
+  },
+  {
+    "sctid": "724178000",
+    "preferred_name": "Laryngeal abductor paralysis with intellectual disability syndrome"
+  },
+  {
+    "sctid": "724207001",
+    "preferred_name": "Kleefstra syndrome"
+  },
+  {
+    "sctid": "724226009",
+    "preferred_name": "Infantile osteopetrosis with neuroaxonal dysplasia syndrome"
+  },
+  {
+    "sctid": "724227000",
+    "preferred_name": "Infantile onset spinocerebellar ataxia"
+  },
+  {
+    "sctid": "724228005",
+    "preferred_name": "Infantile choroidocerebral calcification syndrome"
+  },
+  {
+    "sctid": "724274009",
+    "preferred_name": "Infant epilepsy with migrant focal crisis"
+  },
+  {
+    "sctid": "724281002",
+    "preferred_name": "Hyposmia, nasal and ocular hypoplasia, hypogonadotropic hypogonadism syndrome"
+  },
+  {
+    "sctid": "724283004",
+    "preferred_name": "Hypomyelinating leukodystrophy with atrophy of basal ganglia and cerebellum"
+  },
+  {
+    "sctid": "724357007",
+    "preferred_name": "Hereditary cerebral hemorrhage with amyloidosis"
+  },
+  {
+    "sctid": "724383002",
+    "preferred_name": "Hemidystonia hemiatrophy syndrome"
+  },
+  {
+    "sctid": "724385009",
+    "preferred_name": "Growth delay due to insulin-like growth factor type 1 deficiency"
+  },
+  {
+    "sctid": "72442006",
+    "preferred_name": "Disorder of posterior pituitary"
+  },
+  {
+    "sctid": "724424009",
+    "preferred_name": "Cerebral ischemic stroke due to small artery occlusion"
+  },
+  {
+    "sctid": "724425005",
+    "preferred_name": "Cerebral ischemic stroke due to intracranial large artery atherosclerosis"
+  },
+  {
+    "sctid": "724426006",
+    "preferred_name": "Cerebral ischemic stroke due to extracranial large artery atherosclerosis"
+  },
+  {
+    "sctid": "724429004",
+    "preferred_name": "Stroke co-occurrent with migraine"
+  },
+  {
+    "sctid": "724508005",
+    "preferred_name": "Late-onset central hypoventilation co-occurrent and due to hypothalamic dysfunction"
+  },
+  {
+    "sctid": "72452005",
+    "preferred_name": "Cerebral hypernatremia"
+  },
+  {
+    "sctid": "724542001",
+    "preferred_name": "Encephalitis caused by Venezuelan equine encephalomyelitis virus"
+  },
+  {
+    "sctid": "724543006",
+    "preferred_name": "Infection causing multiple abscesses of brain"
+  },
+  {
+    "sctid": "724544000",
+    "preferred_name": "Infection causing tic"
+  },
+  {
+    "sctid": "724545004",
+    "preferred_name": "Tic due to and following infection"
+  },
+  {
+    "sctid": "724546003",
+    "preferred_name": "Infection causing parkinsonism"
+  },
+  {
+    "sctid": "724549005",
+    "preferred_name": "Epilepsy due to infectious disease of central nervous system"
+  },
+  {
+    "sctid": "724561002",
+    "preferred_name": "Encephalopathy due to nutritional deficiency"
+  },
+  {
+    "sctid": "724562009",
+    "preferred_name": "Myelopathy due to nutritional deficiency"
+  },
+  {
+    "sctid": "724564005",
+    "preferred_name": "Intellectual developmental disorder due to nutritional deficiency"
+  },
+  {
+    "sctid": "724565006",
+    "preferred_name": "White matter disorder due to nutritional deficiency"
+  },
+  {
+    "sctid": "724576005",
+    "preferred_name": "Pyridoxal 5-phosphate dependent epilepsy"
+  },
+  {
+    "sctid": "724651001",
+    "preferred_name": "Developmental speech fluency disorder"
+  },
+  {
+    "sctid": "724652008",
+    "preferred_name": "Stereotypic movement disorder without self-injurious behavior"
+  },
+  {
+    "sctid": "724654009",
+    "preferred_name": "Anxiety disorder caused by opioid"
+  },
+  {
+    "sctid": "724655005",
+    "preferred_name": "Psychotic disorder caused by opioid"
+  },
+  {
+    "sctid": "724668002",
+    "preferred_name": "Sedative withdrawal with seizure"
+  },
+  {
+    "sctid": "724669005",
+    "preferred_name": "Seizure co-occurrent and due to hypnotic withdrawal"
+  },
+  {
+    "sctid": "724670006",
+    "preferred_name": "Seizure co-occurrent and due to anxiolytic withdrawal"
+  },
+  {
+    "sctid": "724671005",
+    "preferred_name": "Perceptual disturbances and seizures co-occurrent and due to sedative withdrawal"
+  },
+  {
+    "sctid": "724672003",
+    "preferred_name": "Perceptual disturbances and seizures co-occurrent and due to hypnotic withdrawal"
+  },
+  {
+    "sctid": "724673008",
+    "preferred_name": "Psychotic disorder caused by sedative"
+  },
+  {
+    "sctid": "724674002",
+    "preferred_name": "Psychotic disorder caused by hypnotic"
+  },
+  {
+    "sctid": "724675001",
+    "preferred_name": "Psychotic disorder caused by anxiolytic"
+  },
+  {
+    "sctid": "724676000",
+    "preferred_name": "Mood disorder with depressive symptoms caused by sedative"
+  },
+  {
+    "sctid": "724677009",
+    "preferred_name": "Mood disorder with depressive symptoms caused by hypnotic"
+  },
+  {
+    "sctid": "724678004",
+    "preferred_name": "Mood disorder with depressive symptoms caused by anxiolytic"
+  },
+  {
+    "sctid": "724679007",
+    "preferred_name": "Mood disorder with manic symptoms caused by sedative"
+  },
+  {
+    "sctid": "724680005",
+    "preferred_name": "Mood disorder with manic symptoms caused by hypnotic"
+  },
+  {
+    "sctid": "724681009",
+    "preferred_name": "Mood disorder with manic symptoms caused by anxiolytic"
+  },
+  {
+    "sctid": "724682002",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by sedative"
+  },
+  {
+    "sctid": "724683007",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by hypnotic"
+  },
+  {
+    "sctid": "724684001",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by anxiolytic"
+  },
+  {
+    "sctid": "724685000",
+    "preferred_name": "Amnestic disorder caused by sedative"
+  },
+  {
+    "sctid": "724686004",
+    "preferred_name": "Amnestic disorder caused by hypnotic"
+  },
+  {
+    "sctid": "724687008",
+    "preferred_name": "Amnestic disorder caused by anxiolytic"
+  },
+  {
+    "sctid": "724689006",
+    "preferred_name": "Psychotic disorder caused by cocaine"
+  },
+  {
+    "sctid": "724690002",
+    "preferred_name": "Mood disorder with depressive symptoms caused by cocaine"
+  },
+  {
+    "sctid": "724691003",
+    "preferred_name": "Mood disorder with manic symptoms caused by cocaine"
+  },
+  {
+    "sctid": "724692005",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by cocaine"
+  },
+  {
+    "sctid": "724693000",
+    "preferred_name": "Obsessive compulsive disorder caused by cocaine"
+  },
+  {
+    "sctid": "724696008",
+    "preferred_name": "Psychotic disorder caused by hallucinogen"
+  },
+  {
+    "sctid": "724702008",
+    "preferred_name": "Psychotic disorder caused by volatile inhalant"
+  },
+  {
+    "sctid": "724705005",
+    "preferred_name": "Delirium caused by methylenedioxymethamphetamine"
+  },
+  {
+    "sctid": "724706006",
+    "preferred_name": "Psychotic disorder caused by methylenedioxymethamphetamine"
+  },
+  {
+    "sctid": "724707002",
+    "preferred_name": "Mood disorder caused by methylenedioxymethamphetamine"
+  },
+  {
+    "sctid": "724708007",
+    "preferred_name": "Anxiety disorder caused by methylenedioxymethamphetamine"
+  },
+  {
+    "sctid": "724716003",
+    "preferred_name": "Delirium caused by ketamine"
+  },
+  {
+    "sctid": "724717007",
+    "preferred_name": "Delirium caused by dissociative drug"
+  },
+  {
+    "sctid": "724718002",
+    "preferred_name": "Psychotic disorder caused by dissociative drug"
+  },
+  {
+    "sctid": "724719005",
+    "preferred_name": "Psychotic disorder caused by ketamine"
+  },
+  {
+    "sctid": "724720004",
+    "preferred_name": "Mood disorder caused by dissociative drug"
+  },
+  {
+    "sctid": "724721000",
+    "preferred_name": "Mood disorder caused by ketamine"
+  },
+  {
+    "sctid": "724722007",
+    "preferred_name": "Anxiety disorder caused by dissociative drug"
+  },
+  {
+    "sctid": "724723002",
+    "preferred_name": "Anxiety disorder caused by ketamine"
+  },
+  {
+    "sctid": "724724008",
+    "preferred_name": "Psychoactive substance dependence with current use"
+  },
+  {
+    "sctid": "724725009",
+    "preferred_name": "Psychoactive substance withdrawal without complication"
+  },
+  {
+    "sctid": "724726005",
+    "preferred_name": "Perceptual disturbances co-occurrent and due to psychoactive substance withdrawal"
+  },
+  {
+    "sctid": "724727001",
+    "preferred_name": "Seizure co-occurrent and due to psychoactive substance withdrawal"
+  },
+  {
+    "sctid": "724728006",
+    "preferred_name": "Perceptual disturbances and seizures co-occurrent and due to psychoactive substance withdrawal"
+  },
+  {
+    "sctid": "724729003",
+    "preferred_name": "Psychotic disorder caused by psychoactive substance"
+  },
+  {
+    "sctid": "724730008",
+    "preferred_name": "Obsessive compulsive disorder caused by psychoactive substance"
+  },
+  {
+    "sctid": "724733005",
+    "preferred_name": "Oppositional defiant disorder co-occurrent with chronic irritability-anger"
+  },
+  {
+    "sctid": "724734004",
+    "preferred_name": "Oppositional defiant disorder co-occurrent with chronic irritability-anger with normal prosocial emotions"
+  },
+  {
+    "sctid": "724735003",
+    "preferred_name": "Oppositional defiant disorder without chronic irritability-anger"
+  },
+  {
+    "sctid": "724736002",
+    "preferred_name": "Oppositional defiant disorder without chronic irritability-anger with limited prosocial emotions"
+  },
+  {
+    "sctid": "724737006",
+    "preferred_name": "Oppositional defiant disorder without chronic irritability-anger with normal prosocial emotions"
+  },
+  {
+    "sctid": "724738001",
+    "preferred_name": "Childhood onset conduct-dissocial disorder with limited prosocial emotions"
+  },
+  {
+    "sctid": "724739009",
+    "preferred_name": "Childhood onset conduct-dissocial disorder with normal prosocial emotions"
+  },
+  {
+    "sctid": "724740006",
+    "preferred_name": "Adolescent onset conduct-dissocial disorder"
+  },
+  {
+    "sctid": "724741005",
+    "preferred_name": "Adolescent onset conduct-dissocial disorder with limited prosocial emotions"
+  },
+  {
+    "sctid": "724742003",
+    "preferred_name": "Adolescent onset conduct-dissocial disorder with normal prosocial emotions"
+  },
+  {
+    "sctid": "724743008",
+    "preferred_name": "Coercive sexual sadism"
+  },
+  {
+    "sctid": "724744002",
+    "preferred_name": "Paraphilia involving non-consenting individual"
+  },
+  {
+    "sctid": "724745001",
+    "preferred_name": "Paraphilia involving solitary behavior or consenting individuals"
+  },
+  {
+    "sctid": "724746000",
+    "preferred_name": "Delirium due to multiple etiological factors"
+  },
+  {
+    "sctid": "724747009",
+    "preferred_name": "Amnestic disorder due to multiple etiological factors"
+  },
+  {
+    "sctid": "724752004",
+    "preferred_name": "Hypnogogic exploding head syndrome"
+  },
+  {
+    "sctid": "724755002",
+    "preferred_name": "Positive symptoms co-occurrent and due to primary psychotic disorder"
+  },
+  {
+    "sctid": "724756001",
+    "preferred_name": "Negative symptoms co-occurrent and due to primary psychotic disorder"
+  },
+  {
+    "sctid": "724757005",
+    "preferred_name": "Depressive symptoms due to primary psychotic disorder"
+  },
+  {
+    "sctid": "724758000",
+    "preferred_name": "Manic symptoms co-occurrent and due to primary psychotic disorder"
+  },
+  {
+    "sctid": "724759008",
+    "preferred_name": "Psychomotor symptom co-occurrent and due to psychotic disorder"
+  },
+  {
+    "sctid": "724760003",
+    "preferred_name": "Cognitive impairment co-occurrent and due to primary psychotic disorder"
+  },
+  {
+    "sctid": "724761004",
+    "preferred_name": "Sporadic Parkinson disease"
+  },
+  {
+    "sctid": "724762006",
+    "preferred_name": "Parkinsonism due to and following injury of head"
+  },
+  {
+    "sctid": "724763001",
+    "preferred_name": "Parkinsonism due to mass lesion of brain"
+  },
+  {
+    "sctid": "724764007",
+    "preferred_name": "Chorea co-occurrent and due to Huntington disease-like condition"
+  },
+  {
+    "sctid": "724765008",
+    "preferred_name": "Chorea co-occurrent and due to dentatorubropallidoluysian degeneration"
+  },
+  {
+    "sctid": "724766009",
+    "preferred_name": "Chorea co-occurrent and due to Wilson disease"
+  },
+  {
+    "sctid": "724769002",
+    "preferred_name": "Ataxia co-occurrent and due to phytanic acid storage disease"
+  },
+  {
+    "sctid": "724775006",
+    "preferred_name": "X-linked hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "724776007",
+    "preferred_name": "Dementia due to disorder of central nervous system"
+  },
+  {
+    "sctid": "724777003",
+    "preferred_name": "Dementia due to infectious disease"
+  },
+  {
+    "sctid": "724778008",
+    "preferred_name": "Progressive relapsing multiple sclerosis"
+  },
+  {
+    "sctid": "724779000",
+    "preferred_name": "White matter disorder co-occurrent and due to cerebral autosomal dominant arteriopathy with subcortical infarcts and leukoencephalopathy"
+  },
+  {
+    "sctid": "724780002",
+    "preferred_name": "Demyelination of central nervous system co-occurrent and due to neurosarcoidosis"
+  },
+  {
+    "sctid": "724781003",
+    "preferred_name": "Demyelination of central nervous system co-occurrent and due to systemic lupus erythematosus"
+  },
+  {
+    "sctid": "724782005",
+    "preferred_name": "Demyelination of central nervous system co-occurrent and due to Sjogren disease"
+  },
+  {
+    "sctid": "724783000",
+    "preferred_name": "Demyelination of central nervous system co-occurrent and due to Behcet disease"
+  },
+  {
+    "sctid": "724784006",
+    "preferred_name": "Demyelination of central nervous system co-occurrent and due to mitochondrial disease"
+  },
+  {
+    "sctid": "724785007",
+    "preferred_name": "Epilepsy due to perinatal stroke"
+  },
+  {
+    "sctid": "724786008",
+    "preferred_name": "Epilepsy due to perinatal anoxic-ischemic brain injury"
+  },
+  {
+    "sctid": "724787004",
+    "preferred_name": "Epilepsy due to cerebrovascular accident"
+  },
+  {
+    "sctid": "724789001",
+    "preferred_name": "Epilepsy due to intracranial tumor"
+  },
+  {
+    "sctid": "724792002",
+    "preferred_name": "Incomplete cord syndrome of thoracic spinal cord"
+  },
+  {
+    "sctid": "724793007",
+    "preferred_name": "Incomplete cord syndrome of lumbar spinal cord"
+  },
+  {
+    "sctid": "724807008",
+    "preferred_name": "Glioma of central nervous system"
+  },
+  {
+    "sctid": "724813004",
+    "preferred_name": "Autonomic nervous system disorder co-occurrent and due to neurodegenerative disorder"
+  },
+  {
+    "sctid": "724818008",
+    "preferred_name": "Functional monoparesis"
+  },
+  {
+    "sctid": "724819000",
+    "preferred_name": "Functional paraparesis"
+  },
+  {
+    "sctid": "724820006",
+    "preferred_name": "Functional hemiparesis"
+  },
+  {
+    "sctid": "724822003",
+    "preferred_name": "Functional dystonia"
+  },
+  {
+    "sctid": "724823008",
+    "preferred_name": "Functional parkinsonism"
+  },
+  {
+    "sctid": "724988000",
+    "preferred_name": "Epilepsy co-occurrent and due to degenerative brain disorder"
+  },
+  {
+    "sctid": "724989008",
+    "preferred_name": "Epilepsy co-occurrent and due to mesial temporal sclerosis"
+  },
+  {
+    "sctid": "724990004",
+    "preferred_name": "Epilepsy due to immune disorder"
+  },
+  {
+    "sctid": "724991000",
+    "preferred_name": "Epilepsy co-occurrent and due to demyelinating disorder"
+  },
+  {
+    "sctid": "724992007",
+    "preferred_name": "Epilepsy co-occurrent and due to dementia"
+  },
+  {
+    "sctid": "724993002",
+    "preferred_name": "Cerebral ischemic stroke due to occlusion of extracranial large artery"
+  },
+  {
+    "sctid": "724994008",
+    "preferred_name": "Cerebral ischemic stroke due to stenosis of extracranial large artery"
+  },
+  {
+    "sctid": "724999003",
+    "preferred_name": "Isolated optic nerve hypoplasia"
+  },
+  {
+    "sctid": "725000003",
+    "preferred_name": "Secondary intracranial hypotension"
+  },
+  {
+    "sctid": "725001004",
+    "preferred_name": "Idiopathic syringomyelia"
+  },
+  {
+    "sctid": "725012004",
+    "preferred_name": "Incomplete cord syndrome of cervical spinal cord"
+  },
+  {
+    "sctid": "72513001",
+    "preferred_name": "Closed fracture of T7-T12 level with spinal cord injury"
+  },
+  {
+    "sctid": "725132001",
+    "preferred_name": "Ischemic stroke without residual deficits"
+  },
+  {
+    "sctid": "725139005",
+    "preferred_name": "Spastic paraplegia, optic atrophy, neuropathy syndrome"
+  },
+  {
+    "sctid": "725140007",
+    "preferred_name": "Temple Baraitser syndrome"
+  },
+  {
+    "sctid": "725146001",
+    "preferred_name": "Atypical juvenile parkinsonism"
+  },
+  {
+    "sctid": "725163002",
+    "preferred_name": "X-linked spasticity, intellectual disability, epilepsy syndrome"
+  },
+  {
+    "sctid": "725289009",
+    "preferred_name": "5-amino-4-imidazole carboxamide ribosiduria"
+  },
+  {
+    "sctid": "725392005",
+    "preferred_name": "Autosomal dominant striatal neurodegeneration"
+  },
+  {
+    "sctid": "725394006",
+    "preferred_name": "Autosomal recessive ataxia due to ubiquinone deficiency"
+  },
+  {
+    "sctid": "725408001",
+    "preferred_name": "Autosomal recessive cerebellar ataxia with oculomotor apraxia type 2"
+  },
+  {
+    "sctid": "725413002",
+    "preferred_name": "Febrile infection related epilepsy syndrome"
+  },
+  {
+    "sctid": "725433003",
+    "preferred_name": "Autosomal recessive cerebellar ataxia Beauce type"
+  },
+  {
+    "sctid": "725461009",
+    "preferred_name": "Microcephalic osteodysplastic primordial dwarfism types I and III"
+  },
+  {
+    "sctid": "725589005",
+    "preferred_name": "Bullous dystrophy macular type"
+  },
+  {
+    "sctid": "72585000",
+    "preferred_name": "Parkinsonian syndrome with idiopathic orthostatic hypotension"
+  },
+  {
+    "sctid": "725898002",
+    "preferred_name": "Delirium co-occurrent with dementia"
+  },
+  {
+    "sctid": "725906006",
+    "preferred_name": "Intellectual disability Buenos Aires type"
+  },
+  {
+    "sctid": "725908007",
+    "preferred_name": "Neurofaciodigitorenal syndrome"
+  },
+  {
+    "sctid": "725912001",
+    "preferred_name": "X-linked intellectual disability Brooks type"
+  },
+  {
+    "sctid": "726031001",
+    "preferred_name": "CAMOS syndrome"
+  },
+  {
+    "sctid": "726083008",
+    "preferred_name": "Kousseff syndrome"
+  },
+  {
+    "sctid": "72655000",
+    "preferred_name": "Alternating hypoglossal hemiplegia"
+  },
+  {
+    "sctid": "726606003",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 32"
+  },
+  {
+    "sctid": "726607007",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 26"
+  },
+  {
+    "sctid": "726608002",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 23"
+  },
+  {
+    "sctid": "726609005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 64"
+  },
+  {
+    "sctid": "726610000",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 63"
+  },
+  {
+    "sctid": "726611001",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 61"
+  },
+  {
+    "sctid": "726621009",
+    "preferred_name": "Caudal appendage deafness syndrome"
+  },
+  {
+    "sctid": "726622002",
+    "preferred_name": "Spastic paraplegia with Paget disease of bone syndrome"
+  },
+  {
+    "sctid": "726669007",
+    "preferred_name": "Central nervous system calcification, deafness, tubular acidosis, anemia syndrome"
+  },
+  {
+    "sctid": "726670008",
+    "preferred_name": "Weaver Williams syndrome"
+  },
+  {
+    "sctid": "726672000",
+    "preferred_name": "Short stature, unique facies, enamel hypoplasia, progressive joint stiffness, high-pitched voice syndrome"
+  },
+  {
+    "sctid": "726702005",
+    "preferred_name": "Epileptic encephalopathy with global cerebral demyelination"
+  },
+  {
+    "sctid": "726709001",
+    "preferred_name": "Intellectual disability, cataract, calcified pinna, myopathy syndrome"
+  },
+  {
+    "sctid": "726727003",
+    "preferred_name": "X-linked intellectual disability Hedera type"
+  },
+  {
+    "sctid": "726732002",
+    "preferred_name": "X-linked intellectual disability Nascimento type"
+  },
+  {
+    "sctid": "726772006",
+    "preferred_name": "Major depression with psychotic features"
+  },
+  {
+    "sctid": "72820004",
+    "preferred_name": "Neuroleptic-induced parkinsonism"
+  },
+  {
+    "sctid": "72836002",
+    "preferred_name": "Hepatic coma"
+  },
+  {
+    "sctid": "72858000",
+    "preferred_name": "Speech cortex disorder"
+  },
+  {
+    "sctid": "72861004",
+    "preferred_name": "Panic disorder without agoraphobia with mild panic attacks"
+  },
+  {
+    "sctid": "72880002",
+    "preferred_name": "Oropouche virus disease"
+  },
+  {
+    "sctid": "7291006",
+    "preferred_name": "Reactive attachment disorder of infancy"
+  },
+  {
+    "sctid": "72983001",
+    "preferred_name": "Compression of optic nerve"
+  },
+  {
+    "sctid": "72986009",
+    "preferred_name": "Acute hemorrhagic leukoencephalitis"
+  },
+  {
+    "sctid": "73020009",
+    "preferred_name": "Cerebral hemisphere hemorrhage"
+  },
+  {
+    "sctid": "73064001",
+    "preferred_name": "Thyrotropin overproduction"
+  },
+  {
+    "sctid": "73097000",
+    "preferred_name": "Alcohol amnestic disorder"
+  },
+  {
+    "sctid": "73221001",
+    "preferred_name": "Optic papillitis"
+  },
+  {
+    "sctid": "732246009",
+    "preferred_name": "X-linked intellectual disability, limb spasticity, retinal dystrophy, diabetes insipidus syndrome"
+  },
+  {
+    "sctid": "732251003",
+    "preferred_name": "Cortical blindness, intellectual disability, polydactyly syndrome"
+  },
+  {
+    "sctid": "732330391000119107",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral vertebral arteries"
+  },
+  {
+    "sctid": "732923001",
+    "preferred_name": "Hemorrhage of medulla oblongata"
+  },
+  {
+    "sctid": "732926009",
+    "preferred_name": "Hydrocephalus, tall stature, joint laxity syndrome"
+  },
+  {
+    "sctid": "732932004",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 18"
+  },
+  {
+    "sctid": "732933009",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 25"
+  },
+  {
+    "sctid": "732948003",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 10"
+  },
+  {
+    "sctid": "732949006",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 6"
+  },
+  {
+    "sctid": "732954002",
+    "preferred_name": "Osteopenia, intellectual disability, sparse hair syndrome"
+  },
+  {
+    "sctid": "732957009",
+    "preferred_name": "Brachydactyly and preaxial hallux varus syndrome"
+  },
+  {
+    "sctid": "732958004",
+    "preferred_name": "Spastic paraplegia with precocious puberty syndrome"
+  },
+  {
+    "sctid": "732961003",
+    "preferred_name": "Branchial dysplasia, intellectual disability, inguinal hernia syndrome"
+  },
+  {
+    "sctid": "733028000",
+    "preferred_name": "Multiple sclerosis, ichthyosis, factor VIII deficiency syndrome"
+  },
+  {
+    "sctid": "733029008",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 29"
+  },
+  {
+    "sctid": "733031004",
+    "preferred_name": "Epilepsy, microcephaly, skeletal dysplasia syndrome"
+  },
+  {
+    "sctid": "733032006",
+    "preferred_name": "Epilepsy telangiectasia syndrome"
+  },
+  {
+    "sctid": "733033001",
+    "preferred_name": "Spinocerebellar ataxia dysmorphism syndrome"
+  },
+  {
+    "sctid": "733044009",
+    "preferred_name": "Dermatoleukodystrophy"
+  },
+  {
+    "sctid": "733049004",
+    "preferred_name": "Encephalopathy, intracerebral calcification, retinal degeneration syndrome"
+  },
+  {
+    "sctid": "733050004",
+    "preferred_name": "Dysmorphism, short stature, deafness, disorder of sex development syndrome"
+  },
+  {
+    "sctid": "733062000",
+    "preferred_name": "Marfanoid habitus with autosomal recessive intellectual disability syndrome"
+  },
+  {
+    "sctid": "733065003",
+    "preferred_name": "Myoclonus, cerebellar ataxia, deafness syndrome"
+  },
+  {
+    "sctid": "733068001",
+    "preferred_name": "Absent tibia, polydactyly, arachnoid cyst syndrome"
+  },
+  {
+    "sctid": "733072002",
+    "preferred_name": "Stimmler syndrome"
+  },
+  {
+    "sctid": "733082001",
+    "preferred_name": "Early-onset Lafora body disease"
+  },
+  {
+    "sctid": "733086003",
+    "preferred_name": "Pseudoprogeria syndrome"
+  },
+  {
+    "sctid": "733088002",
+    "preferred_name": "Preaxial polydactyly, colobomata, intellectual disability syndrome"
+  },
+  {
+    "sctid": "733089005",
+    "preferred_name": "Spastic paraplegia, nephritis, deafness syndrome"
+  },
+  {
+    "sctid": "733092009",
+    "preferred_name": "Microcephalus, hypergonadotropic hypogonadism, short stature syndrome"
+  },
+  {
+    "sctid": "733094005",
+    "preferred_name": "Dandy-Walker malformation with postaxial polydactyly syndrome"
+  },
+  {
+    "sctid": "733096007",
+    "preferred_name": "Thyrocerebrorenal syndrome"
+  },
+  {
+    "sctid": "733097003",
+    "preferred_name": "Ichthyosis, intellectual disability, dwarfism, renal impairment syndrome"
+  },
+  {
+    "sctid": "733110004",
+    "preferred_name": "Van den Bosch syndrome"
+  },
+  {
+    "sctid": "733113002",
+    "preferred_name": "Hypogonadotropic hypogonadism retinitis pigmentosa syndrome"
+  },
+  {
+    "sctid": "733116005",
+    "preferred_name": "Aniridia, renal agenesis, psychomotor retardation syndrome"
+  },
+  {
+    "sctid": "733117001",
+    "preferred_name": "Thumb stiffness, brachydactyly, intellectual disability syndrome"
+  },
+  {
+    "sctid": "733168003",
+    "preferred_name": "Invasive aspergillosis of brain"
+  },
+  {
+    "sctid": "733173009",
+    "preferred_name": "Eosinophilic meningitis due to Angiostrongylus cantonensis"
+  },
+  {
+    "sctid": "733184002",
+    "preferred_name": "Dementia caused by heavy metal exposure"
+  },
+  {
+    "sctid": "733185001",
+    "preferred_name": "Dementia following injury caused by exposure to ionizing radiation"
+  },
+  {
+    "sctid": "733190003",
+    "preferred_name": "Dementia due to primary malignant neoplasm of brain"
+  },
+  {
+    "sctid": "733191004",
+    "preferred_name": "Dementia due to chronic subdural hematoma"
+  },
+  {
+    "sctid": "733192006",
+    "preferred_name": "Dementia due to herpes encephalitis"
+  },
+  {
+    "sctid": "733193001",
+    "preferred_name": "Dementia with progressive multifocal leukoencephalopathy"
+  },
+  {
+    "sctid": "733194007",
+    "preferred_name": "Dementia with Down syndrome"
+  },
+  {
+    "sctid": "733195008",
+    "preferred_name": "Epilepsy of infancy with migrating focal seizures"
+  },
+  {
+    "sctid": "733198005",
+    "preferred_name": "Encephalopathy due to and following cardiopulmonary bypass"
+  },
+  {
+    "sctid": "733199002",
+    "preferred_name": "Multifocal cerebral infarction due to and following procedure on cardiovascular system"
+  },
+  {
+    "sctid": "733200004",
+    "preferred_name": "Superficial siderosis of central nervous system"
+  },
+  {
+    "sctid": "73331006",
+    "preferred_name": "Hemimyelia"
+  },
+  {
+    "sctid": "733417008",
+    "preferred_name": "Facial dysmorphism, macrocephaly, myopia, Dandy-Walker malformation syndrome"
+  },
+  {
+    "sctid": "733418003",
+    "preferred_name": "Joubert syndrome with Jeune asphyxiating thoracic dystrophy"
+  },
+  {
+    "sctid": "733419006",
+    "preferred_name": "Metaphyseal dysostosis, intellectual disability, conductive deafness syndrome"
+  },
+  {
+    "sctid": "733422008",
+    "preferred_name": "Prion protein systemic amyloidosis"
+  },
+  {
+    "sctid": "733452000",
+    "preferred_name": "Leukoencephalopathy, dystonia, motor neuropathy syndrome"
+  },
+  {
+    "sctid": "733455003",
+    "preferred_name": "Spastic paraplegia, glaucoma, intellectual disability syndrome"
+  },
+  {
+    "sctid": "733472005",
+    "preferred_name": "Microcephalus, glomerulonephritis, marfanoid habitus syndrome"
+  },
+  {
+    "sctid": "733506009",
+    "preferred_name": "Arteritic anterior ischemic optic neuropathy"
+  },
+  {
+    "sctid": "733522005",
+    "preferred_name": "Megalocornea with intellectual disability syndrome"
+  },
+  {
+    "sctid": "733604003",
+    "preferred_name": "Microcephalus, lymphedema, chorioretinopathy syndrome"
+  },
+  {
+    "sctid": "733623005",
+    "preferred_name": "Autism spectrum disorder, epilepsy, arthrogryposis syndrome"
+  },
+  {
+    "sctid": "733630004",
+    "preferred_name": "Deficiency of alpha-ketoglutarate dehydrogenase"
+  },
+  {
+    "sctid": "733636005",
+    "preferred_name": "3-phosphoglycerate dehydrogenase deficiency juvenile form"
+  },
+  {
+    "sctid": "733637001",
+    "preferred_name": "3-phosphoglycerate dehydrogenase deficiency infantile form"
+  },
+  {
+    "sctid": "733650000",
+    "preferred_name": "Adult familial nephronophthisis with spastic quadriparesia syndrome"
+  },
+  {
+    "sctid": "73390009",
+    "preferred_name": "Endophlebitis of cavernous venous sinus"
+  },
+  {
+    "sctid": "733926004",
+    "preferred_name": "Ganglioneuroblastoma of central nervous system"
+  },
+  {
+    "sctid": "734017008",
+    "preferred_name": "Ectodermal dysplasia, intellectual disability, central nervous system malformation syndrome"
+  },
+  {
+    "sctid": "734020000",
+    "preferred_name": "Spinocerebellar ataxia type 40"
+  },
+  {
+    "sctid": "734021001",
+    "preferred_name": "Spinocerebellar ataxia type 38"
+  },
+  {
+    "sctid": "734022008",
+    "preferred_name": "Wolfram-like syndrome"
+  },
+  {
+    "sctid": "734023003",
+    "preferred_name": "Sporadic adult-onset ataxia of unknown etiology"
+  },
+  {
+    "sctid": "734031008",
+    "preferred_name": "Congenital achiasma"
+  },
+  {
+    "sctid": "734065009",
+    "preferred_name": "Embryonal neuroepithelial neoplasm of central nervous system"
+  },
+  {
+    "sctid": "734066005",
+    "preferred_name": "Diffuse large B-cell lymphoma of central nervous system"
+  },
+  {
+    "sctid": "734099007",
+    "preferred_name": "Neuroblastoma of central nervous system"
+  },
+  {
+    "sctid": "73413009",
+    "preferred_name": "Cortex contusion with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "734173003",
+    "preferred_name": "SCARF syndrome"
+  },
+  {
+    "sctid": "73431005",
+    "preferred_name": "Meningococcal optic neuritis"
+  },
+  {
+    "sctid": "734349003",
+    "preferred_name": "Alpha-thalassemia intellectual disability syndrome linked to chromosome 16"
+  },
+  {
+    "sctid": "734434007",
+    "preferred_name": "Pyridoxine-dependent epilepsy"
+  },
+  {
+    "sctid": "73462009",
+    "preferred_name": "Chronic vocal tic disorder"
+  },
+  {
+    "sctid": "73471000",
+    "preferred_name": "Bipolar I disorder, most recent episode mixed with catatonic features"
+  },
+  {
+    "sctid": "73495003",
+    "preferred_name": "Dyssynergia cerebellaris myoclonica"
+  },
+  {
+    "sctid": "735206008",
+    "preferred_name": "Communicating hydrocephalus due to and following traumatic hemorrhage"
+  },
+  {
+    "sctid": "735235000",
+    "preferred_name": "Seizure co-occurrent and due to drug withdrawal"
+  },
+  {
+    "sctid": "735421004",
+    "preferred_name": "Leukoencephalopathy with brain stem and spinal cord involvement and high lactate syndrome"
+  },
+  {
+    "sctid": "735534000",
+    "preferred_name": "Infection of central nervous system caused by Echinococcus"
+  },
+  {
+    "sctid": "735537007",
+    "preferred_name": "Hyperosmolar hyperglycemic coma due to diabetes mellitus without ketoacidosis"
+  },
+  {
+    "sctid": "735541006",
+    "preferred_name": "Dissociative neurological symptom disorder"
+  },
+  {
+    "sctid": "735542004",
+    "preferred_name": "Dissociative neurological disorder with symptom of weakness"
+  },
+  {
+    "sctid": "735543009",
+    "preferred_name": "Dissociative neurological disorder with symptom of alteration of sensation"
+  },
+  {
+    "sctid": "735544003",
+    "preferred_name": "Dissociative neurological disorder with symptom of movement disorder"
+  },
+  {
+    "sctid": "735545002",
+    "preferred_name": "Dissociative neurological symptom disorder with visual symptom"
+  },
+  {
+    "sctid": "735546001",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with swallowing symptom"
+  },
+  {
+    "sctid": "735547005",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with auditory symptom"
+  },
+  {
+    "sctid": "735548000",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with dizziness"
+  },
+  {
+    "sctid": "735549008",
+    "preferred_name": "Gambling disorder predominantly offline"
+  },
+  {
+    "sctid": "735550008",
+    "preferred_name": "Gambling disorder predominantly online"
+  },
+  {
+    "sctid": "735551007",
+    "preferred_name": "Gaming disorder"
+  },
+  {
+    "sctid": "735552000",
+    "preferred_name": "Gaming disorder predominantly online"
+  },
+  {
+    "sctid": "735553005",
+    "preferred_name": "Gaming disorder predominantly offline"
+  },
+  {
+    "sctid": "735554004",
+    "preferred_name": "Infection causing abscess of central nervous system"
+  },
+  {
+    "sctid": "735555003",
+    "preferred_name": "Deep abscess of cerebral hemisphere"
+  },
+  {
+    "sctid": "735556002",
+    "preferred_name": "Abscess of corpus callosum"
+  },
+  {
+    "sctid": "735557006",
+    "preferred_name": "Infection causing granuloma of central nervous system"
+  },
+  {
+    "sctid": "735558001",
+    "preferred_name": "Parasitic infection causing granuloma of cerebrum"
+  },
+  {
+    "sctid": "735560004",
+    "preferred_name": "Infection causing granuloma of spinal cord"
+  },
+  {
+    "sctid": "735561000",
+    "preferred_name": "Infection causing granuloma of extradural space of spinal cord"
+  },
+  {
+    "sctid": "735562007",
+    "preferred_name": "Infection causing cyst of central nervous system"
+  },
+  {
+    "sctid": "735625001",
+    "preferred_name": "Acquired generalized anorgasmia"
+  },
+  {
+    "sctid": "735626000",
+    "preferred_name": "Acquired situational anorgasmia"
+  },
+  {
+    "sctid": "735627009",
+    "preferred_name": "Lifelong generalized anorgasmia"
+  },
+  {
+    "sctid": "735628004",
+    "preferred_name": "Lifelong situational anorgasmia"
+  },
+  {
+    "sctid": "735646005",
+    "preferred_name": "Bilateral injury of optic nerve"
+  },
+  {
+    "sctid": "735648006",
+    "preferred_name": "Bilateral injury of optic pathway"
+  },
+  {
+    "sctid": "735649003",
+    "preferred_name": "Bilateral injury of optic tract"
+  },
+  {
+    "sctid": "735749005",
+    "preferred_name": "Myelomeningocele and hydrocephalus"
+  },
+  {
+    "sctid": "735750005",
+    "preferred_name": "Psychotic disorder with schizophreniform symptoms caused by cocaine"
+  },
+  {
+    "sctid": "735757008",
+    "preferred_name": "Primary ganglioneuroblastoma of brain"
+  },
+  {
+    "sctid": "735907005",
+    "preferred_name": "Exertional heat stroke"
+  },
+  {
+    "sctid": "736314008",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with cognitive symptoms"
+  },
+  {
+    "sctid": "736315009",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with alteration of consciousness"
+  },
+  {
+    "sctid": "736316005",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with symptom of speech production"
+  },
+  {
+    "sctid": "736321008",
+    "preferred_name": "Injury of both visual cortices"
+  },
+  {
+    "sctid": "736838001",
+    "preferred_name": "Cupping of optic disc co-occurrent and due to open angle glaucoma"
+  },
+  {
+    "sctid": "737006004",
+    "preferred_name": "Cupping of optic discs of bilateral eyes co-occurrent and due to open-angle glaucoma"
+  },
+  {
+    "sctid": "737225007",
+    "preferred_name": "Secondary psychotic syndrome with hallucinations and delusions"
+  },
+  {
+    "sctid": "737226008",
+    "preferred_name": "Disorder caused by cannabis"
+  },
+  {
+    "sctid": "737227004",
+    "preferred_name": "Autosomal dominant hereditary spastic paraplegia"
+  },
+  {
+    "sctid": "737228009",
+    "preferred_name": "Progressive focal cortical atrophy"
+  },
+  {
+    "sctid": "737229001",
+    "preferred_name": "White matter disorder due to vascular abnormality"
+  },
+  {
+    "sctid": "737230006",
+    "preferred_name": "White matter disorder due to ischemia"
+  },
+  {
+    "sctid": "737231005",
+    "preferred_name": "Traumatic hemorrhage of thalamus"
+  },
+  {
+    "sctid": "737232003",
+    "preferred_name": "Traumatic hemorrhage of basal ganglia"
+  },
+  {
+    "sctid": "737233008",
+    "preferred_name": "Concussion of cervical spinal cord"
+  },
+  {
+    "sctid": "737234002",
+    "preferred_name": "Traumatic edema of cervical spinal cord"
+  },
+  {
+    "sctid": "737236000",
+    "preferred_name": "Concussion of thoracic spinal cord"
+  },
+  {
+    "sctid": "737237009",
+    "preferred_name": "Traumatic edema of thoracic spinal cord"
+  },
+  {
+    "sctid": "737238004",
+    "preferred_name": "Concussion of lumbar spinal cord"
+  },
+  {
+    "sctid": "737239007",
+    "preferred_name": "Traumatic edema of lumbar spinal cord"
+  },
+  {
+    "sctid": "737334000",
+    "preferred_name": "Disorder caused by synthetic cannabinoid use"
+  },
+  {
+    "sctid": "737336003",
+    "preferred_name": "Synthetic cannabinoid abuse"
+  },
+  {
+    "sctid": "737337007",
+    "preferred_name": "Synthetic cannabinoid dependence"
+  },
+  {
+    "sctid": "737338002",
+    "preferred_name": "Synthetic cannabinoid withdrawal"
+  },
+  {
+    "sctid": "737339005",
+    "preferred_name": "Delirium caused by synthetic cannabinoid"
+  },
+  {
+    "sctid": "737340007",
+    "preferred_name": "Psychotic disorder caused by synthetic cannabinoid"
+  },
+  {
+    "sctid": "737341006",
+    "preferred_name": "Anxiety disorder caused by synthetic cannabinoid"
+  },
+  {
+    "sctid": "737342004",
+    "preferred_name": "Sleep disorder caused by synthetic cannabinoid"
+  },
+  {
+    "sctid": "737582007",
+    "preferred_name": "Hemiparkinsonism hemiatrophy syndrome"
+  },
+  {
+    "sctid": "7379000",
+    "preferred_name": "Pseudobulbar palsy"
+  },
+  {
+    "sctid": "738276008",
+    "preferred_name": "Influenza with CNS disorder"
+  },
+  {
+    "sctid": "73867007",
+    "preferred_name": "Severe major depression with psychotic features"
+  },
+  {
+    "sctid": "73935008",
+    "preferred_name": "Toxic encephalopathy due to hydroxyquinoline"
+  },
+  {
+    "sctid": "739665005",
+    "preferred_name": "Complete spinal cord injury"
+  },
+  {
+    "sctid": "739666006",
+    "preferred_name": "Incomplete spinal cord injury"
+  },
+  {
+    "sctid": "7397008",
+    "preferred_name": "Aggressor identification syndrome"
+  },
+  {
+    "sctid": "73972002",
+    "preferred_name": "Postpartum neurosis"
+  },
+  {
+    "sctid": "74010007",
+    "preferred_name": "Panic disorder with agoraphobia, severe agoraphobic avoidance AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "74012004",
+    "preferred_name": "Congenital anomaly of pituitary gland"
+  },
+  {
+    "sctid": "74073002",
+    "preferred_name": "Cerebellar hemangioblastomatosis"
+  },
+  {
+    "sctid": "74107003",
+    "preferred_name": "Acromegaly"
+  },
+  {
+    "sctid": "74142004",
+    "preferred_name": "Feeding disorder of infancy OR early childhood"
+  },
+  {
+    "sctid": "74266001",
+    "preferred_name": "Mood disorder in partial remission"
+  },
+  {
+    "sctid": "74267005",
+    "preferred_name": "Toxic encephalopathy due to carbon tetrachloride"
+  },
+  {
+    "sctid": "74333002",
+    "preferred_name": "Spasmodic torticollis"
+  },
+  {
+    "sctid": "74351001",
+    "preferred_name": "Reye's syndrome"
+  },
+  {
+    "sctid": "74360009",
+    "preferred_name": "Open fracture of C5-C7 level with central cord syndrome"
+  },
+  {
+    "sctid": "7454002",
+    "preferred_name": "Simple partial seizure with autonomic dysfunction"
+  },
+  {
+    "sctid": "7461003",
+    "preferred_name": "Attention deficit hyperactivity disorder, predominantly hyperactive impulsive type"
+  },
+  {
+    "sctid": "74644004",
+    "preferred_name": "Influenza with encephalopathy"
+  },
+  {
+    "sctid": "74686005",
+    "preferred_name": "Mild depressed bipolar I disorder"
+  },
+  {
+    "sctid": "74728003",
+    "preferred_name": "Hypopituitarism"
+  },
+  {
+    "sctid": "74732009",
+    "preferred_name": "Mental disorder"
+  },
+  {
+    "sctid": "74737003",
+    "preferred_name": "Complex partial seizure + impairment consciousness at onset"
+  },
+  {
+    "sctid": "74772000",
+    "preferred_name": "Meningomyelitis"
+  },
+  {
+    "sctid": "74791000",
+    "preferred_name": "Pedophilia, limited to incest"
+  },
+  {
+    "sctid": "74803002",
+    "preferred_name": "Taijin kyofusho"
+  },
+  {
+    "sctid": "74810008",
+    "preferred_name": "Premotor cortex syndrome"
+  },
+  {
+    "sctid": "74850006",
+    "preferred_name": "Conduct disorder, solitary aggressive type"
+  },
+  {
+    "sctid": "74934004",
+    "preferred_name": "Psychoactive substance-induced withdrawal syndrome"
+  },
+  {
+    "sctid": "75019001",
+    "preferred_name": "Athetoid cerebral palsy"
+  },
+  {
+    "sctid": "75023009",
+    "preferred_name": "Post-traumatic epilepsy"
+  },
+  {
+    "sctid": "75038005",
+    "preferred_name": "Cerebellar hemorrhage"
+  },
+  {
+    "sctid": "75046006",
+    "preferred_name": "Combined pyramidal-extrapyramidal syndrome"
+  },
+  {
+    "sctid": "75076004",
+    "preferred_name": "Amyelencephalus"
+  },
+  {
+    "sctid": "75084000",
+    "preferred_name": "Severe major depression without psychotic features"
+  },
+  {
+    "sctid": "75122001",
+    "preferred_name": "Inhalant-induced psychotic disorder with delusions"
+  },
+  {
+    "sctid": "75138007",
+    "preferred_name": "Endophlebitis of superior sagittal sinus"
+  },
+  {
+    "sctid": "75143000",
+    "preferred_name": "Toxic encephalitis due to thallium"
+  },
+  {
+    "sctid": "75299005",
+    "preferred_name": "Spastic spinal syphilitic paralysis"
+  },
+  {
+    "sctid": "75360000",
+    "preferred_name": "Bipolar I disorder, single manic episode, in remission"
+  },
+  {
+    "sctid": "75467001",
+    "preferred_name": "Intervertebral disc disorder of cervical region with myelopathy"
+  },
+  {
+    "sctid": "75507000",
+    "preferred_name": "Subarachnoid hemorrhage following injury with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "755301000000102",
+    "preferred_name": "Paranoid state in remission"
+  },
+  {
+    "sctid": "755311000000100",
+    "preferred_name": "Non-organic psychosis in remission"
+  },
+  {
+    "sctid": "755321000000106",
+    "preferred_name": "Single major depressive episode, severe, with psychosis, psychosis in remission"
+  },
+  {
+    "sctid": "755331000000108",
+    "preferred_name": "Recurrent major depressive episodes, severe, with psychosis, psychosis in remission"
+  },
+  {
+    "sctid": "75605002",
+    "preferred_name": "Sangue dormido"
+  },
+  {
+    "sctid": "75752004",
+    "preferred_name": "Bipolar I disorder, most recent episode depressed with melancholic features"
+  },
+  {
+    "sctid": "75834006",
+    "preferred_name": "Strachan's syndrome"
+  },
+  {
+    "sctid": "75837004",
+    "preferred_name": "Mood disorder with depressive features due to general medical condition"
+  },
+  {
+    "sctid": "75853001",
+    "preferred_name": "Central nervous system disorder of water regulation"
+  },
+  {
+    "sctid": "758664007",
+    "preferred_name": "Isolated follicle stimulating hormone deficiency"
+  },
+  {
+    "sctid": "75885003",
+    "preferred_name": "Disorder of visual pathways associated with neoplasm"
+  },
+  {
+    "sctid": "759291281000119108",
+    "preferred_name": "Acute nontraumatic intracranial subdural hematoma"
+  },
+  {
+    "sctid": "75968004",
+    "preferred_name": "Sotos' syndrome"
+  },
+  {
+    "sctid": "759950981000119101",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of left vertebral artery"
+  },
+  {
+    "sctid": "760721000000109",
+    "preferred_name": "Mixed bipolar affective disorder, in partial remission"
+  },
+  {
+    "sctid": "76105009",
+    "preferred_name": "Cyclothymia"
+  },
+  {
+    "sctid": "7611002",
+    "preferred_name": "Septo-optic dysplasia sequence"
+  },
+  {
+    "sctid": "76129002",
+    "preferred_name": "Ganser syndrome"
+  },
+  {
+    "sctid": "76156000",
+    "preferred_name": "Juvenile cerebellar degeneration AND myoclonus"
+  },
+  {
+    "sctid": "762281000",
+    "preferred_name": "Hypertrophic pachymeningitis due to infection"
+  },
+  {
+    "sctid": "762282007",
+    "preferred_name": "Idiopathic hypertrophic pachymeningitis"
+  },
+  {
+    "sctid": "762287001",
+    "preferred_name": "Mixed neonatal apnea"
+  },
+  {
+    "sctid": "762294003",
+    "preferred_name": "Transient infantile hyperthyrotropinemia"
+  },
+  {
+    "sctid": "762295002",
+    "preferred_name": "Congenital obstructive hydrocephalus"
+  },
+  {
+    "sctid": "762297005",
+    "preferred_name": "White matter disorder due to vitamin B12 deficiency"
+  },
+  {
+    "sctid": "762299008",
+    "preferred_name": "Myelopathy due to toxicity of substance"
+  },
+  {
+    "sctid": "762317007",
+    "preferred_name": "Developmental language disorder and impairment of receptive and expressive language"
+  },
+  {
+    "sctid": "762318002",
+    "preferred_name": "Developmental language disorder and impairment of expressive language"
+  },
+  {
+    "sctid": "762319005",
+    "preferred_name": "Developmental language disorder and impairment of mainly pragmatic language"
+  },
+  {
+    "sctid": "762320004",
+    "preferred_name": "Mood disorder with manic symptoms caused by opioid"
+  },
+  {
+    "sctid": "762321000",
+    "preferred_name": "Mood disorder with depressive symptoms caused by opioid"
+  },
+  {
+    "sctid": "762322007",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by opioid"
+  },
+  {
+    "sctid": "762324008",
+    "preferred_name": "Delirium caused by stimulant"
+  },
+  {
+    "sctid": "762325009",
+    "preferred_name": "Psychotic disorder caused by stimulant"
+  },
+  {
+    "sctid": "762326005",
+    "preferred_name": "Psychotic disorder with hallucinations caused by stimulant"
+  },
+  {
+    "sctid": "762327001",
+    "preferred_name": "Psychotic disorder with delusions caused by stimulant"
+  },
+  {
+    "sctid": "762328006",
+    "preferred_name": "Mood disorder caused by stimulant"
+  },
+  {
+    "sctid": "762329003",
+    "preferred_name": "Mood disorder with depressive symptoms caused by stimulant"
+  },
+  {
+    "sctid": "762330008",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by stimulant"
+  },
+  {
+    "sctid": "762331007",
+    "preferred_name": "Anxiety disorder caused by stimulant"
+  },
+  {
+    "sctid": "762332000",
+    "preferred_name": "Obsessive compulsive disorder caused by stimulant"
+  },
+  {
+    "sctid": "762335003",
+    "preferred_name": "Mood disorder with manic symptoms caused by hallucinogen"
+  },
+  {
+    "sctid": "762336002",
+    "preferred_name": "Mood disorder with depressive symptoms caused by hallucinogen"
+  },
+  {
+    "sctid": "762337006",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by hallucinogen"
+  },
+  {
+    "sctid": "762338001",
+    "preferred_name": "Mood disorder with manic symptoms caused by volatile inhalant"
+  },
+  {
+    "sctid": "762339009",
+    "preferred_name": "Mood disorder with depressive symptoms caused by volatile inhalant"
+  },
+  {
+    "sctid": "762340006",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by volatile inhalant"
+  },
+  {
+    "sctid": "762344002",
+    "preferred_name": "Mood disorder with manic symptoms caused by dissociative drug"
+  },
+  {
+    "sctid": "762345001",
+    "preferred_name": "Mood disorder with depressive symptoms caused by dissociative drug"
+  },
+  {
+    "sctid": "762346000",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by dissociative drug"
+  },
+  {
+    "sctid": "762347009",
+    "preferred_name": "Childhood onset conduct-dissocial disorder"
+  },
+  {
+    "sctid": "762350007",
+    "preferred_name": "Dementia due to prion disease"
+  },
+  {
+    "sctid": "762351006",
+    "preferred_name": "Dementia due to and following injury of head"
+  },
+  {
+    "sctid": "762352004",
+    "preferred_name": "Demyelination due to systemic vasculitis"
+  },
+  {
+    "sctid": "762357005",
+    "preferred_name": "Traumatic injury of left optic nerve"
+  },
+  {
+    "sctid": "762358000",
+    "preferred_name": "Traumatic injury of right optic nerve"
+  },
+  {
+    "sctid": "762360003",
+    "preferred_name": "Traumatic injury of left visual pathway"
+  },
+  {
+    "sctid": "76236006",
+    "preferred_name": "Atypical tic disorder"
+  },
+  {
+    "sctid": "762361004",
+    "preferred_name": "Traumatic injury of right visual pathway"
+  },
+  {
+    "sctid": "762362006",
+    "preferred_name": "Traumatic injury of left optic tract"
+  },
+  {
+    "sctid": "762363001",
+    "preferred_name": "Traumatic injury of right optic tract"
+  },
+  {
+    "sctid": "762436001",
+    "preferred_name": "Injury of left visual cortex"
+  },
+  {
+    "sctid": "762457009",
+    "preferred_name": "Astroblastoma of brain"
+  },
+  {
+    "sctid": "762461003",
+    "preferred_name": "Complex dissociative intrusion disorder"
+  },
+  {
+    "sctid": "762502009",
+    "preferred_name": "Developmental language disorder and language impairment"
+  },
+  {
+    "sctid": "762506007",
+    "preferred_name": "Delirium caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762507003",
+    "preferred_name": "Psychotic disorder caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762508008",
+    "preferred_name": "Psychotic disorder with hallucinations caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762509000",
+    "preferred_name": "Psychotic disorder with delusions caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762510005",
+    "preferred_name": "Psychotic disorder with schizophreniform symptoms caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762511009",
+    "preferred_name": "Mood disorder caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762512002",
+    "preferred_name": "Mood disorder with depressive symptoms caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762513007",
+    "preferred_name": "Mood disorder with manic symptoms caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762514001",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762515000",
+    "preferred_name": "Anxiety disorder caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762516004",
+    "preferred_name": "Obsessive compulsive disorder caused by synthetic cathinone"
+  },
+  {
+    "sctid": "762522008",
+    "preferred_name": "Penoscrotodynia"
+  },
+  {
+    "sctid": "762617003",
+    "preferred_name": "Injury of right visual cortex"
+  },
+  {
+    "sctid": "762663009",
+    "preferred_name": "Mesencephalic light-near dissociation"
+  },
+  {
+    "sctid": "762672001",
+    "preferred_name": "Synthetic cathinone withdrawal"
+  },
+  {
+    "sctid": "762707000",
+    "preferred_name": "Subcortical dementia"
+  },
+  {
+    "sctid": "763065008",
+    "preferred_name": "Ataxia telangiectasia variant"
+  },
+  {
+    "sctid": "763068005",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 31"
+  },
+  {
+    "sctid": "763069002",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 41"
+  },
+  {
+    "sctid": "763070001",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 42"
+  },
+  {
+    "sctid": "763130006",
+    "preferred_name": "Cleft palate, large ears, small head syndrome"
+  },
+  {
+    "sctid": "763136000",
+    "preferred_name": "Charcot-Marie-Tooth disease, deafness, intellectual disability syndrome"
+  },
+  {
+    "sctid": "763186006",
+    "preferred_name": "Grubben, De Cock, Borghgraef syndrome"
+  },
+  {
+    "sctid": "763278004",
+    "preferred_name": "Facial dysmorphism, cleft palate, loose skin syndrome"
+  },
+  {
+    "sctid": "763280005",
+    "preferred_name": "Encephalopathy, hypertrophic cardiomyopathy, renal tubular disease syndrome"
+  },
+  {
+    "sctid": "763310000",
+    "preferred_name": "Acute necrotizing encephalopathy of childhood"
+  },
+  {
+    "sctid": "763312008",
+    "preferred_name": "Autosomal recessive cerebellar ataxia, pyramidal signs, nystagmus, oculomotor apraxia syndrome"
+  },
+  {
+    "sctid": "763320005",
+    "preferred_name": "Craniofaciofrontodigital syndrome"
+  },
+  {
+    "sctid": "763344007",
+    "preferred_name": "Cerebellar ataxia, intellectual disability, oculomotor apraxia, cerebellar cysts syndrome"
+  },
+  {
+    "sctid": "763348005",
+    "preferred_name": "Autosomal recessive cerebellar ataxia with late-onset spasticity"
+  },
+  {
+    "sctid": "763349002",
+    "preferred_name": "Progressive myoclonic epilepsy with dystonia"
+  },
+  {
+    "sctid": "763350002",
+    "preferred_name": "Intellectual disability, obesity, brain malformation, facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "763351003",
+    "preferred_name": "Spectrin-associated autosomal recessive cerebellar ataxia"
+  },
+  {
+    "sctid": "763353000",
+    "preferred_name": "Cerebrofacioarticular syndrome"
+  },
+  {
+    "sctid": "763366000",
+    "preferred_name": "Leukoencephalopathy, thalamus and brainstem anomalies, high lactate syndrome"
+  },
+  {
+    "sctid": "763367009",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 48"
+  },
+  {
+    "sctid": "763369007",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 37"
+  },
+  {
+    "sctid": "763370008",
+    "preferred_name": "X-linked spastic paraplegia type 34"
+  },
+  {
+    "sctid": "763373005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 5A"
+  },
+  {
+    "sctid": "763374004",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 12"
+  },
+  {
+    "sctid": "763375003",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 19"
+  },
+  {
+    "sctid": "763376002",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 28"
+  },
+  {
+    "sctid": "763377006",
+    "preferred_name": "Autosomal spastic paraplegia type 30"
+  },
+  {
+    "sctid": "763402002",
+    "preferred_name": "Spastic paraplegia, neuropathy, poikiloderma syndrome"
+  },
+  {
+    "sctid": "763403007",
+    "preferred_name": "Spastic paraplegia, facial cutaneous lesion syndrome"
+  },
+  {
+    "sctid": "763404001",
+    "preferred_name": "Ichthyosis, alopecia, eclabion, ectropion, intellectual disability syndrome"
+  },
+  {
+    "sctid": "76349003",
+    "preferred_name": "Extrapyramidal disease"
+  },
+  {
+    "sctid": "763534009",
+    "preferred_name": "Hot water reflex epilepsy"
+  },
+  {
+    "sctid": "763615003",
+    "preferred_name": "Aortic arch anomaly, facial dysmorphism, intellectual disability syndrome"
+  },
+  {
+    "sctid": "763618001",
+    "preferred_name": "Wiedemann Steiner syndrome"
+  },
+  {
+    "sctid": "763622006",
+    "preferred_name": "Thinking epilepsy"
+  },
+  {
+    "sctid": "763626009",
+    "preferred_name": "Intellectual disability due to nutritional deficiency"
+  },
+  {
+    "sctid": "763632004",
+    "preferred_name": "Startle epilepsy"
+  },
+  {
+    "sctid": "763665007",
+    "preferred_name": "Craniodigital syndrome and intellectual disability syndrome"
+  },
+  {
+    "sctid": "763669001",
+    "preferred_name": "Spastic ataxia with congenital miosis"
+  },
+  {
+    "sctid": "763688008",
+    "preferred_name": "Deafness, encephaloneuropathy, obesity, valvulopathy syndrome"
+  },
+  {
+    "sctid": "763715007",
+    "preferred_name": "Familial hyperprolactinemia"
+  },
+  {
+    "sctid": "763721006",
+    "preferred_name": "Hypermethioninemia encephalopathy due to deficiency of adenosine kinase"
+  },
+  {
+    "sctid": "763722004",
+    "preferred_name": "Hypotonia, speech impairment, severe cognitive delay syndrome"
+  },
+  {
+    "sctid": "763741001",
+    "preferred_name": "Intellectual disability, alacrima, achalasia syndrome"
+  },
+  {
+    "sctid": "763742008",
+    "preferred_name": "Intellectual disability, polydactyly, uncombable hair syndrome"
+  },
+  {
+    "sctid": "763743003",
+    "preferred_name": "Intellectual disability, spasticity, ectrodactyly syndrome"
+  },
+  {
+    "sctid": "763744009",
+    "preferred_name": "Intellectual disability, brachydactyly, Pierre Robin syndrome"
+  },
+  {
+    "sctid": "763745005",
+    "preferred_name": "Intellectual disability Wolff type"
+  },
+  {
+    "sctid": "763770005",
+    "preferred_name": "Familial cortical myoclonus"
+  },
+  {
+    "sctid": "763773007",
+    "preferred_name": "Macrocephaly and developmental delay syndrome"
+  },
+  {
+    "sctid": "763793004",
+    "preferred_name": "Limbic encephalitis with contactin-associated protein-like 2 antibodies"
+  },
+  {
+    "sctid": "763794005",
+    "preferred_name": "Limbic encephalitis with leucine-rich glioma-inactivated 1 antibodies"
+  },
+  {
+    "sctid": "763795006",
+    "preferred_name": "Malan overgrowth syndrome"
+  },
+  {
+    "sctid": "763797003",
+    "preferred_name": "Agenesis of corpus callosum and abnormal genitalia syndrome"
+  },
+  {
+    "sctid": "763798008",
+    "preferred_name": "Microcephalus, complex motor and sensory axonal neuropathy syndrome"
+  },
+  {
+    "sctid": "763802009",
+    "preferred_name": "Micturition induced epilepsy"
+  },
+  {
+    "sctid": "763803004",
+    "preferred_name": "Morvan syndrome"
+  },
+  {
+    "sctid": "763821001",
+    "preferred_name": "Porencephaly, cerebellar hypoplasia, internal malformations syndrome"
+  },
+  {
+    "sctid": "763827002",
+    "preferred_name": "Orgasm induced epilepsy"
+  },
+  {
+    "sctid": "763834000",
+    "preferred_name": "Oro-facial digital syndrome type 12"
+  },
+  {
+    "sctid": "763837007",
+    "preferred_name": "Oro-facial digital syndrome type 14"
+  },
+  {
+    "sctid": "763861000",
+    "preferred_name": "Pachygyria, intellectual disability, epilepsy syndrome"
+  },
+  {
+    "sctid": "763865009",
+    "preferred_name": "Pilocytic astrocytoma"
+  },
+  {
+    "sctid": "763869003",
+    "preferred_name": "Radiation myelitis"
+  },
+  {
+    "sctid": "76399004",
+    "preferred_name": "Mal de ojo"
+  },
+  {
+    "sctid": "764095005",
+    "preferred_name": "Leukoencephalopathy, ataxia, hypodontia, hypomyelination syndrome"
+  },
+  {
+    "sctid": "76418009",
+    "preferred_name": "Concussion with mental confusion AND/OR disorientation without loss of consciousness"
+  },
+  {
+    "sctid": "76435008",
+    "preferred_name": "Open fracture of C1-C4 level with spinal cord injury"
+  },
+  {
+    "sctid": "76441001",
+    "preferred_name": "Severe major depression, single episode, without psychotic features"
+  },
+  {
+    "sctid": "764453009",
+    "preferred_name": "Action myoclonus renal failure syndrome"
+  },
+  {
+    "sctid": "764455002",
+    "preferred_name": "Cognitive impairment, coarse facies, heart defects, obesity, pulmonary involvement, short stature, skeletal dysplasia syndrome"
+  },
+  {
+    "sctid": "764456001",
+    "preferred_name": "Hyperammonemic encephalopathy due to carbonic anhydrase VA deficiency"
+  },
+  {
+    "sctid": "764522009",
+    "preferred_name": "Familial focal epilepsy with variable foci"
+  },
+  {
+    "sctid": "764591000000108",
+    "preferred_name": "Mixed bipolar affective disorder, severe"
+  },
+  {
+    "sctid": "764611000000100",
+    "preferred_name": "Recurrent major depressive episodes, severe"
+  },
+  {
+    "sctid": "764621000000106",
+    "preferred_name": "Recurrent manic episodes, severe"
+  },
+  {
+    "sctid": "764641000000104",
+    "preferred_name": "Single manic episode, severe"
+  },
+  {
+    "sctid": "764651000000101",
+    "preferred_name": "Nondependent antidepressant type drug abuse"
+  },
+  {
+    "sctid": "764661000000103",
+    "preferred_name": "Cervical spinal cord injury, without spinal bone injury, C5-7"
+  },
+  {
+    "sctid": "764671000000105",
+    "preferred_name": "Recurrent manic episodes, in partial remission"
+  },
+  {
+    "sctid": "764681000000107",
+    "preferred_name": "Recurrent manic episodes, in remission"
+  },
+  {
+    "sctid": "764686003",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 15"
+  },
+  {
+    "sctid": "764688002",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 35"
+  },
+  {
+    "sctid": "764691000000109",
+    "preferred_name": "Recurrent major depressive episodes, in partial remission"
+  },
+  {
+    "sctid": "764701000000109",
+    "preferred_name": "Recurrent major depressive episodes, in remission"
+  },
+  {
+    "sctid": "764711000000106",
+    "preferred_name": "Single major depressive episode, in remission"
+  },
+  {
+    "sctid": "764731000000103",
+    "preferred_name": "Single manic episode in partial remission"
+  },
+  {
+    "sctid": "764732004",
+    "preferred_name": "Microcephalus, cerebellar hypoplasia, cardiac conduction defect syndrome"
+  },
+  {
+    "sctid": "764733009",
+    "preferred_name": "Progressive external ophthalmoplegia, myopathy, emaciation syndrome"
+  },
+  {
+    "sctid": "764734003",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 21"
+  },
+  {
+    "sctid": "764736001",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 43"
+  },
+  {
+    "sctid": "76474001",
+    "preferred_name": "Herpetic acute necrotizing encephalitis"
+  },
+  {
+    "sctid": "764741000000107",
+    "preferred_name": "Single manic episode in remission"
+  },
+  {
+    "sctid": "764783004",
+    "preferred_name": "Mild bodily distress disorder"
+  },
+  {
+    "sctid": "764784005",
+    "preferred_name": "Moderate bodily distress disorder"
+  },
+  {
+    "sctid": "764785006",
+    "preferred_name": "Severe bodily distress disorder"
+  },
+  {
+    "sctid": "764861005",
+    "preferred_name": "Intellectual disability Birk-Barel type"
+  },
+  {
+    "sctid": "764950001",
+    "preferred_name": "Cryptorchidism, arachnodactyly, intellectual disability syndrome"
+  },
+  {
+    "sctid": "764959000",
+    "preferred_name": "Intellectual disability, myopathy, short stature, endocrine defect syndrome"
+  },
+  {
+    "sctid": "764962002",
+    "preferred_name": "Hepatoencephalopathy due to combined oxidative phosphorylation defect type 1"
+  },
+  {
+    "sctid": "764993001",
+    "preferred_name": "Mycoplasma pneumoniae encephalitis"
+  },
+  {
+    "sctid": "764998005",
+    "preferred_name": "Non-herpetic acute limbic encephalitis"
+  },
+  {
+    "sctid": "765045003",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 62"
+  },
+  {
+    "sctid": "765089003",
+    "preferred_name": "Focal epilepsy, intellectual disability, cerebro-cerebellar malformation syndrome"
+  },
+  {
+    "sctid": "765091006",
+    "preferred_name": "Spinocerebellar ataxia with axonal neuropathy type 1"
+  },
+  {
+    "sctid": "765093009",
+    "preferred_name": "Rolandic epilepsy, speech dyspraxia syndrome"
+  },
+  {
+    "sctid": "765100000",
+    "preferred_name": "RRM2B-related mitochondrial DNA depletion syndrome, encephalomyopathic form with renal tubulopathy"
+  },
+  {
+    "sctid": "765108007",
+    "preferred_name": "Pedophilia targeting children of female sex"
+  },
+  {
+    "sctid": "765109004",
+    "preferred_name": "Pedophilia targeting children of male sex"
+  },
+  {
+    "sctid": "765110009",
+    "preferred_name": "Sexual arousal by exposure of genitals to non-consenting person"
+  },
+  {
+    "sctid": "765111008",
+    "preferred_name": "Sexual arousal by exposure of genitals to non-consenting postpubertal person"
+  },
+  {
+    "sctid": "765112001",
+    "preferred_name": "Sexual arousal by exposure of genitals to non-consenting prepubertal person"
+  },
+  {
+    "sctid": "765151006",
+    "preferred_name": "Asphyxiophilia"
+  },
+  {
+    "sctid": "765169002",
+    "preferred_name": "Telephone scatologia"
+  },
+  {
+    "sctid": "765170001",
+    "preferred_name": "SCN8A-related epilepsy with encephalopathy"
+  },
+  {
+    "sctid": "765176007",
+    "preferred_name": "Psychosis and severe depression co-occurrent and due to bipolar affective disorder"
+  },
+  {
+    "sctid": "765202001",
+    "preferred_name": "Familial multiple benign meningioma"
+  },
+  {
+    "sctid": "765216006",
+    "preferred_name": "Audiogenic epilepsy"
+  },
+  {
+    "sctid": "765325002",
+    "preferred_name": "Peripheral demyelinating neuropathy, central dysmyelinating leukodystrophy, Waardenburg syndrome, Hirschsprung disease"
+  },
+  {
+    "sctid": "765331004",
+    "preferred_name": "Autosomal dominant polycystic kidney disease type 1 with tuberous sclerosis"
+  },
+  {
+    "sctid": "765399000",
+    "preferred_name": "Sexual arousal by exposure of genitals to non-consenting prepubertal and postpubertal person"
+  },
+  {
+    "sctid": "765401006",
+    "preferred_name": "Mitochondrial DNA depletion syndrome encephalomyopathic form"
+  },
+  {
+    "sctid": "765403009",
+    "preferred_name": "FBXL4-related encephalomyopathic mitochondrial DNA depletion syndrome"
+  },
+  {
+    "sctid": "765434008",
+    "preferred_name": "HIVEP2-related intellectual disability"
+  },
+  {
+    "sctid": "765471005",
+    "preferred_name": "X-linked intellectual disability, hypogonadism, ichthyosis, obesity, short stature syndrome"
+  },
+  {
+    "sctid": "76566000",
+    "preferred_name": "Subchronic residual schizophrenia"
+  },
+  {
+    "sctid": "765751002",
+    "preferred_name": "Autoimmune encephalopathy with parasomnia and obstructive sleep apnea"
+  },
+  {
+    "sctid": "765753004",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 45"
+  },
+  {
+    "sctid": "765756007",
+    "preferred_name": "Benign infantile seizure with mild gastroenteritis syndrome"
+  },
+  {
+    "sctid": "765757003",
+    "preferred_name": "Bilateral polymicrogyria"
+  },
+  {
+    "sctid": "765758008",
+    "preferred_name": "Microcephalic primordial dwarfism Montreal type"
+  },
+  {
+    "sctid": "765761009",
+    "preferred_name": "Brachydactyly, mesomelia, intellectual disability, heart defect syndrome"
+  },
+  {
+    "sctid": "766044005",
+    "preferred_name": "Acute encephalopathy with biphasic seizures and late reduced diffusion"
+  },
+  {
+    "sctid": "766246000",
+    "preferred_name": "Marburg acute multiple sclerosis"
+  },
+  {
+    "sctid": "766709000",
+    "preferred_name": "Isolated cerebellar vermis hypoplasia"
+  },
+  {
+    "sctid": "766710005",
+    "preferred_name": "Isolated focal cortical dysplasia"
+  },
+  {
+    "sctid": "766753005",
+    "preferred_name": "Nijmegen breakage syndrome-like disorder"
+  },
+  {
+    "sctid": "766767001",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 67"
+  },
+  {
+    "sctid": "766814006",
+    "preferred_name": "Autosomal recessive cerebellar ataxia with saccadic intrusion syndrome"
+  },
+  {
+    "sctid": "766815007",
+    "preferred_name": "Perioral myoclonia with absences"
+  },
+  {
+    "sctid": "766818009",
+    "preferred_name": "X-linked non progressive cerebellar ataxia"
+  },
+  {
+    "sctid": "766824003",
+    "preferred_name": "ADNP-related multiple congenital anomalies, intellectual disability, autism spectrum disorder"
+  },
+  {
+    "sctid": "766870005",
+    "preferred_name": "Epiphyseal dysplasia, hearing loss, dysmorphism syndrome"
+  },
+  {
+    "sctid": "766871009",
+    "preferred_name": "Diencephalic mesencephalic junction dysplasia"
+  },
+  {
+    "sctid": "766872002",
+    "preferred_name": "Parkinsonism caused by cyanide"
+  },
+  {
+    "sctid": "766932005",
+    "preferred_name": "Hypothalamic hamartoma with gelastic seizure"
+  },
+  {
+    "sctid": "766934006",
+    "preferred_name": "Isolated unilateral hemispheric cerebellar hypoplasia"
+  },
+  {
+    "sctid": "767254005",
+    "preferred_name": "Recurrent benign focal seizures of childhood"
+  },
+  {
+    "sctid": "767448007",
+    "preferred_name": "Pineoblastoma"
+  },
+  {
+    "sctid": "767631007",
+    "preferred_name": "Bipolar disorder, most recent episode depression"
+  },
+  {
+    "sctid": "767632000",
+    "preferred_name": "Bipolar disorder, most recent episode manic"
+  },
+  {
+    "sctid": "767633005",
+    "preferred_name": "Bipolar affective disorder, most recent episode mixed"
+  },
+  {
+    "sctid": "767635003",
+    "preferred_name": "Bipolar I disorder, most recent episode manic"
+  },
+  {
+    "sctid": "767636002",
+    "preferred_name": "Bipolar I disorder, most recent episode depression"
+  },
+  {
+    "sctid": "76812003",
+    "preferred_name": "Panic disorder with agoraphobia, moderate agoraphobic avoidance AND panic attacks in partial remission"
+  },
+  {
+    "sctid": "768473009",
+    "preferred_name": "PURA syndrome"
+  },
+  {
+    "sctid": "768553002",
+    "preferred_name": "Hypermanganesemia with dystonia"
+  },
+  {
+    "sctid": "768554008",
+    "preferred_name": "Hypermanganesemia with dystonia 2"
+  },
+  {
+    "sctid": "768555009",
+    "preferred_name": "5q31.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "768556005",
+    "preferred_name": "Ataxia pancytopenia syndrome"
+  },
+  {
+    "sctid": "768663003",
+    "preferred_name": "CLCN2-related leukoencephalopathy"
+  },
+  {
+    "sctid": "768666006",
+    "preferred_name": "STXBP1 encephalopathy with epilepsy"
+  },
+  {
+    "sctid": "768677000",
+    "preferred_name": "PPP2R5D-related intellectual disability"
+  },
+  {
+    "sctid": "76868007",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in full remission AND mild panic attacks"
+  },
+  {
+    "sctid": "76880004",
+    "preferred_name": "Angelman syndrome"
+  },
+  {
+    "sctid": "768843007",
+    "preferred_name": "DNMT3A-related overgrowth syndrome"
+  },
+  {
+    "sctid": "76889003",
+    "preferred_name": "Failed attempted termination of pregnancy with cerebral anoxia"
+  },
+  {
+    "sctid": "768939009",
+    "preferred_name": "Primary tethered cord syndrome"
+  },
+  {
+    "sctid": "76896001",
+    "preferred_name": "Subpial siderosis"
+  },
+  {
+    "sctid": "769023031000119104",
+    "preferred_name": "Cerebrovascular accident of thalamus"
+  },
+  {
+    "sctid": "769065000",
+    "preferred_name": "TUBB4A-related leukodystrophy"
+  },
+  {
+    "sctid": "76938004",
+    "preferred_name": "Infantile encephalopathy AND lactic acidosis"
+  },
+  {
+    "sctid": "76976005",
+    "preferred_name": "Optic atrophy"
+  },
+  {
+    "sctid": "77015008",
+    "preferred_name": "Crossed hemiplegia"
+  },
+  {
+    "sctid": "770404004",
+    "preferred_name": "Autosomal recessive chorioretinopathy and microcephaly syndrome"
+  },
+  {
+    "sctid": "770405003",
+    "preferred_name": "Benign familial mesial temporal lobe epilepsy"
+  },
+  {
+    "sctid": "770431001",
+    "preferred_name": "Early-onset epileptic encephalopathy and intellectual disability due to GRIN2A mutation"
+  },
+  {
+    "sctid": "770438007",
+    "preferred_name": "Infantile spasm and broad thumb syndrome"
+  },
+  {
+    "sctid": "770560008",
+    "preferred_name": "Lissencephaly due to LIS1 mutation"
+  },
+  {
+    "sctid": "770564004",
+    "preferred_name": "Microcephalic primordial dwarfism Alazami type"
+  },
+  {
+    "sctid": "770565003",
+    "preferred_name": "Microcephalic primordial dwarfism Dauber type"
+  },
+  {
+    "sctid": "770604006",
+    "preferred_name": "X-linked cerebral, cerebellar, coloboma syndrome"
+  },
+  {
+    "sctid": "770622009",
+    "preferred_name": "Benign infantile focal epilepsy with midline spikes and waves during sleep"
+  },
+  {
+    "sctid": "770623004",
+    "preferred_name": "Benign occipital lobe epilepsy"
+  },
+  {
+    "sctid": "770624005",
+    "preferred_name": "Benign partial epilepsy of infancy with complex partial seizures"
+  },
+  {
+    "sctid": "770625006",
+    "preferred_name": "Combined immunodeficiency with faciooculoskeletal anomalies syndrome"
+  },
+  {
+    "sctid": "770628008",
+    "preferred_name": "Diffuse leptomeningeal melanocytosis"
+  },
+  {
+    "sctid": "770643005",
+    "preferred_name": "Mesial temporal lobe epilepsy with hippocampal sclerosis"
+  },
+  {
+    "sctid": "770655004",
+    "preferred_name": "Microcephalus, brain defect, spasticity, hypernatremia syndrome"
+  },
+  {
+    "sctid": "770664009",
+    "preferred_name": "Neonatal brainstem dysfunction"
+  },
+  {
+    "sctid": "770678005",
+    "preferred_name": "Progressive encephalopathy with edema, hypsarrhythmia, and optic atrophy-like syndrome"
+  },
+  {
+    "sctid": "770679002",
+    "preferred_name": "Polyneuropathy, intellectual disability, acromicria, premature menopause syndrome"
+  },
+  {
+    "sctid": "770680004",
+    "preferred_name": "Prader-Willi-like syndrome"
+  },
+  {
+    "sctid": "770682007",
+    "preferred_name": "Rosette-forming glioneuronal neoplasm"
+  },
+  {
+    "sctid": "770683002",
+    "preferred_name": "Secondary syringomyelia"
+  },
+  {
+    "sctid": "770719004",
+    "preferred_name": "3q27.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "770720005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 58"
+  },
+  {
+    "sctid": "770721009",
+    "preferred_name": "Microcephaly, thin corpus callosum, intellectual disability syndrome"
+  },
+  {
+    "sctid": "770722002",
+    "preferred_name": "Proximal myopathy with extrapyramidal signs"
+  },
+  {
+    "sctid": "770723007",
+    "preferred_name": "Optic atrophy, intellectual disability syndrome"
+  },
+  {
+    "sctid": "770724001",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 70"
+  },
+  {
+    "sctid": "770725000",
+    "preferred_name": "Infantile cerebral and cerebellar atrophy with postnatal progressive microcephaly"
+  },
+  {
+    "sctid": "770750002",
+    "preferred_name": "Intellectual disability, seizures, macrocephaly, obesity syndrome"
+  },
+  {
+    "sctid": "770751003",
+    "preferred_name": "Severe motor and intellectual disabilities, sensorineural deafness, dystonia syndrome"
+  },
+  {
+    "sctid": "770755007",
+    "preferred_name": "Intellectual disability, seizures, hypotonia, ophthalmologic, skeletal anomalies syndrome"
+  },
+  {
+    "sctid": "770756008",
+    "preferred_name": "2p13.2 microdeletion syndrome"
+  },
+  {
+    "sctid": "770757004",
+    "preferred_name": "X-linked parkinsonism with spasticity syndrome"
+  },
+  {
+    "sctid": "770758009",
+    "preferred_name": "New-onset refractory status epilepticus"
+  },
+  {
+    "sctid": "770790004",
+    "preferred_name": "Developmental delay with autism spectrum disorder and gait instability"
+  },
+  {
+    "sctid": "770793002",
+    "preferred_name": "5p13 microduplication syndrome"
+  },
+  {
+    "sctid": "770794008",
+    "preferred_name": "11p15.4 microduplication syndrome"
+  },
+  {
+    "sctid": "770898002",
+    "preferred_name": "Autosomal recessive cerebellar ataxia, epilepsy, intellectual disability syndrome due to WWOX deficiency"
+  },
+  {
+    "sctid": "770901001",
+    "preferred_name": "Autosomal recessive intellectual disability, motor dysfunction, multiple joint contracture syndrome"
+  },
+  {
+    "sctid": "770907002",
+    "preferred_name": "Kagami Ogata syndrome"
+  },
+  {
+    "sctid": "770939009",
+    "preferred_name": "Huntington disease-like 3"
+  },
+  {
+    "sctid": "770941005",
+    "preferred_name": "Alopecia, progressive neurological defect, endocrinopathy syndrome"
+  },
+  {
+    "sctid": "771074000",
+    "preferred_name": "Microcephaly, short stature, intellectual disability, facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "771077007",
+    "preferred_name": "Intellectual disability, short stature, hypertelorism syndrome"
+  },
+  {
+    "sctid": "771141002",
+    "preferred_name": "Benign partial epilepsy with secondarily generalized seizures in infancy"
+  },
+  {
+    "sctid": "771142009",
+    "preferred_name": "Cortical dysplasia with focal epilepsy syndrome"
+  },
+  {
+    "sctid": "771146007",
+    "preferred_name": "Holoprosencephaly with caudal dysgenesis syndrome"
+  },
+  {
+    "sctid": "771147003",
+    "preferred_name": "Isolated arhinencephaly"
+  },
+  {
+    "sctid": "771148008",
+    "preferred_name": "X-linked colobomatous microphthalmia, microcephaly, intellectual disability, short stature syndrome"
+  },
+  {
+    "sctid": "771149000",
+    "preferred_name": "Hepatic fibrosis, renal cyst, intellectual disability syndrome"
+  },
+  {
+    "sctid": "771179007",
+    "preferred_name": "Extrasystoles, short stature, hyperpigmentation, microcephaly syndrome"
+  },
+  {
+    "sctid": "771184001",
+    "preferred_name": "Leukoencephalopathy, palmoplantar keratoderma syndrome"
+  },
+  {
+    "sctid": "771223000",
+    "preferred_name": "Infantile epileptic dyskinetic encephalopathy"
+  },
+  {
+    "sctid": "771234002",
+    "preferred_name": "Isolated bilateral hemispheric cerebellar hypoplasia"
+  },
+  {
+    "sctid": "771262009",
+    "preferred_name": "Pseudoleprechaunism syndrome Patterson type"
+  },
+  {
+    "sctid": "771271000",
+    "preferred_name": "Steroid-responsive encephalopathy associated with autoimmune thyroiditis"
+  },
+  {
+    "sctid": "7713009",
+    "preferred_name": "Intrapontine hemorrhage"
+  },
+  {
+    "sctid": "771303004",
+    "preferred_name": "Severe neonatal onset encephalopathy with microcephaly"
+  },
+  {
+    "sctid": "771304005",
+    "preferred_name": "Benign nocturnal alternating hemiplegia of childhood"
+  },
+  {
+    "sctid": "771305006",
+    "preferred_name": "Progressive polyneuropathy with bilateral striatal necrosis"
+  },
+  {
+    "sctid": "771308008",
+    "preferred_name": "Non-acquired combined pituitary hormone deficiency, sensorineural hearing loss, spine abnormalities syndrome"
+  },
+  {
+    "sctid": "771336003",
+    "preferred_name": "Polymicrogyria with optic nerve hypoplasia"
+  },
+  {
+    "sctid": "771418002",
+    "preferred_name": "Postoperative delirium"
+  },
+  {
+    "sctid": "771419005",
+    "preferred_name": "Hyperactive postoperative delirium"
+  },
+  {
+    "sctid": "771420004",
+    "preferred_name": "Hypoactive postoperative delirium"
+  },
+  {
+    "sctid": "771421000",
+    "preferred_name": "Mixed hyperactive hypoactive postoperative delirium"
+  },
+  {
+    "sctid": "771448004",
+    "preferred_name": "Autism epilepsy syndrome due to branched chain ketoacid dehydrogenase kinase deficiency"
+  },
+  {
+    "sctid": "771469002",
+    "preferred_name": "Early-onset spastic ataxia, myoclonic epilepsy, neuropathy syndrome"
+  },
+  {
+    "sctid": "771470001",
+    "preferred_name": "Jawad syndrome"
+  },
+  {
+    "sctid": "771471002",
+    "preferred_name": "Optic nerve edema, splenomegaly syndrome"
+  },
+  {
+    "sctid": "771472009",
+    "preferred_name": "Developmental and speech delay due to SOX5 deficiency"
+  },
+  {
+    "sctid": "771476007",
+    "preferred_name": "Autosomal recessive leukoencephalopathy, ischemic stroke, retinitis pigmentosa syndrome"
+  },
+  {
+    "sctid": "771477003",
+    "preferred_name": "15q overgrowth syndrome"
+  },
+  {
+    "sctid": "771512003",
+    "preferred_name": "Autism spectrum disorder due to AUTS2 deficiency"
+  },
+  {
+    "sctid": "771514002",
+    "preferred_name": "Early-onset progressive neurodegeneration, blindness, ataxia, spasticity syndrome"
+  },
+  {
+    "sctid": "771516000",
+    "preferred_name": "Solute carrier family 35 member A2 congenital disorder of glycosylation"
+  },
+  {
+    "sctid": "771540008",
+    "preferred_name": "Meningitis following central neuraxial block"
+  },
+  {
+    "sctid": "77157004",
+    "preferred_name": "Disorder of optic nerve"
+  },
+  {
+    "sctid": "7718000",
+    "preferred_name": "Bilis"
+  },
+  {
+    "sctid": "772127009",
+    "preferred_name": "White Sutton syndrome"
+  },
+  {
+    "sctid": "772224009",
+    "preferred_name": "Warburg micro syndrome"
+  },
+  {
+    "sctid": "772225005",
+    "preferred_name": "RAB18 deficiency"
+  },
+  {
+    "sctid": "77274005",
+    "preferred_name": "Idiopathic diabetes insipidus"
+  },
+  {
+    "sctid": "77287004",
+    "preferred_name": "Borderline intellectual disability"
+  },
+  {
+    "sctid": "773230003",
+    "preferred_name": "Cyclin-dependent kinase-like 5 deficiency"
+  },
+  {
+    "sctid": "773274001",
+    "preferred_name": "X-linked intellectual disability, craniofacioskeletal syndrome"
+  },
+  {
+    "sctid": "773275000",
+    "preferred_name": "Post-transplant acute limbic encephalitis"
+  },
+  {
+    "sctid": "773280009",
+    "preferred_name": "Hydrocephalus, blue sclera, nephropathy syndrome"
+  },
+  {
+    "sctid": "773303005",
+    "preferred_name": "Spondyloepimetaphyseal dysplasia Genevieve type"
+  },
+  {
+    "sctid": "773305003",
+    "preferred_name": "Microcephaly, polymicrogyria, corpus callosum agenesis syndrome"
+  },
+  {
+    "sctid": "773307006",
+    "preferred_name": "Zechi Ceide syndrome"
+  },
+  {
+    "sctid": "77332003",
+    "preferred_name": "Partialism"
+  },
+  {
+    "sctid": "773329005",
+    "preferred_name": "CK syndrome"
+  },
+  {
+    "sctid": "773394007",
+    "preferred_name": "Autosomal recessive frontotemporal pachygyria"
+  },
+  {
+    "sctid": "773395008",
+    "preferred_name": "Limbic encephalitis with dipeptidyl-peptidase 6 antibodies"
+  },
+  {
+    "sctid": "773400009",
+    "preferred_name": "Severe feeding difficulties, failure to thrive, microcephaly due to ASXL3 deficiency syndrome"
+  },
+  {
+    "sctid": "773404000",
+    "preferred_name": "Roifman syndrome"
+  },
+  {
+    "sctid": "773405004",
+    "preferred_name": "Intellectual disability with strabismus syndrome"
+  },
+  {
+    "sctid": "773416006",
+    "preferred_name": "Intellectual disability, facial dysmorphism, hand anomalies syndrome"
+  },
+  {
+    "sctid": "773418007",
+    "preferred_name": "XYLT1-CDG - xylosyltransferase 1 congenital disorder of glycosylation"
+  },
+  {
+    "sctid": "773419004",
+    "preferred_name": "Severe intellectual disability, short stature, behavioral abnormalities, facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "773421009",
+    "preferred_name": "Infantile-onset mesial temporal lobe epilepsy with severe cognitive regression"
+  },
+  {
+    "sctid": "773425000",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 59"
+  },
+  {
+    "sctid": "773493002",
+    "preferred_name": "9q31.1q31.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "773494008",
+    "preferred_name": "14q24.1q24.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "773497001",
+    "preferred_name": "Partial corpus callosum agenesis, cerebellar vermis hypoplasia with posterior fossa cysts syndrome"
+  },
+  {
+    "sctid": "773498006",
+    "preferred_name": "Autosomal recessive cerebellar ataxia, epilepsy, intellectual disability syndrome due to TUD deficiency"
+  },
+  {
+    "sctid": "773547003",
+    "preferred_name": "13q12.3 microdeletion syndrome"
+  },
+  {
+    "sctid": "773548008",
+    "preferred_name": "Early-onset epileptic encephalopathy, cortical blindness, intellectual disability, facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "77355000",
+    "preferred_name": "Cannabis-induced organic mental disorder"
+  },
+  {
+    "sctid": "773551001",
+    "preferred_name": "Severe intellectual disability, poor language, strabismus, grimacing face, long fingers syndrome"
+  },
+  {
+    "sctid": "773552008",
+    "preferred_name": "Intellectual disability, feeding difficulties, developmental delay, microcephaly syndrome"
+  },
+  {
+    "sctid": "773553003",
+    "preferred_name": "Hypohidrosis, enamel hypoplasia, palmoplantar keratoderma, intellectual disability syndrome"
+  },
+  {
+    "sctid": "773554009",
+    "preferred_name": "THOC6-related developmental delay-microcephaly-facial dysmorphism syndrome"
+  },
+  {
+    "sctid": "773556006",
+    "preferred_name": "Short ulna, dysmorphism, hypotonia, intellectual disability syndrome"
+  },
+  {
+    "sctid": "773578004",
+    "preferred_name": "Spondylocostal dysostosis, hypospadias, intellectual disability syndrome"
+  },
+  {
+    "sctid": "773581009",
+    "preferred_name": "Intellectual disability, craniofacial dysmorphism, cryptorchidism syndrome"
+  },
+  {
+    "sctid": "773583007",
+    "preferred_name": "Aphonia, deafness, retinal dystrophy, bifid halluces, intellectual disability syndrome"
+  },
+  {
+    "sctid": "773587008",
+    "preferred_name": "X-linked intellectual disability, cardiomegaly, congestive heart failure syndrome"
+  },
+  {
+    "sctid": "773610007",
+    "preferred_name": "Chudley McCullough syndrome"
+  },
+  {
+    "sctid": "773621003",
+    "preferred_name": "Intellectual disability, hypotonia, brachycephaly, pyloric stenosis, cryptorchidism syndrome"
+  },
+  {
+    "sctid": "773627004",
+    "preferred_name": "Porencephaly, microcephaly, bilateral congenital cataract syndrome"
+  },
+  {
+    "sctid": "773643006",
+    "preferred_name": "Multiple congenital anomalies, hypotonia, seizures syndrome type 2"
+  },
+  {
+    "sctid": "773645004",
+    "preferred_name": "Familial infantile gigantism"
+  },
+  {
+    "sctid": "773663004",
+    "preferred_name": "Rapid-onset childhood obesity, hypothalamic dysfunction, hypoventilation, autonomic dysregulation syndrome"
+  },
+  {
+    "sctid": "773664005",
+    "preferred_name": "Deficiency in anterior pituitary function, variable immunodeficiency syndrome"
+  },
+  {
+    "sctid": "773665006",
+    "preferred_name": "Hypogonadotropic hypogonadism, severe microcephaly, sensorineural hearing loss, dysmorphism syndrome"
+  },
+  {
+    "sctid": "773668008",
+    "preferred_name": "Childhood encephalopathy due to thiamine pyrophosphokinase deficiency"
+  },
+  {
+    "sctid": "773670004",
+    "preferred_name": "Distal Xq28 microduplication syndrome"
+  },
+  {
+    "sctid": "773672007",
+    "preferred_name": "Lethal occipital encephalocele, skeletal dysplasia syndrome"
+  },
+  {
+    "sctid": "773688007",
+    "preferred_name": "Chronic lymphocytic inflammation with pontine perivascular enhancement responsive to steroids"
+  },
+  {
+    "sctid": "773692000",
+    "preferred_name": "Late-onset localized junctional epidermolysis bullosa, intellectual disability syndrome"
+  },
+  {
+    "sctid": "773699009",
+    "preferred_name": "Pitt Hopkins-like syndrome"
+  },
+  {
+    "sctid": "773735007",
+    "preferred_name": "Deafness with onychodystrophy syndrome"
+  },
+  {
+    "sctid": "773737004",
+    "preferred_name": "NPHP3-related Meckel-like syndrome"
+  },
+  {
+    "sctid": "77375009",
+    "preferred_name": "Adductor spastic dysphonia of conversion reaction"
+  },
+  {
+    "sctid": "773769008",
+    "preferred_name": "Ataxia, photosensitivity, short stature syndrome"
+  },
+  {
+    "sctid": "773772001",
+    "preferred_name": "Rare non-syndromic intellectual disability"
+  },
+  {
+    "sctid": "773984007",
+    "preferred_name": "Piebald trait with neurologic defects syndrome"
+  },
+  {
+    "sctid": "773989002",
+    "preferred_name": "Late-onset isolated adrenocorticotropic hormone deficiency"
+  },
+  {
+    "sctid": "774068004",
+    "preferred_name": "AHDC1-related intellectual disability, obstructive sleep apnea, mild dysmorphism syndrome"
+  },
+  {
+    "sctid": "774069007",
+    "preferred_name": "PRKAR1B-related neurodegenerative dementia with intermediate filaments"
+  },
+  {
+    "sctid": "774070008",
+    "preferred_name": "FBLN1-related developmental delay, central nervous system anomaly, syndactyly syndrome"
+  },
+  {
+    "sctid": "774102003",
+    "preferred_name": "Intellectual disability, obesity, prognathism, eye and skin anomalies syndrome"
+  },
+  {
+    "sctid": "774149004",
+    "preferred_name": "Severe intellectual disability, progressive postnatal microcephaly, midline stereotypic hand movements syndrome"
+  },
+  {
+    "sctid": "774150004",
+    "preferred_name": "Sacral agenesis, abnormal ossification of vertebral bodies, persistent notochordal canal syndrome"
+  },
+  {
+    "sctid": "774151000",
+    "preferred_name": "Ferro-cerebro-cutaneous syndrome"
+  },
+  {
+    "sctid": "774203000",
+    "preferred_name": "Intellectual disability, severe speech delay, mild dysmorphism syndrome"
+  },
+  {
+    "sctid": "774206008",
+    "preferred_name": "Fatal post-viral neurodegenerative disorder"
+  },
+  {
+    "sctid": "774208009",
+    "preferred_name": "SCALP syndrome"
+  },
+  {
+    "sctid": "77475008",
+    "preferred_name": "Jealous delusion disorder"
+  },
+  {
+    "sctid": "77486005",
+    "preferred_name": "Mood disorder with major depressive-like episode due to general medical condition"
+  },
+  {
+    "sctid": "77553008",
+    "preferred_name": "Opticocochleodentate degeneration"
+  },
+  {
+    "sctid": "77575005",
+    "preferred_name": "Secondary hyperprolactinemia due to prolactin-secreting tumor"
+  },
+  {
+    "sctid": "775907000",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 9"
+  },
+  {
+    "sctid": "77600008",
+    "preferred_name": "Bing-Neel syndrome"
+  },
+  {
+    "sctid": "776087007",
+    "preferred_name": "Autosomal recessive cerebral atrophy"
+  },
+  {
+    "sctid": "7761000119106",
+    "preferred_name": "Psychotic disorder due to amphetamine use"
+  },
+  {
+    "sctid": "776204008",
+    "preferred_name": "Colobomatous microphthalmia, obesity, hypogenitalism, intellectual disability syndrome"
+  },
+  {
+    "sctid": "77645007",
+    "preferred_name": "Salmonella meningitis"
+  },
+  {
+    "sctid": "77675002",
+    "preferred_name": "Anorexia nervosa, restricting type"
+  },
+  {
+    "sctid": "777998000",
+    "preferred_name": "Temtamy preaxial brachydactyly syndrome"
+  },
+  {
+    "sctid": "777999008",
+    "preferred_name": "Hypomyelination with brain stem and spinal cord involvement and leg spasticity"
+  },
+  {
+    "sctid": "778001003",
+    "preferred_name": "KCNQ2-related epileptic encephalopathy"
+  },
+  {
+    "sctid": "778002005",
+    "preferred_name": "SCN2A encephalopathy"
+  },
+  {
+    "sctid": "778005007",
+    "preferred_name": "Duplication of pituitary gland"
+  },
+  {
+    "sctid": "778009001",
+    "preferred_name": "Blepharophimosis, intellectual disability syndrome, Verloes type"
+  },
+  {
+    "sctid": "778011005",
+    "preferred_name": "Severe intellectual disability and progressive spastic paraplegia"
+  },
+  {
+    "sctid": "778021002",
+    "preferred_name": "Microphthalmia, retinitis pigmentosa, foveoschisis, optic disc drusen syndrome"
+  },
+  {
+    "sctid": "778025006",
+    "preferred_name": "Atypical hypotonia cystinuria syndrome"
+  },
+  {
+    "sctid": "778029000",
+    "preferred_name": "FASTKD2-related infantile mitochondrial encephalomyopathy"
+  },
+  {
+    "sctid": "778030005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 27"
+  },
+  {
+    "sctid": "778046002",
+    "preferred_name": "Somatomammotropinoma"
+  },
+  {
+    "sctid": "778047006",
+    "preferred_name": "Myoclonic epilepsy in non-progressive encephalopathy"
+  },
+  {
+    "sctid": "778048001",
+    "preferred_name": "MT-ATP6-related mitochondrial spastic paraplegia"
+  },
+  {
+    "sctid": "778060000",
+    "preferred_name": "COL4A1-related familial vascular leukoencephalopathy"
+  },
+  {
+    "sctid": "778063003",
+    "preferred_name": "Cryptogenic late-onset epileptic spasms"
+  },
+  {
+    "sctid": "778070003",
+    "preferred_name": "Autosomal dominant primary microcephaly"
+  },
+  {
+    "sctid": "77815007",
+    "preferred_name": "Gender identity disorder of adulthood, previously homosexual"
+  },
+  {
+    "sctid": "77817004",
+    "preferred_name": "Neu-Laxova syndrome"
+  },
+  {
+    "sctid": "77911002",
+    "preferred_name": "Severe major depression, single episode, with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "7794004",
+    "preferred_name": "Chronic motor tic disorder"
+  },
+  {
+    "sctid": "78004001",
+    "preferred_name": "Bulimia nervosa"
+  },
+  {
+    "sctid": "78028004",
+    "preferred_name": "Brain stem contusion with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "780822000",
+    "preferred_name": "Desmoplastic infantile astrocytoma and ganglioglioma"
+  },
+  {
+    "sctid": "780827006",
+    "preferred_name": "SYNGAP1-related intellectual disability"
+  },
+  {
+    "sctid": "78085003",
+    "preferred_name": "Open fracture of T7-T12 level with incomplete spinal cord lesion"
+  },
+  {
+    "sctid": "781129002",
+    "preferred_name": "Inadvertent dural tap during anesthesia"
+  },
+  {
+    "sctid": "78157002",
+    "preferred_name": "Closed fracture of C5-C7 level with central cord syndrome"
+  },
+  {
+    "sctid": "78211006",
+    "preferred_name": "Open fracture of thoracic spine with spinal cord injury"
+  },
+  {
+    "sctid": "782432008",
+    "preferred_name": "Acquired hydrocephalus of newborn"
+  },
+  {
+    "sctid": "782501005",
+    "preferred_name": "Adjustment disorder with mixed anxiety and depressed mood"
+  },
+  {
+    "sctid": "782670003",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 3"
+  },
+  {
+    "sctid": "782680004",
+    "preferred_name": "Gangliocytoma of central nervous system"
+  },
+  {
+    "sctid": "78269000",
+    "preferred_name": "Bipolar I disorder, single manic episode, in partial remission"
+  },
+  {
+    "sctid": "782690007",
+    "preferred_name": "Gemignani syndrome"
+  },
+  {
+    "sctid": "782695002",
+    "preferred_name": "Primary dystonia DYT17 type"
+  },
+  {
+    "sctid": "782696001",
+    "preferred_name": "Recessive mitochondrial ataxia syndrome"
+  },
+  {
+    "sctid": "782718007",
+    "preferred_name": "Dystonia aphonia syndrome"
+  },
+  {
+    "sctid": "782719004",
+    "preferred_name": "Autosomal recessive cerebellar ataxia due to STUB1 deficiency"
+  },
+  {
+    "sctid": "782720005",
+    "preferred_name": "Congenital pontocerebellar hypoplasia type 10"
+  },
+  {
+    "sctid": "782721009",
+    "preferred_name": "Autosomal recessive cerebellar ataxia, epilepsy, intellectual disability syndrome due to RUBCN deficiency"
+  },
+  {
+    "sctid": "782723007",
+    "preferred_name": "Severe intellectual disability, progressive spastic diplegia syndrome"
+  },
+  {
+    "sctid": "782725000",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 69"
+  },
+  {
+    "sctid": "782726004",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 71"
+  },
+  {
+    "sctid": "782727008",
+    "preferred_name": "Autosomal spastic paraplegia type 72"
+  },
+  {
+    "sctid": "782736007",
+    "preferred_name": "Intellectual disability, facial dysmorphism syndrome due to SETD5 haploinsufficiency"
+  },
+  {
+    "sctid": "782737003",
+    "preferred_name": "Diffuse cerebral and cerebellar atrophy, intractable seizures, progressive microcephaly syndrome"
+  },
+  {
+    "sctid": "782743001",
+    "preferred_name": "Huntington disease-like syndrome due to C9ORF72 expansions"
+  },
+  {
+    "sctid": "782744007",
+    "preferred_name": "Lipoic acid synthetase deficiency"
+  },
+  {
+    "sctid": "782746009",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 60"
+  },
+  {
+    "sctid": "782747000",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 66"
+  },
+  {
+    "sctid": "782753000",
+    "preferred_name": "Intellectual disability, coarse face, macrocephaly, cerebellar hypotrophy syndrome"
+  },
+  {
+    "sctid": "782754006",
+    "preferred_name": "Foveal hypoplasia, optic nerve decussation defect, anterior segment dysgenesis syndrome"
+  },
+  {
+    "sctid": "782755007",
+    "preferred_name": "Primary microcephaly, mild intellectual disability, young-onset diabetes syndrome"
+  },
+  {
+    "sctid": "782757004",
+    "preferred_name": "Congenital microcephaly, severe encephalopathy, progressive cerebral atrophy syndrome"
+  },
+  {
+    "sctid": "782771007",
+    "preferred_name": "Mitochondrial DNA depletion syndrome hepatocerebrorenal form"
+  },
+  {
+    "sctid": "782772000",
+    "preferred_name": "Congenital muscular dystrophy with intellectual disability and severe epilepsy"
+  },
+  {
+    "sctid": "782822006",
+    "preferred_name": "Infantile cerebellar and retinal degeneration"
+  },
+  {
+    "sctid": "782825008",
+    "preferred_name": "Primary microcephaly, epilepsy, permanent neonatal diabetes syndrome"
+  },
+  {
+    "sctid": "782879004",
+    "preferred_name": "Occipital pachygyria and polymicrogyria"
+  },
+  {
+    "sctid": "782884005",
+    "preferred_name": "Pontine tegmental cap dysplasia"
+  },
+  {
+    "sctid": "782886007",
+    "preferred_name": "Infantile spasms, psychomotor retardation, progressive brain atrophy, basal ganglia disease syndrome"
+  },
+  {
+    "sctid": "782887003",
+    "preferred_name": "Inherited congenital spastic tetraplegia"
+  },
+  {
+    "sctid": "782911008",
+    "preferred_name": "Hereditary cryohydrocytosis with reduced stomatin"
+  },
+  {
+    "sctid": "782917007",
+    "preferred_name": "Familial adrenal hypoplasia with absent pituitary luteinizing hormone"
+  },
+  {
+    "sctid": "782941005",
+    "preferred_name": "Richieri Costa-da Silva syndrome"
+  },
+  {
+    "sctid": "782945001",
+    "preferred_name": "Ophthalmoplegia, intellectual disability, lingua scrotalis syndrome"
+  },
+  {
+    "sctid": "782951006",
+    "preferred_name": "Thoracic dysplasia and hydrocephalus syndrome"
+  },
+  {
+    "sctid": "783005002",
+    "preferred_name": "Severe microbrachycephaly, intellectual disability, athetoid cerebral palsy syndrome"
+  },
+  {
+    "sctid": "783008000",
+    "preferred_name": "Pituitary dermoid and epidermoid cysts"
+  },
+  {
+    "sctid": "783009008",
+    "preferred_name": "Pituitary deficiency due to Rathke cleft cysts"
+  },
+  {
+    "sctid": "783012006",
+    "preferred_name": "Parkinsonian pyramidal syndrome"
+  },
+  {
+    "sctid": "783016009",
+    "preferred_name": "Panhypophysitis"
+  },
+  {
+    "sctid": "783055005",
+    "preferred_name": "Progressive myoclonic epilepsy type 5"
+  },
+  {
+    "sctid": "783060009",
+    "preferred_name": "Autosomal recessive cerebellar ataxia, psychomotor delay syndrome"
+  },
+  {
+    "sctid": "783061008",
+    "preferred_name": "Facial dysmorphism, developmental delay, behavioral abnormalities syndrome due to 10p11.21p12.31 microdeletion"
+  },
+  {
+    "sctid": "783062001",
+    "preferred_name": "Progressive myoclonic epilepsy type 6"
+  },
+  {
+    "sctid": "783064000",
+    "preferred_name": "Progressive myoclonic epilepsy type 3"
+  },
+  {
+    "sctid": "783065004",
+    "preferred_name": "Autosomal recessive optic atrophy type 7"
+  },
+  {
+    "sctid": "783089006",
+    "preferred_name": "Macrocephaly, intellectual disability, autism syndrome"
+  },
+  {
+    "sctid": "783090002",
+    "preferred_name": "IRVAN syndrome"
+  },
+  {
+    "sctid": "783094006",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 14"
+  },
+  {
+    "sctid": "783139000",
+    "preferred_name": "Progressive myoclonic epilepsy type 8"
+  },
+  {
+    "sctid": "783157004",
+    "preferred_name": "Leigh syndrome with nephrotic syndrome"
+  },
+  {
+    "sctid": "783158009",
+    "preferred_name": "Infundibulo neurohypophysitis"
+  },
+  {
+    "sctid": "783161005",
+    "preferred_name": "ABri amyloidosis"
+  },
+  {
+    "sctid": "783174004",
+    "preferred_name": "Congenital muscular dystrophy with intellectual disability"
+  },
+  {
+    "sctid": "783176002",
+    "preferred_name": "Congenital muscular dystrophy with cerebellar involvement"
+  },
+  {
+    "sctid": "783179009",
+    "preferred_name": "Cranio-cervical dystonia with laryngeal and upper limb involvement"
+  },
+  {
+    "sctid": "783198006",
+    "preferred_name": "Hereditary sensory and autonomic neuropathy due to TECPR2 mutation"
+  },
+  {
+    "sctid": "783203003",
+    "preferred_name": "Ataxia with tapetoretinal degeneration syndrome"
+  },
+  {
+    "sctid": "783242003",
+    "preferred_name": "Adult-onset cervical dystonia DYT23 type"
+  },
+  {
+    "sctid": "783243008",
+    "preferred_name": "Adenohypophysitis"
+  },
+  {
+    "sctid": "783258000",
+    "preferred_name": "ADan amyloidosis"
+  },
+  {
+    "sctid": "78358001",
+    "preferred_name": "Amphetamine withdrawal"
+  },
+  {
+    "sctid": "783619003",
+    "preferred_name": "DYRK1A-related intellectual disability syndrome due to 21q22.13q22.2 microdeletion"
+  },
+  {
+    "sctid": "783622001",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 38"
+  },
+  {
+    "sctid": "783697000",
+    "preferred_name": "X-linked spastic paraplegia type 16"
+  },
+  {
+    "sctid": "783698005",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 13"
+  },
+  {
+    "sctid": "783701002",
+    "preferred_name": "Port-wine nevi, mega cisterna magna, hydrocephalus syndrome"
+  },
+  {
+    "sctid": "783702009",
+    "preferred_name": "X-linked intellectual disability due to GRIA3 mutations"
+  },
+  {
+    "sctid": "783703004",
+    "preferred_name": "White matter hypoplasia, corpus callosum agenesis, intellectual disability syndrome"
+  },
+  {
+    "sctid": "783724009",
+    "preferred_name": "Fetal spina bifida"
+  },
+  {
+    "sctid": "783726006",
+    "preferred_name": "Fetal hydrocephalus"
+  },
+  {
+    "sctid": "783734000",
+    "preferred_name": "Mitochondrial DNA depletion syndrome, hepatocerebral form due to DGUOK deficiency"
+  },
+  {
+    "sctid": "783739005",
+    "preferred_name": "Familial temporal lobe epilepsy"
+  },
+  {
+    "sctid": "783764008",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 56"
+  },
+  {
+    "sctid": "783787000",
+    "preferred_name": "Retinal vasculopathy with cerebral leukoencephalopathy and systemic manifestations"
+  },
+  {
+    "sctid": "784341001",
+    "preferred_name": "Amyotrophic lateral sclerosis type 4"
+  },
+  {
+    "sctid": "784342008",
+    "preferred_name": "Familial infantile myoclonic epilepsy"
+  },
+  {
+    "sctid": "784343003",
+    "preferred_name": "Autosomal recessive spastic ataxia with leukoencephalopathy"
+  },
+  {
+    "sctid": "784344009",
+    "preferred_name": "Cortical dysgenesis with pontocerebellar hypoplasia due to TUBB3 mutation"
+  },
+  {
+    "sctid": "784345005",
+    "preferred_name": "Malignant migrating partial seizures of infancy"
+  },
+  {
+    "sctid": "784347002",
+    "preferred_name": "Autosomal recessive spastic ataxia, optic atrophy, dysarthria syndrome"
+  },
+  {
+    "sctid": "784371009",
+    "preferred_name": "Huntington disease-like 1"
+  },
+  {
+    "sctid": "784372002",
+    "preferred_name": "Familial mesial temporal lobe epilepsy with febrile seizures"
+  },
+  {
+    "sctid": "784377008",
+    "preferred_name": "Autosomal dominant epilepsy with auditory features"
+  },
+  {
+    "sctid": "784573006",
+    "preferred_name": "Traumatic intracranial extradural hemorrhage"
+  },
+  {
+    "sctid": "785298001",
+    "preferred_name": "Muscle eye brain disease with bilateral multicystic leukodystrophy"
+  },
+  {
+    "sctid": "785299009",
+    "preferred_name": "Cobblestone lissencephaly without muscular or ocular involvement"
+  },
+  {
+    "sctid": "785300001",
+    "preferred_name": "Infantile-onset autosomal recessive non progressive cerebellar ataxia"
+  },
+  {
+    "sctid": "785301002",
+    "preferred_name": "Childhood-onset autosomal recessive slowly progressive spinocerebellar ataxia"
+  },
+  {
+    "sctid": "785302009",
+    "preferred_name": "Adult-onset autosomal recessive cerebellar ataxia"
+  },
+  {
+    "sctid": "785303004",
+    "preferred_name": "Multiple congenital anomalies, hypotonia, seizures syndrome"
+  },
+  {
+    "sctid": "785304005",
+    "preferred_name": "Autosomal recessive spastic paraplegia type 24"
+  },
+  {
+    "sctid": "785305006",
+    "preferred_name": "Autosomal dominant spastic paraplegia type 8"
+  },
+  {
+    "sctid": "785306007",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type E"
+  },
+  {
+    "sctid": "785307003",
+    "preferred_name": "Lissencephaly with cerebellar hypoplasia type A"
+  },
+  {
+    "sctid": "78569004",
+    "preferred_name": "Posterior inferior cerebellar artery syndrome"
+  },
+  {
+    "sctid": "785722006",
+    "preferred_name": "Obesity due to leptin receptor gene deficiency"
+  },
+  {
+    "sctid": "785726009",
+    "preferred_name": "Hyperekplexia epilepsy syndrome"
+  },
+  {
+    "sctid": "785810000",
+    "preferred_name": "Synucleinopathy"
+  },
+  {
+    "sctid": "786076007",
+    "preferred_name": "Congenital pit of optic disc"
+  },
+  {
+    "sctid": "786078008",
+    "preferred_name": "Acquired pit of optic disc"
+  },
+  {
+    "sctid": "786120041000132108",
+    "preferred_name": "Substance induced psychotic disorder"
+  },
+  {
+    "sctid": "78640000",
+    "preferred_name": "Severe manic bipolar I disorder with psychotic features, mood-congruent"
+  },
+  {
+    "sctid": "78667006",
+    "preferred_name": "Dysthymia"
+  },
+  {
+    "sctid": "78689005",
+    "preferred_name": "Chronic brain syndrome"
+  },
+  {
+    "sctid": "78693004",
+    "preferred_name": "Congenital hypoplasia of part of brain"
+  },
+  {
+    "sctid": "787093004",
+    "preferred_name": "Developmental delay, facial dysmorphism syndrome due to MED13L deficiency"
+  },
+  {
+    "sctid": "787171006",
+    "preferred_name": "21q22.11q22.12 microdeletion syndrome"
+  },
+  {
+    "sctid": "787174003",
+    "preferred_name": "Intellectual disability, hyperkinetic movement, truncal ataxia syndrome"
+  },
+  {
+    "sctid": "787175002",
+    "preferred_name": "ANK3-related intellectual disability, sleep disturbance syndrome"
+  },
+  {
+    "sctid": "787177005",
+    "preferred_name": "Inflammatory disorder of visual pathway"
+  },
+  {
+    "sctid": "78784005",
+    "preferred_name": "Amyelia"
+  },
+  {
+    "sctid": "788120007",
+    "preferred_name": "Antenatal depression"
+  },
+  {
+    "sctid": "788417006",
+    "preferred_name": "Alopecia, epilepsy, intellectual disability syndrome Moynahan type"
+  },
+  {
+    "sctid": "788584007",
+    "preferred_name": "Blepharophimosis and mental retardation syndrome"
+  },
+  {
+    "sctid": "788756004",
+    "preferred_name": "Spindle cell oncocytoma of posterior pituitary gland"
+  },
+  {
+    "sctid": "788757008",
+    "preferred_name": "Pituicytoma of posterior pituitary gland"
+  },
+  {
+    "sctid": "788758003",
+    "preferred_name": "Sellar ependymoma of posterior pituitary gland"
+  },
+  {
+    "sctid": "78879009",
+    "preferred_name": "Intracranial hemorrhage following injury with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "788863007",
+    "preferred_name": "Amnestic disorder caused by psychoactive substance"
+  },
+  {
+    "sctid": "788864001",
+    "preferred_name": "Amnestic disorder caused by volatile solvent"
+  },
+  {
+    "sctid": "788880006",
+    "preferred_name": "Cerebral ischemic stroke due to dissection of artery"
+  },
+  {
+    "sctid": "788881005",
+    "preferred_name": "Cerebral ischemic stroke due to aortic arch embolism"
+  },
+  {
+    "sctid": "788882003",
+    "preferred_name": "Cerebral ischemic stroke due to global hypoperfusion with watershed infarct"
+  },
+  {
+    "sctid": "788883008",
+    "preferred_name": "Cerebral ischemic stroke due to hypercoagulable state"
+  },
+  {
+    "sctid": "788884002",
+    "preferred_name": "Cerebral ischemic stroke due to subarachnoid hemorrhage"
+  },
+  {
+    "sctid": "788898005",
+    "preferred_name": "Dementia caused by volatile inhalant"
+  },
+  {
+    "sctid": "788899002",
+    "preferred_name": "Dementia due to pellagra"
+  },
+  {
+    "sctid": "788904003",
+    "preferred_name": "Disorder caused by dissociative drug"
+  },
+  {
+    "sctid": "788905002",
+    "preferred_name": "Disorder caused by stimulant"
+  },
+  {
+    "sctid": "788907005",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with chorea"
+  },
+  {
+    "sctid": "788908000",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with dystonia"
+  },
+  {
+    "sctid": "788909008",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with facial spasm"
+  },
+  {
+    "sctid": "788910003",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with myoclonus"
+  },
+  {
+    "sctid": "788911004",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with Parkinsonism"
+  },
+  {
+    "sctid": "788912006",
+    "preferred_name": "Dissociative neurological symptom disorder co-occurrent with tremor"
+  },
+  {
+    "sctid": "788915008",
+    "preferred_name": "Henipavirus encephalitis"
+  },
+  {
+    "sctid": "788916009",
+    "preferred_name": "Ammonia encephalopathy"
+  },
+  {
+    "sctid": "788930004",
+    "preferred_name": "Focal brain contusion"
+  },
+  {
+    "sctid": "788931000",
+    "preferred_name": "Focal contusion of occipital lobe"
+  },
+  {
+    "sctid": "788932007",
+    "preferred_name": "Focal contusion of parietal lobe"
+  },
+  {
+    "sctid": "788933002",
+    "preferred_name": "Focal contusion of temporal lobe"
+  },
+  {
+    "sctid": "788934008",
+    "preferred_name": "Focal brain laceration"
+  },
+  {
+    "sctid": "788955005",
+    "preferred_name": "Impulse control disorder caused by cocaine"
+  },
+  {
+    "sctid": "788956006",
+    "preferred_name": "Impulse control disorder caused by psychoactive substance"
+  },
+  {
+    "sctid": "788957002",
+    "preferred_name": "Impulse control disorder caused by stimulant"
+  },
+  {
+    "sctid": "788958007",
+    "preferred_name": "Impulse control disorder caused by synthetic cathinone"
+  },
+  {
+    "sctid": "788969005",
+    "preferred_name": "Intracranial hypotension due to lumbar puncture"
+  },
+  {
+    "sctid": "788980005",
+    "preferred_name": "Trypanosoma brucei gambiense meningitis"
+  },
+  {
+    "sctid": "788981009",
+    "preferred_name": "Trypanosoma brucei rhodesiense meningitis"
+  },
+  {
+    "sctid": "788983007",
+    "preferred_name": "Mood disorder caused by cannabis"
+  },
+  {
+    "sctid": "789053008",
+    "preferred_name": "Transient motor tic"
+  },
+  {
+    "sctid": "789061003",
+    "preferred_name": "Rapid cycling bipolar II disorder"
+  },
+  {
+    "sctid": "789063000",
+    "preferred_name": "Primary hyperaldosteronism, seizures, neurological abnormalities syndrome"
+  },
+  {
+    "sctid": "789119007",
+    "preferred_name": "Synthetic cannabinoid induced mood disorder"
+  },
+  {
+    "sctid": "78914008",
+    "preferred_name": "Laceration of brain"
+  },
+  {
+    "sctid": "789170003",
+    "preferred_name": "Disinhibited behavior due to dementia"
+  },
+  {
+    "sctid": "789187001",
+    "preferred_name": "X-linked acrogigantism due to Xq26 microduplication"
+  },
+  {
+    "sctid": "789399002",
+    "preferred_name": "Persistent adjustment disorder"
+  },
+  {
+    "sctid": "789657008",
+    "preferred_name": "ATPase cation transporting 13A2 related juvenile neuronal ceroid lipofuscinosis"
+  },
+  {
+    "sctid": "789674008",
+    "preferred_name": "SPOAN and SPOAN-related disorder"
+  },
+  {
+    "sctid": "78968003",
+    "preferred_name": "Brain stem contusion with open intracranial wound"
+  },
+  {
+    "sctid": "791000124107",
+    "preferred_name": "2-methyl-3-hydroxybutyric aciduria"
+  },
+  {
+    "sctid": "792004",
+    "preferred_name": "Creutzfeldt-Jakob disease"
+  },
+  {
+    "sctid": "79204003",
+    "preferred_name": "Chronic undifferentiated schizophrenia with acute exacerbations"
+  },
+  {
+    "sctid": "79220008",
+    "preferred_name": "Brain stem contusion without open intracranial wound AND with concussion"
+  },
+  {
+    "sctid": "79267007",
+    "preferred_name": "Retinal migraine"
+  },
+  {
+    "sctid": "79298009",
+    "preferred_name": "Mild major depression, single episode"
+  },
+  {
+    "sctid": "79341000119107",
+    "preferred_name": "Mixed dementia"
+  },
+  {
+    "sctid": "79348005",
+    "preferred_name": "Simple partial seizure, consciousness not impaired"
+  },
+  {
+    "sctid": "79385002",
+    "preferred_name": "Lowe syndrome"
+  },
+  {
+    "sctid": "79459002",
+    "preferred_name": "Cheshire cat syndrome"
+  },
+  {
+    "sctid": "79524000",
+    "preferred_name": "Ecouteurism"
+  },
+  {
+    "sctid": "79584002",
+    "preferred_name": "Moderate bipolar disorder"
+  },
+  {
+    "sctid": "79591004",
+    "preferred_name": "Spastic paralysis due to spinal birth injury"
+  },
+  {
+    "sctid": "79631006",
+    "preferred_name": "Absence seizure"
+  },
+  {
+    "sctid": "79633009",
+    "preferred_name": "Spastic hemiplegia"
+  },
+  {
+    "sctid": "79745005",
+    "preferred_name": "Reflex epilepsy"
+  },
+  {
+    "sctid": "79801002",
+    "preferred_name": "Congenital leptomeningeal angiomatosis"
+  },
+  {
+    "sctid": "79842004",
+    "preferred_name": "Stuporous depression"
+  },
+  {
+    "sctid": "79866005",
+    "preferred_name": "Subchronic paranoid schizophrenia"
+  },
+  {
+    "sctid": "79897009",
+    "preferred_name": "Cerebellar abscess"
+  },
+  {
+    "sctid": "7990002",
+    "preferred_name": "Immunoglobulinemia with isolated somatotropin deficiency"
+  },
+  {
+    "sctid": "80098002",
+    "preferred_name": "Diffuse Lewy body disease"
+  },
+  {
+    "sctid": "80180004",
+    "preferred_name": "Pallidonigral degeneration"
+  },
+  {
+    "sctid": "80328002",
+    "preferred_name": "Progressive cone-rod dystrophy"
+  },
+  {
+    "sctid": "80381005",
+    "preferred_name": "Adductor spastic dysphonia of dystonia"
+  },
+  {
+    "sctid": "80495009",
+    "preferred_name": "Sleep walking disorder"
+  },
+  {
+    "sctid": "80499003",
+    "preferred_name": "Traumatic injury of visual pathways"
+  },
+  {
+    "sctid": "80544005",
+    "preferred_name": "Spongy degeneration of central nervous system"
+  },
+  {
+    "sctid": "80599001",
+    "preferred_name": "Isolated corticotropin deficiency"
+  },
+  {
+    "sctid": "806161651000119106",
+    "preferred_name": "Cerebrovascular accident due to embolism of right vertebral artery"
+  },
+  {
+    "sctid": "80651009",
+    "preferred_name": "Aicardi's syndrome"
+  },
+  {
+    "sctid": "80690008",
+    "preferred_name": "Degenerative disease of the central nervous system"
+  },
+  {
+    "sctid": "80711002",
+    "preferred_name": "Narcissistic personality disorder"
+  },
+  {
+    "sctid": "80734006",
+    "preferred_name": "Marinesco-Sj\u00f6gren syndrome"
+  },
+  {
+    "sctid": "80758005",
+    "preferred_name": "Embolism of lateral venous sinus"
+  },
+  {
+    "sctid": "80849007",
+    "preferred_name": "Gigantism"
+  },
+  {
+    "sctid": "80868005",
+    "preferred_name": "Cocaine withdrawal"
+  },
+  {
+    "sctid": "80901002",
+    "preferred_name": "Endophlebitis of torcular Herophili"
+  },
+  {
+    "sctid": "80935004",
+    "preferred_name": "Flaccid hemiplegia"
+  },
+  {
+    "sctid": "80980003",
+    "preferred_name": "Open fracture of C5-C7 level with spinal cord injury"
+  },
+  {
+    "sctid": "81042008",
+    "preferred_name": "Congenital anomaly of spinal cord"
+  },
+  {
+    "sctid": "81211007",
+    "preferred_name": "Primary lateral sclerosis"
+  },
+  {
+    "sctid": "81308009",
+    "preferred_name": "Disorder of brain"
+  },
+  {
+    "sctid": "81319007",
+    "preferred_name": "Severe bipolar II disorder, most recent episode major depressive without psychotic features"
+  },
+  {
+    "sctid": "813921000000104",
+    "preferred_name": "Spastic hemiplegic cerebral palsy"
+  },
+  {
+    "sctid": "81412002",
+    "preferred_name": "Cortex contusion with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "81442004",
+    "preferred_name": "Closed fracture of cervical region with spinal cord injury"
+  },
+  {
+    "sctid": "81463002",
+    "preferred_name": "Bestiality"
+  },
+  {
+    "sctid": "81475007",
+    "preferred_name": "Acquired nephrogenic diabetes insipidus"
+  },
+  {
+    "sctid": "816067005",
+    "preferred_name": "Woodhouse Sakati syndrome"
+  },
+  {
+    "sctid": "816068000",
+    "preferred_name": "Periventricular nodular heterotopia"
+  },
+  {
+    "sctid": "816205008",
+    "preferred_name": "Malignant pituitary blastoma"
+  },
+  {
+    "sctid": "81642009",
+    "preferred_name": "Late effect of spinal cord injury"
+  },
+  {
+    "sctid": "8166000",
+    "preferred_name": "Thrombophlebitis of basilar sinus"
+  },
+  {
+    "sctid": "81682002",
+    "preferred_name": "Functional disease of the CNS with neuroendocrine disturbance"
+  },
+  {
+    "sctid": "816984002",
+    "preferred_name": "Progressive multiple sclerosis"
+  },
+  {
+    "sctid": "81780002",
+    "preferred_name": "Beckwith-Wiedemann syndrome"
+  },
+  {
+    "sctid": "81812009",
+    "preferred_name": "Hwa-byung"
+  },
+  {
+    "sctid": "8183009",
+    "preferred_name": "Closed fracture of T7-T12 level with central cord syndrome"
+  },
+  {
+    "sctid": "8185002",
+    "preferred_name": "Panic disorder with agoraphobia AND moderate panic attacks"
+  },
+  {
+    "sctid": "81854007",
+    "preferred_name": "Alexander's disease"
+  },
+  {
+    "sctid": "818967003",
+    "preferred_name": "Medulloepithelioma of central nervous system"
+  },
+  {
+    "sctid": "81903006",
+    "preferred_name": "Inhibited male orgasm"
+  },
+  {
+    "sctid": "81981006",
+    "preferred_name": "Benign multirecurrent endothelioleukocytal meningitis"
+  },
+  {
+    "sctid": "82058009",
+    "preferred_name": "Myelocele"
+  },
+  {
+    "sctid": "82108004",
+    "preferred_name": "Nutritional optic neuropathy"
+  },
+  {
+    "sctid": "8217007",
+    "preferred_name": "Arachnoiditis"
+  },
+  {
+    "sctid": "822021000000103",
+    "preferred_name": "Acute encephalitis"
+  },
+  {
+    "sctid": "822031000000101",
+    "preferred_name": "Acute meningitis"
+  },
+  {
+    "sctid": "822041000000105",
+    "preferred_name": "Acute viral meningitis"
+  },
+  {
+    "sctid": "82218004",
+    "preferred_name": "Postoperative depression"
+  },
+  {
+    "sctid": "82339009",
+    "preferred_name": "Amphetamine-induced anxiety disorder"
+  },
+  {
+    "sctid": "82344002",
+    "preferred_name": "Cerebellar contusion with open intracranial wound"
+  },
+  {
+    "sctid": "82346000",
+    "preferred_name": "Acquired obstructive hydrocephalus"
+  },
+  {
+    "sctid": "82351000119105",
+    "preferred_name": "Altered behavior due to Pick's disease"
+  },
+  {
+    "sctid": "82361000119107",
+    "preferred_name": "Altered behavior in Huntington's dementia"
+  },
+  {
+    "sctid": "82371000119101",
+    "preferred_name": "Dementia due to multiple sclerosis with altered behavior"
+  },
+  {
+    "sctid": "82381000119103",
+    "preferred_name": "Epileptic dementia with behavioral disturbance"
+  },
+  {
+    "sctid": "82401000",
+    "preferred_name": "Simple partial seizure with motor dysfunction"
+  },
+  {
+    "sctid": "82415003",
+    "preferred_name": "Agoraphobia without history of panic disorder without limited symptom attacks"
+  },
+  {
+    "sctid": "82494000",
+    "preferred_name": "Panic disorder without agoraphobia with panic attacks in full remission"
+  },
+  {
+    "sctid": "82501000119102",
+    "preferred_name": "Anaplastic astrocytoma of central nervous system"
+  },
+  {
+    "sctid": "82547005",
+    "preferred_name": "Acute adenoviral meningoencephalitis"
+  },
+  {
+    "sctid": "82598004",
+    "preferred_name": "Secondary hypothyroidism"
+  },
+  {
+    "sctid": "82636008",
+    "preferred_name": "Orgasm disorder"
+  },
+  {
+    "sctid": "827172005",
+    "preferred_name": "X-linked progressive cerebellar ataxia"
+  },
+  {
+    "sctid": "82738004",
+    "preferred_name": "Panic disorder with agoraphobia, moderate agoraphobic avoidance AND moderate panic attacks"
+  },
+  {
+    "sctid": "82793005",
+    "preferred_name": "Hypothalamic obesity"
+  },
+  {
+    "sctid": "82800008",
+    "preferred_name": "Dipsogenic diabetes insipidus"
+  },
+  {
+    "sctid": "8291000119107",
+    "preferred_name": "Atonic epilepsy"
+  },
+  {
+    "sctid": "82959004",
+    "preferred_name": "Dementia paralytica juvenilis"
+  },
+  {
+    "sctid": "82998009",
+    "preferred_name": "Moderate manic bipolar I disorder"
+  },
+  {
+    "sctid": "82999001",
+    "preferred_name": "Epidural hemorrhage"
+  },
+  {
+    "sctid": "830015009",
+    "preferred_name": "Dermoid cyst of spinal cord"
+  },
+  {
+    "sctid": "830032008",
+    "preferred_name": "Dermoid cyst of occipital lobe"
+  },
+  {
+    "sctid": "830033003",
+    "preferred_name": "Dermoid cyst of brain"
+  },
+  {
+    "sctid": "8301004",
+    "preferred_name": "Caudal regression syndrome"
+  },
+  {
+    "sctid": "830275007",
+    "preferred_name": "Inadvertent dural tap"
+  },
+  {
+    "sctid": "83090005",
+    "preferred_name": "Dural ossification"
+  },
+  {
+    "sctid": "83157008",
+    "preferred_name": "Fatal familial insomnia"
+  },
+  {
+    "sctid": "83159006",
+    "preferred_name": "Cytomegalovirus encephalitis"
+  },
+  {
+    "sctid": "83168008",
+    "preferred_name": "Psychoactive substance-induced organic amnestic disorder"
+  },
+  {
+    "sctid": "83176005",
+    "preferred_name": "Primary dysthymia"
+  },
+  {
+    "sctid": "832007",
+    "preferred_name": "Moderate major depression"
+  },
+  {
+    "sctid": "83225003",
+    "preferred_name": "Bipolar II disorder"
+  },
+  {
+    "sctid": "83231000119101",
+    "preferred_name": "Optic nerve and photoreceptor degeneration"
+  },
+  {
+    "sctid": "83233002",
+    "preferred_name": "Ghost sickness"
+  },
+  {
+    "sctid": "83253003",
+    "preferred_name": "Shyness disorder of childhood"
+  },
+  {
+    "sctid": "833326008",
+    "preferred_name": "Cortical vascular dementia"
+  },
+  {
+    "sctid": "83351003",
+    "preferred_name": "Basilar migraine"
+  },
+  {
+    "sctid": "83367009",
+    "preferred_name": "Amphetamine-induced organic mental disorder"
+  },
+  {
+    "sctid": "83458005",
+    "preferred_name": "Agitated depression"
+  },
+  {
+    "sctid": "83465002",
+    "preferred_name": "Neuroleptic-induced acute dystonia"
+  },
+  {
+    "sctid": "83482000",
+    "preferred_name": "Body dysmorphic disorder"
+  },
+  {
+    "sctid": "83501007",
+    "preferred_name": "Organic mood disorder of mixed type"
+  },
+  {
+    "sctid": "83605009",
+    "preferred_name": "Anismus"
+  },
+  {
+    "sctid": "836301008",
+    "preferred_name": "Amnestic mild cognitive disorder"
+  },
+  {
+    "sctid": "83631006",
+    "preferred_name": "Panic disorder with agoraphobia, moderate agoraphobic avoidance AND severe panic attacks"
+  },
+  {
+    "sctid": "83716008",
+    "preferred_name": "Traumatic spinal cord compression"
+  },
+  {
+    "sctid": "83746006",
+    "preferred_name": "Chronic schizophrenia"
+  },
+  {
+    "sctid": "83759003",
+    "preferred_name": "Adductor spastic dysphonia of musculoskeletal tension reaction"
+  },
+  {
+    "sctid": "838276009",
+    "preferred_name": "Amyotrophic lateral sclerosis, parkinsonism, dementia complex"
+  },
+  {
+    "sctid": "838304009",
+    "preferred_name": "Benign ependymoma of central nervous system"
+  },
+  {
+    "sctid": "838307002",
+    "preferred_name": "Childhood-onset autosomal dominant optic atrophy"
+  },
+  {
+    "sctid": "838315004",
+    "preferred_name": "Encephalomyelitis caused by Burkholderia"
+  },
+  {
+    "sctid": "838324008",
+    "preferred_name": "Autoimmune optic neuropathy"
+  },
+  {
+    "sctid": "838332000",
+    "preferred_name": "Abscess of brainstem"
+  },
+  {
+    "sctid": "838339009",
+    "preferred_name": "Basal encephalocele"
+  },
+  {
+    "sctid": "838345001",
+    "preferred_name": "Autosomal recessive optic atrophy type 6"
+  },
+  {
+    "sctid": "838350007",
+    "preferred_name": "Adenoma of neuroepithelium of iris"
+  },
+  {
+    "sctid": "838351006",
+    "preferred_name": "Acute seizure due to infection of central nervous system"
+  },
+  {
+    "sctid": "838363001",
+    "preferred_name": "Arteritic anterior ischemic optic neuropathy due to giant cell arteritis"
+  },
+  {
+    "sctid": "838371002",
+    "preferred_name": "Abscess of cerebral hemisphere lobe"
+  },
+  {
+    "sctid": "838373004",
+    "preferred_name": "Abscess of frontal lobe"
+  },
+  {
+    "sctid": "838384006",
+    "preferred_name": "Abscess of subdural space of spinal cord caused by fungus"
+  },
+  {
+    "sctid": "838387004",
+    "preferred_name": "Abscess of spinal subdural space caused by Mycobacterium"
+  },
+  {
+    "sctid": "838388009",
+    "preferred_name": "Abscess of spinal epidural space caused by Mycobacterium"
+  },
+  {
+    "sctid": "838389001",
+    "preferred_name": "Abscess of spinal subdural space caused by bacterium"
+  },
+  {
+    "sctid": "838390005",
+    "preferred_name": "Abscess of spinal cord caused by fungus"
+  },
+  {
+    "sctid": "838391009",
+    "preferred_name": "Abscess of spinal epidural space caused by bacterium"
+  },
+  {
+    "sctid": "838392002",
+    "preferred_name": "Abscess of parietal lobe"
+  },
+  {
+    "sctid": "838393007",
+    "preferred_name": "Abscess of pons cerebri"
+  },
+  {
+    "sctid": "838394001",
+    "preferred_name": "Abscess of midbrain"
+  },
+  {
+    "sctid": "838395000",
+    "preferred_name": "Abscess of occipital lobe"
+  },
+  {
+    "sctid": "838441009",
+    "preferred_name": "MASA syndrome"
+  },
+  {
+    "sctid": "838528007",
+    "preferred_name": "Mood disorder with manic symptoms caused by amphetamine and amphetamine derivative"
+  },
+  {
+    "sctid": "838529004",
+    "preferred_name": "Mood disorder with mixed depressive and manic symptoms caused by amphetamine and amphetamine derivative"
+  },
+  {
+    "sctid": "838530009",
+    "preferred_name": "Mood disorder with depressive symptoms caused by amphetamine and amphetamine derivative"
+  },
+  {
+    "sctid": "83890006",
+    "preferred_name": "Cluster C personality disorder"
+  },
+  {
+    "sctid": "83942000",
+    "preferred_name": "Acute disseminated encephalomyelitis"
+  },
+  {
+    "sctid": "83982007",
+    "preferred_name": "Subacute necrotic myelopathy"
+  },
+  {
+    "sctid": "83991006",
+    "preferred_name": "Incomplete spinal cord lesion at C5-C7 level without bone injury"
+  },
+  {
+    "sctid": "84002002",
+    "preferred_name": "Pedophilia"
+  },
+  {
+    "sctid": "840432000",
+    "preferred_name": "Infection of central nervous system caused by Paracoccidioides brasiliensis"
+  },
+  {
+    "sctid": "840440006",
+    "preferred_name": "Encephalitis caused by Leptospira species"
+  },
+  {
+    "sctid": "840442003",
+    "preferred_name": "Encephalitis caused by human immunodeficiency virus type 2"
+  },
+  {
+    "sctid": "840447009",
+    "preferred_name": "Cyst of spinal subdural space caused by parasite"
+  },
+  {
+    "sctid": "840449007",
+    "preferred_name": "Cognitive impairment caused by ingestible alcohol"
+  },
+  {
+    "sctid": "840452004",
+    "preferred_name": "Classical sporadic Creutzfeldt-Jakob disease"
+  },
+  {
+    "sctid": "840454003",
+    "preferred_name": "Cyst of spinal cord caused by parasite"
+  },
+  {
+    "sctid": "840464007",
+    "preferred_name": "Dementia due to carbon monoxide poisoning"
+  },
+  {
+    "sctid": "840465008",
+    "preferred_name": "Dementia due to iron deficiency"
+  },
+  {
+    "sctid": "840471002",
+    "preferred_name": "Hydrocephalus due to Dandy-Walker malformation"
+  },
+  {
+    "sctid": "840496004",
+    "preferred_name": "Encephalitis caused by Borrelia species"
+  },
+  {
+    "sctid": "840498003",
+    "preferred_name": "Encephalitis caused by human immunodeficiency virus type 1"
+  },
+  {
+    "sctid": "840501003",
+    "preferred_name": "Dystonia caused by toxin"
+  },
+  {
+    "sctid": "840511005",
+    "preferred_name": "Compression of spinal cord due to intraspinal abscess"
+  },
+  {
+    "sctid": "840721004",
+    "preferred_name": "Incomplete spinal cord syndrome"
+  },
+  {
+    "sctid": "84160009",
+    "preferred_name": "Laryngeal hemiplegia"
+  },
+  {
+    "sctid": "84161000119100",
+    "preferred_name": "Complex partial seizure of parietal lobe"
+  },
+  {
+    "sctid": "84170006",
+    "preferred_name": "Contusion of brain with open intracranial wound"
+  },
+  {
+    "sctid": "84171000119106",
+    "preferred_name": "Complex partial seizure of frontal lobe"
+  },
+  {
+    "sctid": "84181000119109",
+    "preferred_name": "Complex partial seizure of occipital lobe"
+  },
+  {
+    "sctid": "84191000119107",
+    "preferred_name": "Complex partial seizure of temporal lobe"
+  },
+  {
+    "sctid": "84201000119105",
+    "preferred_name": "Intractable partial temporal lobe epilepsy with impairment of consciousness"
+  },
+  {
+    "sctid": "84209002",
+    "preferred_name": "Psychogenic amnesia"
+  },
+  {
+    "sctid": "84211000119108",
+    "preferred_name": "Intractable complex partial parietal lobe epilepsy"
+  },
+  {
+    "sctid": "84221000119101",
+    "preferred_name": "Intractable partial frontal lobe epilepsy with impairment of consciousness"
+  },
+  {
+    "sctid": "84231000119103",
+    "preferred_name": "Intractable partial occipital lobe epilepsy with impairment of consciousness"
+  },
+  {
+    "sctid": "843004",
+    "preferred_name": "Poliomyelomalacia"
+  },
+  {
+    "sctid": "84306007",
+    "preferred_name": "Chronic adhesive pachymeningitis"
+  },
+  {
+    "sctid": "84438001",
+    "preferred_name": "Pure autonomic failure"
+  },
+  {
+    "sctid": "84461004",
+    "preferred_name": "Exencephaly"
+  },
+  {
+    "sctid": "84466009",
+    "preferred_name": "Dependent personality disorder"
+  },
+  {
+    "sctid": "8459005",
+    "preferred_name": "Closed fracture of C1-C4 level with incomplete cord lesion"
+  },
+  {
+    "sctid": "846680003",
+    "preferred_name": "Functional hypogonadotropic hypogonadism"
+  },
+  {
+    "sctid": "84757009",
+    "preferred_name": "Epilepsy"
+  },
+  {
+    "sctid": "84760002",
+    "preferred_name": "Schizoaffective disorder, depressive type"
+  },
+  {
+    "sctid": "84788008",
+    "preferred_name": "Menopausal depression"
+  },
+  {
+    "sctid": "84873005",
+    "preferred_name": "Dural arteriovenous malformation"
+  },
+  {
+    "sctid": "84900008",
+    "preferred_name": "Cerebellar laceration with open intracranial wound AND loss of consciousness"
+  },
+  {
+    "sctid": "84937002",
+    "preferred_name": "Cerebral hyponatremia"
+  },
+  {
+    "sctid": "849488701000119104",
+    "preferred_name": "Cerebrovascular accident due to embolism of right anterior cerebral artery"
+  },
+  {
+    "sctid": "849579281000119106",
+    "preferred_name": "Cerebrovascular accident due to occlusion of right posterior communicating artery"
+  },
+  {
+    "sctid": "84984002",
+    "preferred_name": "Adjustment disorder with disturbance of conduct"
+  },
+  {
+    "sctid": "85039006",
+    "preferred_name": "Postpartum amenorrhea-galactorrhea syndrome"
+  },
+  {
+    "sctid": "85061001",
+    "preferred_name": "Separation anxiety disorder of childhood, early onset"
+  },
+  {
+    "sctid": "85080004",
+    "preferred_name": "Secondary dysthymia"
+  },
+  {
+    "sctid": "85102008",
+    "preferred_name": "Cerebellar ataxia"
+  },
+  {
+    "sctid": "8511007",
+    "preferred_name": "Transient tic disorder, single episode"
+  },
+  {
+    "sctid": "851365731000119106",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of left posterior cerebral artery"
+  },
+  {
+    "sctid": "8522006",
+    "preferred_name": "Klismaphilia"
+  },
+  {
+    "sctid": "85248005",
+    "preferred_name": "Bipolar disorder in remission"
+  },
+  {
+    "sctid": "85262003",
+    "preferred_name": "Open fracture of T1-T6 level with posterior cord syndrome"
+  },
+  {
+    "sctid": "8528005",
+    "preferred_name": "Acute ascending myelitis"
+  },
+  {
+    "sctid": "85402004",
+    "preferred_name": "Meningoeruptive syndrome"
+  },
+  {
+    "sctid": "8551000119100",
+    "preferred_name": "Benign neoplasm of spinal intradural extramedullary space"
+  },
+  {
+    "sctid": "85561006",
+    "preferred_name": "Uncomplicated alcohol withdrawal"
+  },
+  {
+    "sctid": "85592008",
+    "preferred_name": "Primary progressive cerebellar degeneration"
+  },
+  {
+    "sctid": "85638002",
+    "preferred_name": "Cerebrospinal fluid rhinorrhea"
+  },
+  {
+    "sctid": "85641006",
+    "preferred_name": "Hemianencephaly"
+  },
+  {
+    "sctid": "85821003",
+    "preferred_name": "Acute non-psychotic brain syndrome"
+  },
+  {
+    "sctid": "85861002",
+    "preferred_name": "Subchronic undifferentiated schizophrenia"
+  },
+  {
+    "sctid": "859422751000119101",
+    "preferred_name": "Cerebrovascular accident due to embolism of left carotid artery"
+  },
+  {
+    "sctid": "86058007",
+    "preferred_name": "Severe bipolar I disorder, single manic episode with psychotic features, mood-incongruent"
+  },
+  {
+    "sctid": "86073008",
+    "preferred_name": "Hypersomatotropic gigantism"
+  },
+  {
+    "sctid": "860799000",
+    "preferred_name": "Encephalopathy due to folate deficiency"
+  },
+  {
+    "sctid": "860802009",
+    "preferred_name": "Ex-vacuo hydrocephalus due to infection"
+  },
+  {
+    "sctid": "860803004",
+    "preferred_name": "Hydrocephalus due to tuberculosis of brain"
+  },
+  {
+    "sctid": "860804005",
+    "preferred_name": "Epilepsy due to infectious encephalitis"
+  },
+  {
+    "sctid": "860805006",
+    "preferred_name": "Encephalomyelitis caused by Neisseria meningitidis"
+  },
+  {
+    "sctid": "860806007",
+    "preferred_name": "Epilepsy due to infectious meningitis"
+  },
+  {
+    "sctid": "860808008",
+    "preferred_name": "Idiopathic non-arteritic ischemic optic neuropathy"
+  },
+  {
+    "sctid": "860815000",
+    "preferred_name": "Epilepsy due to neonatal central nervous system infection"
+  },
+  {
+    "sctid": "860822008",
+    "preferred_name": "Encephalitis caused by Nocardia"
+  },
+  {
+    "sctid": "860825005",
+    "preferred_name": "Hypertrophic pachymeningitis due to disorder of immune function"
+  },
+  {
+    "sctid": "860826006",
+    "preferred_name": "Creutzfeldt-Jakob Disease caused by human growth hormone"
+  },
+  {
+    "sctid": "860834000",
+    "preferred_name": "Granuloma of brain caused by Schistosoma"
+  },
+  {
+    "sctid": "860840007",
+    "preferred_name": "Granuloma of brain caused by Schistosoma japonicum"
+  },
+  {
+    "sctid": "860841006",
+    "preferred_name": "Encephalomyelitis caused by bacterium"
+  },
+  {
+    "sctid": "860842004",
+    "preferred_name": "Encephalomyelitis caused by Coxiella burnetii"
+  },
+  {
+    "sctid": "860843009",
+    "preferred_name": "Granuloma of spinal epidural space caused by Mycobacterium"
+  },
+  {
+    "sctid": "860844003",
+    "preferred_name": "Granuloma of spinal epidural space caused by fungus"
+  },
+  {
+    "sctid": "860845002",
+    "preferred_name": "Granuloma of spinal subdural space caused by parasite"
+  },
+  {
+    "sctid": "860846001",
+    "preferred_name": "Granuloma of spinal epidural space caused by bacterium"
+  },
+  {
+    "sctid": "860847005",
+    "preferred_name": "Granuloma of spinal subdural space caused by Mycobacterium"
+  },
+  {
+    "sctid": "860849008",
+    "preferred_name": "Granuloma of spinal cord caused by fungus"
+  },
+  {
+    "sctid": "860850008",
+    "preferred_name": "Granuloma of spinal subdural space caused by bacterium"
+  },
+  {
+    "sctid": "860851007",
+    "preferred_name": "Granuloma of cerebral hemispheric lobe"
+  },
+  {
+    "sctid": "860852000",
+    "preferred_name": "Granuloma of brainstem"
+  },
+  {
+    "sctid": "860864008",
+    "preferred_name": "Granuloma of brain caused by Schistosoma haematobium"
+  },
+  {
+    "sctid": "860865009",
+    "preferred_name": "Encephalitis caused by Trypanosoma brucei gambiense"
+  },
+  {
+    "sctid": "860866005",
+    "preferred_name": "Encephalitis caused by Trypanosoma brucei rhodesiense"
+  },
+  {
+    "sctid": "860868006",
+    "preferred_name": "Encephalitis caused by Me Tri virus"
+  },
+  {
+    "sctid": "860884007",
+    "preferred_name": "Idiopathic non-arteritic posterior ischemic optic neuropathy"
+  },
+  {
+    "sctid": "860886009",
+    "preferred_name": "Granuloma of brain caused by Schistosoma mansoni"
+  },
+  {
+    "sctid": "86125000",
+    "preferred_name": "Cerebellar contusion with open intracranial wound AND concussion"
+  },
+  {
+    "sctid": "86188000",
+    "preferred_name": "Kuru"
+  },
+  {
+    "sctid": "8635005",
+    "preferred_name": "Alcohol withdrawal delirium"
+  },
+  {
+    "sctid": "864171000000103",
+    "preferred_name": "Non-epileptic attack disorder"
+  },
+  {
+    "sctid": "864471000000106",
+    "preferred_name": "Anterior opercular syndrome"
+  },
+  {
+    "sctid": "86553761000119103",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral posterior cerebral arteries"
+  },
+  {
+    "sctid": "86558004",
+    "preferred_name": "Cerebellar pressure cone"
+  },
+  {
+    "sctid": "866045007",
+    "preferred_name": "Myelitis caused by Actinomyces"
+  },
+  {
+    "sctid": "866050001",
+    "preferred_name": "Mixed germ cell neoplasm of central nervous system"
+  },
+  {
+    "sctid": "866053004",
+    "preferred_name": "Middle interhemispheric variant of holoprosencephaly"
+  },
+  {
+    "sctid": "866055006",
+    "preferred_name": "Myelitis caused by Enterovirus"
+  },
+  {
+    "sctid": "866056007",
+    "preferred_name": "Myelitis caused by Epstein-Barr virus"
+  },
+  {
+    "sctid": "866057003",
+    "preferred_name": "Myelitis caused by Dengue virus"
+  },
+  {
+    "sctid": "866058008",
+    "preferred_name": "Myelitis caused by Human echovirus"
+  },
+  {
+    "sctid": "866059000",
+    "preferred_name": "Myelitis caused by Human coxsackievirus A"
+  },
+  {
+    "sctid": "866060005",
+    "preferred_name": "Myelitis caused by Cytomegalovirus"
+  },
+  {
+    "sctid": "866061009",
+    "preferred_name": "Myelitis caused by Coccidioides"
+  },
+  {
+    "sctid": "866062002",
+    "preferred_name": "Myelitis caused by Coenurus cerebralis"
+  },
+  {
+    "sctid": "866063007",
+    "preferred_name": "Myelitis caused by Mycoplasma pneumoniae"
+  },
+  {
+    "sctid": "866064001",
+    "preferred_name": "Myelitis caused by Aspergillus"
+  },
+  {
+    "sctid": "866065000",
+    "preferred_name": "Myelitis caused by Schistosoma mansoni"
+  },
+  {
+    "sctid": "866066004",
+    "preferred_name": "Myelitis caused by Borrelia burgdorferi"
+  },
+  {
+    "sctid": "866067008",
+    "preferred_name": "Myelitis caused by Schistosoma japonicum"
+  },
+  {
+    "sctid": "866090003",
+    "preferred_name": "Meningomyelitis caused by Treponema pallidum"
+  },
+  {
+    "sctid": "866099002",
+    "preferred_name": "Leber idiopathic stellate neuroretinitis"
+  },
+  {
+    "sctid": "866104001",
+    "preferred_name": "Intracranial hypotension due to cerebrospinal fluid fistula"
+  },
+  {
+    "sctid": "866121005",
+    "preferred_name": "Myelitis caused by Schistosoma"
+  },
+  {
+    "sctid": "866123008",
+    "preferred_name": "Myelitis caused by Schistosoma haematobium"
+  },
+  {
+    "sctid": "866124002",
+    "preferred_name": "Myelitis caused by human poliovirus"
+  },
+  {
+    "sctid": "866125001",
+    "preferred_name": "Myelitis caused by Retroviridae"
+  },
+  {
+    "sctid": "866126000",
+    "preferred_name": "Myelitis caused by Influenza A virus"
+  },
+  {
+    "sctid": "866127009",
+    "preferred_name": "Myelitis caused by Plasmodium"
+  },
+  {
+    "sctid": "866128004",
+    "preferred_name": "Myelitis caused by Roseolovirus"
+  },
+  {
+    "sctid": "866129007",
+    "preferred_name": "Myelitis caused by human T-lymphotropic virus type 1"
+  },
+  {
+    "sctid": "866130002",
+    "preferred_name": "Myelitis caused by Herpes simplex type 2"
+  },
+  {
+    "sctid": "866131003",
+    "preferred_name": "Myelitis caused by Human herpes virus"
+  },
+  {
+    "sctid": "866132005",
+    "preferred_name": "Myelitis caused by Herpes simplex type 1"
+  },
+  {
+    "sctid": "866133000",
+    "preferred_name": "Infectious neuroretinitis"
+  },
+  {
+    "sctid": "866251007",
+    "preferred_name": "Myelitis caused by Human coxsackievirus B"
+  },
+  {
+    "sctid": "86765009",
+    "preferred_name": "Mild intellectual disability"
+  },
+  {
+    "sctid": "86842008",
+    "preferred_name": "Iatrogenic pituitary disorder"
+  },
+  {
+    "sctid": "870260008",
+    "preferred_name": "Pervasive developmental disorder with marked impairment of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870261007",
+    "preferred_name": "Pervasive developmental disorder with marked impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870262000",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870263005",
+    "preferred_name": "Pervasive developmental disorder with impairment of functional language"
+  },
+  {
+    "sctid": "870264004",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and pervasive impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870265003",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870266002",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and marked impairment of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870267006",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and marked impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870268001",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and complete impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870269009",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and absence of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870270005",
+    "preferred_name": "Pervasive developmental disorder with disorder of intellectual development and complete impairment of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870280009",
+    "preferred_name": "Pervasive developmental disorder with severe impairment of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870282001",
+    "preferred_name": "Pervasive developmental disorder with severe impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870283006",
+    "preferred_name": "Spinal subdural granuloma caused by fungus"
+  },
+  {
+    "sctid": "870284000",
+    "preferred_name": "Pelizaeus Merzbacher like disease due to HSPD1 mutation"
+  },
+  {
+    "sctid": "870285004",
+    "preferred_name": "Pelizaeus Merzbacher like disease due to SLC16A2 mutation"
+  },
+  {
+    "sctid": "870286003",
+    "preferred_name": "Pelizaeus Merzbacher like disease due to AIMP1 mutation"
+  },
+  {
+    "sctid": "870287007",
+    "preferred_name": "Pelizaeus Merzbacher like disease due to GJC2 mutation"
+  },
+  {
+    "sctid": "870288002",
+    "preferred_name": "Parkinsonism caused by methanol"
+  },
+  {
+    "sctid": "870290001",
+    "preferred_name": "Myelopathy due to vitamin B12 deficiency"
+  },
+  {
+    "sctid": "870291002",
+    "preferred_name": "Myelopathy due to lathyrism"
+  },
+  {
+    "sctid": "870293004",
+    "preferred_name": "Myelitis caused by Treponema pallidum"
+  },
+  {
+    "sctid": "870294005",
+    "preferred_name": "Myelitis caused by Toxoplasma gondii"
+  },
+  {
+    "sctid": "870295006",
+    "preferred_name": "Parkinsonism caused by carbon disulfide"
+  },
+  {
+    "sctid": "870303005",
+    "preferred_name": "Pervasive developmental disorder with complete impairment of functional language with loss of previously acquired skills"
+  },
+  {
+    "sctid": "870304004",
+    "preferred_name": "Pervasive developmental disorder with complete impairment of functional language without loss of previously acquired skills"
+  },
+  {
+    "sctid": "870305003",
+    "preferred_name": "Pervasive developmental disorder with cognitive developmental delay and marked impairment of functional language"
+  },
+  {
+    "sctid": "870306002",
+    "preferred_name": "Pervasive developmental disorder with complete impairment of functional language"
+  },
+  {
+    "sctid": "870307006",
+    "preferred_name": "Pervasive developmental disorder with abscence of functional language"
+  },
+  {
+    "sctid": "870308001",
+    "preferred_name": "Pervasive developmental disorder with cognitive developmental delay and complete impairment of functional language"
+  },
+  {
+    "sctid": "870314008",
+    "preferred_name": "Pachymeningitis due to secondary malignant neoplastic disease"
+  },
+  {
+    "sctid": "870317001",
+    "preferred_name": "Pachymeningitis due to inflammatory disorder"
+  },
+  {
+    "sctid": "870319003",
+    "preferred_name": "Optic atrophy due to late syphilis"
+  },
+  {
+    "sctid": "870337002",
+    "preferred_name": "Spinal epidural cyst caused by parasite"
+  },
+  {
+    "sctid": "870339004",
+    "preferred_name": "Spinal epidural granuloma caused by parasite"
+  },
+  {
+    "sctid": "870340002",
+    "preferred_name": "Granuloma of spinal cord caused by Mycobacterium"
+  },
+  {
+    "sctid": "870341003",
+    "preferred_name": "Granuloma of spinal cord caused by parasite"
+  },
+  {
+    "sctid": "870342005",
+    "preferred_name": "Spinal cord compression due to granulomatous disorder"
+  },
+  {
+    "sctid": "870343000",
+    "preferred_name": "Granuloma of spinal cord caused by bacterium"
+  },
+  {
+    "sctid": "870345007",
+    "preferred_name": "Compression of spinal cord due to cavernous hemangioma"
+  },
+  {
+    "sctid": "870347004",
+    "preferred_name": "Retrobulbar neuritis due to late syphilis"
+  },
+  {
+    "sctid": "870364001",
+    "preferred_name": "Traumatic anterior cord syndrome"
+  },
+  {
+    "sctid": "87043009",
+    "preferred_name": "Cerebral anoxia after obstetrical surgery AND/OR other procedure including delivery"
+  },
+  {
+    "sctid": "870540001",
+    "preferred_name": "Contusion of hindbrain"
+  },
+  {
+    "sctid": "870548008",
+    "preferred_name": "Closed fracture of skull with cerebral laceration"
+  },
+  {
+    "sctid": "870549000",
+    "preferred_name": "Closed fracture of skull with cerebral contusion"
+  },
+  {
+    "sctid": "870550000",
+    "preferred_name": "Closed fracture of base of skull with cerebral laceration"
+  },
+  {
+    "sctid": "870551001",
+    "preferred_name": "Closed fracture of base of skull with cerebral contusion"
+  },
+  {
+    "sctid": "870553003",
+    "preferred_name": "Open fracture of vault of skull with cerebral laceration"
+  },
+  {
+    "sctid": "870554009",
+    "preferred_name": "Open fracture of vault of skull with cerebral contusion"
+  },
+  {
+    "sctid": "870555005",
+    "preferred_name": "Open fracture of skull with cerebral contusion"
+  },
+  {
+    "sctid": "870556006",
+    "preferred_name": "Open fracture of skull with cerebral laceration"
+  },
+  {
+    "sctid": "870563006",
+    "preferred_name": "Contusion of cerebrum with open intracranial wound"
+  },
+  {
+    "sctid": "870565004",
+    "preferred_name": "Contusion of hindbrain with open intracranial wound"
+  },
+  {
+    "sctid": "870568002",
+    "preferred_name": "Orthorexia nervosa"
+  },
+  {
+    "sctid": "87091000119101",
+    "preferred_name": "Malignant glioma of cerebrum"
+  },
+  {
+    "sctid": "87095001",
+    "preferred_name": "Olfactory seizure"
+  },
+  {
+    "sctid": "87101000119106",
+    "preferred_name": "Primary malignant glioma of brain"
+  },
+  {
+    "sctid": "87111000119109",
+    "preferred_name": "Malignant glioma of hypothalamus"
+  },
+  {
+    "sctid": "87121000119102",
+    "preferred_name": "Malignant glioma of cerebellum"
+  },
+  {
+    "sctid": "87131000119104",
+    "preferred_name": "Primary extramedullary malignant tumor of spinal cord"
+  },
+  {
+    "sctid": "87132004",
+    "preferred_name": "Opioid withdrawal"
+  },
+  {
+    "sctid": "87141000119108",
+    "preferred_name": "Primary malignant neoplasm of intramedullary spinal cord"
+  },
+  {
+    "sctid": "87151000119105",
+    "preferred_name": "Malignant glioma of central nervous system"
+  },
+  {
+    "sctid": "87161000119107",
+    "preferred_name": "Benign ependymoma of brain"
+  },
+  {
+    "sctid": "87194000",
+    "preferred_name": "Nerve fiber bundle defect"
+  },
+  {
+    "sctid": "87203005",
+    "preferred_name": "Bipolar I disorder, most recent episode depressed with postpartum onset"
+  },
+  {
+    "sctid": "87227007",
+    "preferred_name": "Cerebral depression in newborn"
+  },
+  {
+    "sctid": "87235005",
+    "preferred_name": "Dialysis disequilibrium syndrome"
+  },
+  {
+    "sctid": "87414006",
+    "preferred_name": "Reactive depression (situational)"
+  },
+  {
+    "sctid": "87476004",
+    "preferred_name": "Convulsions in the newborn"
+  },
+  {
+    "sctid": "874937002",
+    "preferred_name": "Cerebral cortex laceration with concussion"
+  },
+  {
+    "sctid": "874938007",
+    "preferred_name": "Subdural hemorrhage with open intracranial wound"
+  },
+  {
+    "sctid": "874939004",
+    "preferred_name": "Cerebellar laceration with concussion"
+  },
+  {
+    "sctid": "874940002",
+    "preferred_name": "Brain stem laceration with concussion"
+  },
+  {
+    "sctid": "874943000",
+    "preferred_name": "Brain stem laceration with loss of consciousness"
+  },
+  {
+    "sctid": "87512008",
+    "preferred_name": "Mild major depression"
+  },
+  {
+    "sctid": "87536007",
+    "preferred_name": "Central nervous system complication"
+  },
+  {
+    "sctid": "87555007",
+    "preferred_name": "Claude's syndrome"
+  },
+  {
+    "sctid": "87607002",
+    "preferred_name": "Pelizaeus-Merzbacher disease, classic form"
+  },
+  {
+    "sctid": "87764000",
+    "preferred_name": "Foster-Kennedy syndrome"
+  },
+  {
+    "sctid": "87798009",
+    "preferred_name": "Panic disorder with agoraphobia, agoraphobic avoidance in full remission AND moderate panic attacks"
+  },
+  {
+    "sctid": "87810006",
+    "preferred_name": "Megaloblastic anemia due to alcoholism"
+  },
+  {
+    "sctid": "87842000",
+    "preferred_name": "Generalized neuromuscular exhaustion syndrome"
+  },
+  {
+    "sctid": "878808006",
+    "preferred_name": "Nongerminomatous germ cell tumor of central nervous system"
+  },
+  {
+    "sctid": "87888006",
+    "preferred_name": "Cortex contusion with open intracranial wound"
+  },
+  {
+    "sctid": "87937009",
+    "preferred_name": "Endophlebitis of intracranial venous sinus"
+  },
+  {
+    "sctid": "87950005",
+    "preferred_name": "Bipolar I disorder, single manic episode with catatonic features"
+  },
+  {
+    "sctid": "87991007",
+    "preferred_name": "Gender identity disorder"
+  },
+  {
+    "sctid": "879919001",
+    "preferred_name": "Bilateral megalencephaly"
+  },
+  {
+    "sctid": "879939002",
+    "preferred_name": "14q32 deletion syndrome"
+  },
+  {
+    "sctid": "88032003",
+    "preferred_name": "Amaurosis fugax"
+  },
+  {
+    "sctid": "88125005",
+    "preferred_name": "Henoch's chorea"
+  },
+  {
+    "sctid": "881694631000119107",
+    "preferred_name": "Cerebrovascular accident of medulla oblongata"
+  },
+  {
+    "sctid": "88269008",
+    "preferred_name": "Thalamic syndrome"
+  },
+  {
+    "sctid": "8829008",
+    "preferred_name": "Isolated lutropin deficiency"
+  },
+  {
+    "sctid": "8837000",
+    "preferred_name": "Amphetamine delirium"
+  },
+  {
+    "sctid": "8840000",
+    "preferred_name": "Closed fracture of C1-C4 level with spinal cord injury"
+  },
+  {
+    "sctid": "88405003",
+    "preferred_name": "Open fracture of T7-T12 level with central cord syndrome"
+  },
+  {
+    "sctid": "88518009",
+    "preferred_name": "Wilson's disease"
+  },
+  {
+    "sctid": "885831000000109",
+    "preferred_name": "Choreoathetoid cerebral palsy"
+  },
+  {
+    "sctid": "88740003",
+    "preferred_name": "Thyrotoxicosis factitia with thyrotoxic crisis"
+  },
+  {
+    "sctid": "88755007",
+    "preferred_name": "Phlebitis of lateral venous sinus"
+  },
+  {
+    "sctid": "88845000",
+    "preferred_name": "Explosive type organic personality disorder"
+  },
+  {
+    "sctid": "88902008",
+    "preferred_name": "Hysterical blindness"
+  },
+  {
+    "sctid": "889211000000104",
+    "preferred_name": "Specific learning disability"
+  },
+  {
+    "sctid": "88939009",
+    "preferred_name": "Severe mood disorder without psychotic features"
+  },
+  {
+    "sctid": "88975006",
+    "preferred_name": "Schizophreniform disorder"
+  },
+  {
+    "sctid": "88984006",
+    "preferred_name": "Hysterical paralysis"
+  },
+  {
+    "sctid": "890118006",
+    "preferred_name": "Mowat-Wilson syndrome due to monosomy 2q22"
+  },
+  {
+    "sctid": "89016005",
+    "preferred_name": "Axis III diagnosis"
+  },
+  {
+    "sctid": "890285006",
+    "preferred_name": "Bilateral frontal polymicrogyria"
+  },
+  {
+    "sctid": "890286007",
+    "preferred_name": "Bilateral frontoparietal polymicrogyria"
+  },
+  {
+    "sctid": "890287003",
+    "preferred_name": "Bilateral generalized polymicrogyria"
+  },
+  {
+    "sctid": "890288008",
+    "preferred_name": "Bilateral parasagittal parieto-occipital polymicrogyria"
+  },
+  {
+    "sctid": "890396001",
+    "preferred_name": "Congenital pit of bilateral optic discs"
+  },
+  {
+    "sctid": "890422008",
+    "preferred_name": "Cervicothoracic spina bifida aperta with hydrocephalus"
+  },
+  {
+    "sctid": "890430009",
+    "preferred_name": "Complete agenesis of vermis"
+  },
+  {
+    "sctid": "890432001",
+    "preferred_name": "Cockayne syndrome type 3"
+  },
+  {
+    "sctid": "890433006",
+    "preferred_name": "Cockayne syndrome type 1"
+  },
+  {
+    "sctid": "890434000",
+    "preferred_name": "Cockayne syndrome type 2"
+  },
+  {
+    "sctid": "89248000",
+    "preferred_name": "Erotic zoophilia"
+  },
+  {
+    "sctid": "89261000",
+    "preferred_name": "Isolated thyrotropin deficiency"
+  },
+  {
+    "sctid": "89361000119103",
+    "preferred_name": "Mild developmental articulation disorder"
+  },
+  {
+    "sctid": "89369001",
+    "preferred_name": "Anencephalus"
+  },
+  {
+    "sctid": "89381000119107",
+    "preferred_name": "Moderate receptive language delay"
+  },
+  {
+    "sctid": "8939001",
+    "preferred_name": "Incomplete spinal cord lesion at C1-C4 level without bone injury"
+  },
+  {
+    "sctid": "89391000119105",
+    "preferred_name": "Severe receptive language delay"
+  },
+  {
+    "sctid": "89392001",
+    "preferred_name": "Prader-Willi syndrome"
+  },
+  {
+    "sctid": "894125007",
+    "preferred_name": "Cervicothoracic spina bifida aperta"
+  },
+  {
+    "sctid": "89415002",
+    "preferred_name": "Hypersomnia disorder related to another mental disorder"
+  },
+  {
+    "sctid": "89441000119109",
+    "preferred_name": "Ventriculitis of the brain"
+  },
+  {
+    "sctid": "89451009",
+    "preferred_name": "Inhalant-induced mood disorder"
+  },
+  {
+    "sctid": "89476005",
+    "preferred_name": "Pituitary cachexia"
+  },
+  {
+    "sctid": "89501000119108",
+    "preferred_name": "Mild receptive language delay"
+  },
+  {
+    "sctid": "89511000119106",
+    "preferred_name": "Subdural hygroma"
+  },
+  {
+    "sctid": "89525009",
+    "preferred_name": "Gelastic seizure"
+  },
+  {
+    "sctid": "89576007",
+    "preferred_name": "Pallidonigrospinal degeneration"
+  },
+  {
+    "sctid": "89618007",
+    "preferred_name": "Persecutory delusion disorder"
+  },
+  {
+    "sctid": "89654006",
+    "preferred_name": "Disorder of optic chiasm associated with vascular disorder"
+  },
+  {
+    "sctid": "897031002",
+    "preferred_name": "Acute flaccid myelitis"
+  },
+  {
+    "sctid": "898051000000104",
+    "preferred_name": "Speech and language developmental delay"
+  },
+  {
+    "sctid": "898941951000119108",
+    "preferred_name": "Cerebrovascular accident due to occlusion of bilateral vertebral arteries"
+  },
+  {
+    "sctid": "899001",
+    "preferred_name": "Axis I diagnosis"
+  },
+  {
+    "sctid": "89948007",
+    "preferred_name": "Panic disorder with agoraphobia AND mild panic attacks"
+  },
+  {
+    "sctid": "89989005",
+    "preferred_name": "Deferred diagnosis on Axis V"
+  },
+  {
+    "sctid": "90099008",
+    "preferred_name": "Subcortical leukoencephalopathy"
+  },
+  {
+    "sctid": "9015001",
+    "preferred_name": "Brain injury without open intracranial wound"
+  },
+  {
+    "sctid": "90162006",
+    "preferred_name": "Syringopontia"
+  },
+  {
+    "sctid": "90182005",
+    "preferred_name": "Hypophysectomy-induced hypopituitarism"
+  },
+  {
+    "sctid": "90224001",
+    "preferred_name": "Coma in the newborn"
+  },
+  {
+    "sctid": "90253000",
+    "preferred_name": "Progressive subcortical gliosis"
+  },
+  {
+    "sctid": "90302003",
+    "preferred_name": "Tuberculosis of cerebral meninges"
+  },
+  {
+    "sctid": "903741000000102",
+    "preferred_name": "Uhthoff phenomenon"
+  },
+  {
+    "sctid": "90429009",
+    "preferred_name": "Cerebellar laceration without open intracranial wound AND with loss of consciousness"
+  },
+  {
+    "sctid": "904531000000100",
+    "preferred_name": "Bilateral spastic cerebral palsy"
+  },
+  {
+    "sctid": "90584004",
+    "preferred_name": "Spinal cord injury"
+  },
+  {
+    "sctid": "90755006",
+    "preferred_name": "Nicotine withdrawal"
+  },
+  {
+    "sctid": "90768003",
+    "preferred_name": "Contusion of brain without open intracranial wound"
+  },
+  {
+    "sctid": "90790003",
+    "preferred_name": "Avoidant disorder of adolescence"
+  },
+  {
+    "sctid": "90791004",
+    "preferred_name": "Posthemiplegic ataxia"
+  },
+  {
+    "sctid": "90811000119100",
+    "preferred_name": "Low grade malignant glioma of brain"
+  },
+  {
+    "sctid": "9083002",
+    "preferred_name": "Pedophilia, opposite sex"
+  },
+  {
+    "sctid": "90831000119105",
+    "preferred_name": "Grade 4 malignant glioma of brain"
+  },
+  {
+    "sctid": "91012008",
+    "preferred_name": "Repeated concussion"
+  },
+  {
+    "sctid": "9116003",
+    "preferred_name": "Shin-byung"
+  },
+  {
+    "sctid": "91187007",
+    "preferred_name": "Pituitary dwarfism with small sella turcica"
+  },
+  {
+    "sctid": "91377003",
+    "preferred_name": "Transient hyperprolactinemia"
+  },
+  {
+    "sctid": "91483004",
+    "preferred_name": "Tuberculous encephalitis"
+  },
+  {
+    "sctid": "91502009",
+    "preferred_name": "Spinocerebellar disease"
+  },
+  {
+    "sctid": "915141931000119109",
+    "preferred_name": "Cerebrovascular accident due to embolism of basilar artery"
+  },
+  {
+    "sctid": "9167000",
+    "preferred_name": "Moderate mood disorder"
+  },
+  {
+    "sctid": "91952008",
+    "preferred_name": "Azorean disease"
+  },
+  {
+    "sctid": "91953003",
+    "preferred_name": "Azorean disease, type I"
+  },
+  {
+    "sctid": "91954009",
+    "preferred_name": "Azorean disease, type II"
+  },
+  {
+    "sctid": "91955005",
+    "preferred_name": "Azorean disease, type III"
+  },
+  {
+    "sctid": "91956006",
+    "preferred_name": "Azorean disease, type IV"
+  },
+  {
+    "sctid": "92029009",
+    "preferred_name": "Benign neoplasm of brain stem"
+  },
+  {
+    "sctid": "92030004",
+    "preferred_name": "Benign neoplasm of brain"
+  },
+  {
+    "sctid": "92048008",
+    "preferred_name": "Benign neoplasm of central nervous system"
+  },
+  {
+    "sctid": "92050000",
+    "preferred_name": "Benign neoplasm of cerebellum"
+  },
+  {
+    "sctid": "92051001",
+    "preferred_name": "Benign neoplasm of cerebral meninges"
+  },
+  {
+    "sctid": "92052008",
+    "preferred_name": "Benign neoplasm of cerebral ventricle"
+  },
+  {
+    "sctid": "92072003",
+    "preferred_name": "Benign neoplasm of craniopharyngeal duct"
+  },
+  {
+    "sctid": "92114009",
+    "preferred_name": "Benign neoplasm of frontal lobe"
+  },
+  {
+    "sctid": "92253009",
+    "preferred_name": "Benign neoplasm of occipital lobe"
+  },
+  {
+    "sctid": "92257005",
+    "preferred_name": "Benign neoplasm of optic nerve"
+  },
+  {
+    "sctid": "92276007",
+    "preferred_name": "Benign neoplasm of parietal lobe"
+  },
+  {
+    "sctid": "92294001",
+    "preferred_name": "Benign neoplasm of pineal gland"
+  },
+  {
+    "sctid": "92296004",
+    "preferred_name": "Benign neoplasm of pituitary gland"
+  },
+  {
+    "sctid": "92405007",
+    "preferred_name": "Benign neoplasm of spinal cord"
+  },
+  {
+    "sctid": "92406008",
+    "preferred_name": "Benign neoplasm of spinal meninges"
+  },
+  {
+    "sctid": "92427003",
+    "preferred_name": "Benign neoplasm of temporal lobe"
+  },
+  {
+    "sctid": "92501000119101",
+    "preferred_name": "Stress reaction with psychomotor agitation"
+  },
+  {
+    "sctid": "92573003",
+    "preferred_name": "Carcinoma in situ of craniopharyngeal duct"
+  },
+  {
+    "sctid": "92682003",
+    "preferred_name": "Carcinoma in situ of pineal gland"
+  },
+  {
+    "sctid": "92683008",
+    "preferred_name": "Carcinoma in situ of pituitary gland"
+  },
+  {
+    "sctid": "92904001",
+    "preferred_name": "Congenital abnormal shape of cerebellum"
+  },
+  {
+    "sctid": "92905000",
+    "preferred_name": "Congenital abnormal shape of cerebrum"
+  },
+  {
+    "sctid": "93249003",
+    "preferred_name": "Congenital hypoplasia of cerebrum"
+  },
+  {
+    "sctid": "9340000",
+    "preferred_name": "Bipolar I disorder, single manic episode"
+  },
+  {
+    "sctid": "9345005",
+    "preferred_name": "Dialysis dementia"
+  },
+  {
+    "sctid": "93461009",
+    "preferred_name": "Gender dysphoria"
+  },
+  {
+    "sctid": "93557001",
+    "preferred_name": "Holorachischisis"
+  },
+  {
+    "sctid": "93559003",
+    "preferred_name": "Hypogonadism with anosmia"
+  },
+  {
+    "sctid": "9366002",
+    "preferred_name": "Palatal myoclonus"
+  },
+  {
+    "sctid": "93726004",
+    "preferred_name": "Primary malignant neoplasm of brain stem"
+  },
+  {
+    "sctid": "93727008",
+    "preferred_name": "Primary malignant neoplasm of brain"
+  },
+  {
+    "sctid": "93744007",
+    "preferred_name": "Primary malignant neoplasm of central nervous system"
+  },
+  {
+    "sctid": "93746009",
+    "preferred_name": "Primary malignant neoplasm of cerebellum"
+  },
+  {
+    "sctid": "93747000",
+    "preferred_name": "Primary malignant neoplasm of cerebral meninges"
+  },
+  {
+    "sctid": "93748005",
+    "preferred_name": "Primary malignant neoplasm of cerebral ventricle"
+  },
+  {
+    "sctid": "93749002",
+    "preferred_name": "Primary malignant neoplasm of cerebrum"
+  },
+  {
+    "sctid": "93768004",
+    "preferred_name": "Primary malignant neoplasm of craniopharyngeal duct"
+  },
+  {
+    "sctid": "93807001",
+    "preferred_name": "Primary malignant neoplasm of frontal lobe"
+  },
+  {
+    "sctid": "93928006",
+    "preferred_name": "Primary malignant neoplasm of occipital lobe"
+  },
+  {
+    "sctid": "93931007",
+    "preferred_name": "Primary malignant neoplasm of optic nerve"
+  },
+  {
+    "sctid": "93946000",
+    "preferred_name": "Primary malignant neoplasm of parietal lobe"
+  },
+  {
+    "sctid": "93962006",
+    "preferred_name": "Primary malignant neoplasm of pineal gland"
+  },
+  {
+    "sctid": "93964007",
+    "preferred_name": "Primary malignant neoplasm of pituitary gland"
+  },
+  {
+    "sctid": "939885431000119109",
+    "preferred_name": "Cerebrovascular accident due to embolism of bilateral middle cerebral arteries"
+  },
+  {
+    "sctid": "94068003",
+    "preferred_name": "Primary malignant neoplasm of spinal cord"
+  },
+  {
+    "sctid": "94069006",
+    "preferred_name": "Primary malignant neoplasm of spinal meninges"
+  },
+  {
+    "sctid": "94086000",
+    "preferred_name": "Primary malignant neoplasm of temporal lobe"
+  },
+  {
+    "sctid": "94224009",
+    "preferred_name": "Secondary malignant neoplasm of brain stem"
+  },
+  {
+    "sctid": "94225005",
+    "preferred_name": "Secondary malignant neoplasm of brain"
+  },
+  {
+    "sctid": "94243009",
+    "preferred_name": "Secondary malignant neoplasm of central nervous system"
+  },
+  {
+    "sctid": "94245002",
+    "preferred_name": "Secondary malignant neoplasm of cerebellum"
+  },
+  {
+    "sctid": "94246001",
+    "preferred_name": "Secondary malignant neoplasm of cerebral meninges"
+  },
+  {
+    "sctid": "94247005",
+    "preferred_name": "Secondary malignant neoplasm of cerebral ventricle"
+  },
+  {
+    "sctid": "94248000",
+    "preferred_name": "Secondary malignant neoplasm of cerebrum"
+  },
+  {
+    "sctid": "94267001",
+    "preferred_name": "Secondary malignant neoplasm of craniopharyngeal duct"
+  },
+  {
+    "sctid": "943071000000104",
+    "preferred_name": "Opioid-induced psychosis"
+  },
+  {
+    "sctid": "943081000000102",
+    "preferred_name": "Cannabis-induced psychosis"
+  },
+  {
+    "sctid": "94309003",
+    "preferred_name": "Secondary malignant neoplasm of frontal lobe"
+  },
+  {
+    "sctid": "943091000000100",
+    "preferred_name": "Sedative-induced psychosis"
+  },
+  {
+    "sctid": "943101000000108",
+    "preferred_name": "Cocaine-induced psychosis"
+  },
+  {
+    "sctid": "943121000000104",
+    "preferred_name": "Psychoactive substance-induced psychosis"
+  },
+  {
+    "sctid": "943131000000102",
+    "preferred_name": "Hallucinogen-induced psychosis"
+  },
+  {
+    "sctid": "943151000000109",
+    "preferred_name": "Volatile inhalant-induced psychosis"
+  },
+  {
+    "sctid": "943781000000104",
+    "preferred_name": "Behavioural, emotional and social difficulties"
+  },
+  {
+    "sctid": "943801000000103",
+    "preferred_name": "Emotional behavioural difficulties"
+  },
+  {
+    "sctid": "94448002",
+    "preferred_name": "Secondary malignant neoplasm of occipital lobe"
+  },
+  {
+    "sctid": "94452002",
+    "preferred_name": "Secondary malignant neoplasm of optic nerve"
+  },
+  {
+    "sctid": "94471000",
+    "preferred_name": "Secondary malignant neoplasm of parietal lobe"
+  },
+  {
+    "sctid": "94489004",
+    "preferred_name": "Secondary malignant neoplasm of pineal gland"
+  },
+  {
+    "sctid": "94491007",
+    "preferred_name": "Secondary malignant neoplasm of pituitary gland"
+  },
+  {
+    "sctid": "94600009",
+    "preferred_name": "Secondary malignant neoplasm of spinal cord"
+  },
+  {
+    "sctid": "94601008",
+    "preferred_name": "Secondary malignant neoplasm of spinal meninges"
+  },
+  {
+    "sctid": "94622002",
+    "preferred_name": "Secondary malignant neoplasm of temporal lobe"
+  },
+  {
+    "sctid": "94631000119100",
+    "preferred_name": "Depressive disorder in mother complicating pregnancy"
+  },
+  {
+    "sctid": "94641000119109",
+    "preferred_name": "Anxiety in pregnancy"
+  },
+  {
+    "sctid": "94766006",
+    "preferred_name": "Neoplasm of uncertain behavior of brain stem"
+  },
+  {
+    "sctid": "94767002",
+    "preferred_name": "Neoplasm of uncertain behavior of brain"
+  },
+  {
+    "sctid": "94784008",
+    "preferred_name": "Neoplasm of uncertain behavior of central nervous system"
+  },
+  {
+    "sctid": "94786005",
+    "preferred_name": "Neoplasm of uncertain behavior of cerebellum"
+  },
+  {
+    "sctid": "94787001",
+    "preferred_name": "Neoplasm of uncertain behavior of cerebral meninges"
+  },
+  {
+    "sctid": "94788006",
+    "preferred_name": "Neoplasm of uncertain behavior of cerebral ventricle"
+  },
+  {
+    "sctid": "94789003",
+    "preferred_name": "Neoplasm of uncertain behavior of cerebrum"
+  },
+  {
+    "sctid": "94808000",
+    "preferred_name": "Neoplasm of uncertain behavior of craniopharyngeal duct"
+  },
+  {
+    "sctid": "94847003",
+    "preferred_name": "Neoplasm of uncertain behavior of frontal lobe"
+  },
+  {
+    "sctid": "94921000119107",
+    "preferred_name": "Episodic mood disorder"
+  },
+  {
+    "sctid": "94968001",
+    "preferred_name": "Neoplasm of uncertain behavior of occipital lobe"
+  },
+  {
+    "sctid": "94971009",
+    "preferred_name": "Neoplasm of uncertain behavior of optic nerve"
+  },
+  {
+    "sctid": "94986003",
+    "preferred_name": "Neoplasm of uncertain behavior of parietal lobe"
+  },
+  {
+    "sctid": "95002008",
+    "preferred_name": "Neoplasm of uncertain behavior of pineal gland"
+  },
+  {
+    "sctid": "95004009",
+    "preferred_name": "Neoplasm of uncertain behavior of pituitary gland"
+  },
+  {
+    "sctid": "95108005",
+    "preferred_name": "Neoplasm of uncertain behavior of spinal cord"
+  },
+  {
+    "sctid": "95109002",
+    "preferred_name": "Neoplasm of uncertain behavior of spinal meninges"
+  },
+  {
+    "sctid": "95126008",
+    "preferred_name": "Neoplasm of uncertain behavior of temporal lobe"
+  },
+  {
+    "sctid": "9520006",
+    "preferred_name": "Dissociated nystagmus"
+  },
+  {
+    "sctid": "95208000",
+    "preferred_name": "Photogenic epilepsy"
+  },
+  {
+    "sctid": "9526000",
+    "preferred_name": "Pineal gland dysfunction"
+  },
+  {
+    "sctid": "95453001",
+    "preferred_name": "Subdural hematoma"
+  },
+  {
+    "sctid": "95454007",
+    "preferred_name": "Brain stem hemorrhage"
+  },
+  {
+    "sctid": "95456009",
+    "preferred_name": "Brain stem ischemia"
+  },
+  {
+    "sctid": "95457000",
+    "preferred_name": "Brain stem infarction"
+  },
+  {
+    "sctid": "95459002",
+    "preferred_name": "Cerebellar artery thrombosis"
+  },
+  {
+    "sctid": "95460007",
+    "preferred_name": "Cerebellar infarction"
+  },
+  {
+    "sctid": "954731000000103",
+    "preferred_name": "Intellectual development disorder of unknown aetiology"
+  },
+  {
+    "sctid": "95478002",
+    "preferred_name": "Congenital sacral meningocele"
+  },
+  {
+    "sctid": "95499004",
+    "preferred_name": "Hypoplasia of the optic nerve"
+  },
+  {
+    "sctid": "95502000",
+    "preferred_name": "Congenital anomaly of optic nerve"
+  },
+  {
+    "sctid": "95569006",
+    "preferred_name": "Uremic coma"
+  },
+  {
+    "sctid": "95610008",
+    "preferred_name": "Congenital brain damage"
+  },
+  {
+    "sctid": "95628005",
+    "preferred_name": "Neonatal encephalopathy"
+  },
+  {
+    "sctid": "95631006",
+    "preferred_name": "Drowsiness of the newborn"
+  },
+  {
+    "sctid": "95633009",
+    "preferred_name": "Neonatal hypokinesia"
+  },
+  {
+    "sctid": "95635002",
+    "preferred_name": "Caffeine withdrawal"
+  },
+  {
+    "sctid": "95636001",
+    "preferred_name": "Sadomasochism"
+  },
+  {
+    "sctid": "95637005",
+    "preferred_name": "Munchausen's by proxy"
+  },
+  {
+    "sctid": "95638000",
+    "preferred_name": "Localized cranial lesion"
+  },
+  {
+    "sctid": "95640005",
+    "preferred_name": "Disorder of brain stem"
+  },
+  {
+    "sctid": "95641009",
+    "preferred_name": "Disorder of midbrain"
+  },
+  {
+    "sctid": "95643007",
+    "preferred_name": "Autoimmune encephalitis"
+  },
+  {
+    "sctid": "95644001",
+    "preferred_name": "Systemic lupus erythematosus encephalitis"
+  },
+  {
+    "sctid": "95646004",
+    "preferred_name": "Cerebellar degeneration"
+  },
+  {
+    "sctid": "95647008",
+    "preferred_name": "Upper motor neuron disease"
+  },
+  {
+    "sctid": "95650006",
+    "preferred_name": "Transient hemiplegia"
+  },
+  {
+    "sctid": "95655001",
+    "preferred_name": "Ophthalmic migraine"
+  },
+  {
+    "sctid": "95656000",
+    "preferred_name": "Familial hemiplegic migraine"
+  },
+  {
+    "sctid": "95660002",
+    "preferred_name": "Thunderclap headache"
+  },
+  {
+    "sctid": "957319791000119104",
+    "preferred_name": "Cerebrovascular accident due to thrombosis of left cerebellar artery"
+  },
+  {
+    "sctid": "95774001",
+    "preferred_name": "Atrophy of optic disc"
+  },
+  {
+    "sctid": "95775000",
+    "preferred_name": "Retrobulbar optic nerve atrophy"
+  },
+  {
+    "sctid": "95776004",
+    "preferred_name": "Disorder of optic tract"
+  },
+  {
+    "sctid": "95815000",
+    "preferred_name": "Central positional vertigo"
+  },
+  {
+    "sctid": "95830009",
+    "preferred_name": "Pituitary infarction"
+  },
+  {
+    "sctid": "95883001",
+    "preferred_name": "Bacterial meningitis"
+  },
+  {
+    "sctid": "962731000000104",
+    "preferred_name": "Acquired delay in feeding"
+  },
+  {
+    "sctid": "963741000000101",
+    "preferred_name": "Bacterial meningoencephalomyelitis"
+  },
+  {
+    "sctid": "965003",
+    "preferred_name": "Toxic amblyopia"
+  },
+  {
+    "sctid": "9674006",
+    "preferred_name": "Adjustment disorder with withdrawal"
+  },
+  {
+    "sctid": "9678009",
+    "preferred_name": "Herpetic meningoencephalitis"
+  },
+  {
+    "sctid": "96981000119102",
+    "preferred_name": "Malignant neoplasm of rectosigmoid junction metastatic to brain"
+  },
+  {
+    "sctid": "9721000119107",
+    "preferred_name": "Malformation of central nervous system of fetus"
+  },
+  {
+    "sctid": "9740002",
+    "preferred_name": "Macroencephaly"
+  },
+  {
+    "sctid": "97571000119109",
+    "preferred_name": "Thrombocytopenia co-occurrent and due to alcoholism"
+  },
+  {
+    "sctid": "9760005",
+    "preferred_name": "Deferred diagnosis on Axis I"
+  },
+  {
+    "sctid": "97751000119108",
+    "preferred_name": "Altered behavior in Alzheimer's disease"
+  },
+  {
+    "sctid": "984661000000105",
+    "preferred_name": "Mild learning disability"
+  },
+  {
+    "sctid": "984671000000103",
+    "preferred_name": "Moderate learning disability"
+  },
+  {
+    "sctid": "984681000000101",
+    "preferred_name": "Profound learning disability"
+  },
+  {
+    "sctid": "98541000119101",
+    "preferred_name": "Herpes zoster myelitis"
+  },
+  {
+    "sctid": "9901000119100",
+    "preferred_name": "Occlusion of cerebral artery with stroke"
+  },
+  {
+    "sctid": "99131000119108",
+    "preferred_name": "Astrocytoma of cerebrum"
+  },
+  {
+    "sctid": "99451000119105",
+    "preferred_name": "Cerebral infarction due to stenosis of carotid artery"
+  },
+  {
+    "sctid": "9971000119105",
+    "preferred_name": "Spinal stenosis in cervical region with myelopathy"
+  },
+  {
+    "sctid": "203082005",
+    "preferred_name": "Fibromyalgia"
+  },
+  {
+    "sctid": "238131007",
+    "preferred_name": "Overweight"
+  },
+  {
+    "sctid": "397540003",
+    "preferred_name": "Visual impairment"
+  },
+  {
+    "sctid": "432119003",
+    "preferred_name": "Aneurysm"
+  },
+  {
+    "sctid": "59770006",
+    "preferred_name": "Dyslexia"
+  },
+  {
+    "sctid": "87486003",
+    "preferred_name": "Aphasia"
+  }
+]


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #211 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added JSON dump of SNOMED CT disorder terms
- On startup, app will now read in the file of SNOMED diagnosis terms and store a lookup file where entries are in the format `<id>:<name>`
- Implemented logic for `/attributes/nb:Diagnosis/vocab` which loads + processes the lookup file contents into a `VocabLabelsResponse` object
- Added graceful exception handling for network errors encountered when requesting external vocabs on startup (cogatlas)

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
