### PR TITLE
[FIX] Make session optional in SPARQL query template

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -153,18 +153,18 @@ async def get(
             else:
                 subject_data = (
                     group.drop(dataset_cols, axis=1)
-                    .groupby(by=["sub_id", "session_id"])
-                    .agg(
+                    # TODO: Switch back to dropna=True once phenotypic sessions are implemented, as all subjects will have at least one non-null session ID
+                    .groupby(by=["sub_id", "session_id"], dropna=False).agg(
                         {
                             "sub_id": "first",
                             "session_id": "first",
                             "num_sessions": "first",
                             "age": "first",
                             "sex": "first",
-                            "diagnosis": lambda x: list(set(x)),
+                            "diagnosis": lambda x: list(x.unique()),
                             "subject_group": "first",
-                            "assessment": lambda x: list(set(x)),
-                            "image_modal": lambda x: list(set(x)),
+                            "assessment": lambda x: list(x.unique()),
+                            "image_modal": lambda x: list(x.unique()),
                             "session_file_path": "first",
                         }
                     )

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -183,15 +183,17 @@ def create_query(
                     nb:hasLabel ?dataset_name;
                     nb:hasSamples ?subject.
             ?subject a nb:Subject;
-                    nb:hasLabel ?sub_id;
-                    nb:hasSession ?session;
-                    nb:hasSession/nb:hasAcquisition/nb:hasContrastType ?image_modal.
-            ?session nb:hasLabel ?session_id.
+                    nb:hasLabel ?sub_id.
             OPTIONAL {{
-                ?dataset_uuid nb:hasPortalURI ?dataset_portal_uri.
+                ?subject nb:hasSession ?session;
+                         nb:hasSession/nb:hasAcquisition/nb:hasContrastType ?image_modal.
+                ?session nb:hasLabel ?session_id.
+                OPTIONAL {{
+                    ?session nb:hasFilePath ?session_file_path.
+                }}
             }}
             OPTIONAL {{
-                ?session nb:hasFilePath ?session_file_path.
+                ?dataset_uuid nb:hasPortalURI ?dataset_portal_uri.
             }}
             OPTIONAL {{
                 ?subject nb:hasAge ?age.
@@ -211,9 +213,11 @@ def create_query(
             {{
                 SELECT ?subject (count(distinct ?session) as ?num_sessions)
                 WHERE {{
-                    ?subject a nb:Subject;
-                            nb:hasSession ?session.
-                    ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
+                    ?subject a nb:Subject.
+                    OPTIONAL {{
+                        ?subject nb:hasSession ?session.
+                        ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
+                    }}
                     {session_level_filters}
                 }} GROUP BY ?subject
             }}


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #225
- Closes #134
- Closes https://github.com/neurobagel/planning/issues/79
<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- make session-related attributes optional for subjects in the SPARQL query template (so that it matches subjects who have phenotypic info but no [imaging] sessions**, since currently sessions aren't created for phenotypic-only data)
- since subjects with only phenotypic data don't have a `session_id` (but the `subject_data` field in the response should have a separate entry per instance of subject data), update the pandas grouper used when processing the graph response to recognize `null` session ID when grouping the data by subject + session
  - otherwise, the `"subject_data"` field for these datasets will be an empty list `[]`
- for subject session-level attribute keys in the response that (theoretically) can be a list, `diagnosis`, `assessment`, etc., use `Series.unique()` instead of `set()` on the column values in the response dataframe to get the unique values per subject-session. This change is needed because `set()` does not work on multiple `null` values - meaning they are _all_ returned, e.g., `"diagnosis": [null, null, null, null]` 
  - see https://stackoverflow.com/questions/26245862/reducing-pandas-series-with-multiple-nan-values-to-a-set-gives-multiple-nan-valu

**note that these are subjects with only phenotypic data _in the graph_ (meaning they either don't have imaging data or the imaging data can't be modelled by neurobagel, so the CLI doesn't create a session layer for them)

### For reviewer:
1. For a basic sanity check the query template change recovers the 7/340 previously missing datasets for the OpenNeuro graph (see https://github.com/neurobagel/planning/issues/54), checkout the current branch and spin up the API locally with `NB_GRAPH_DB=open_neuro/query`), and run the following Python code:

```python
import httpx
response = httpx.get(url="http://127.0.0.1:8000/query/", timeout=30)
num_openneuro_datasets_NEW = len(response.json())  # should return 340

response = httpx.get(url="https://api.neurobagel.org/query/", timeout=30)
num_openneuro_datasets_OLD = len(response.json())  # should return 333
```

2. To see what the subject-level API response looks like for datasets that don't have any sessions in the graph, re-spin up the API pointed to `NB_GRAPH_DB=sysadmin_test/query` (also on `fairmount`; this db contains the 7 previously missing, pheno-only datasets as well as 1 'normal' dataset that has imaging sessions), make sure `NB_RETURN_AGG=false`, and run an empty query using the interactive docs.

3. If you want to manually check that this also fixes https://github.com/neurobagel/planning/issues/79, you can point your local API (with this branch's changes) in aggregate mode to the QPN or PPMI graphs (https://github.com/neurobagel/documentation/wiki/API#neurobagel-hosted-apis) and confirm that with an empty query, the `"dataset_total_subjects"` key and `"num_matching_subjects"` values for each dataset are now the same (I have already done this)

<!-- To be checked off by reviewers -->
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
