### PR TITLE
[TST] Refactor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def test_data():
 
 @pytest.fixture
 def mock_post_query_to_graph():
-    """Mock post_query_to_graph function that returns toy data containing a dataset with no modalities for testing."""
+    """Mock post_query_to_graph function that returns toy aggregate data containing a dataset with no modalities for testing."""
 
     def mockreturn(query, timeout=5.0):
         return {
@@ -99,6 +99,20 @@ def mock_post_query_to_graph():
                 ]
             },
         }
+
+    return mockreturn
+
+
+@pytest.fixture
+def mock_query_matching_dataset_sizes():
+    """
+    Mock query_matching_dataset_sizes function that returns the total number of subjects for a toy dataset 12345.
+    Can be used together with mock_post_query_to_graph to mock both the POST step of a cohort query and the corresponding query for dataset size,
+    in order to test how the response from the graph is processed by the API (crud.get).
+    """
+
+    def mockreturn(dataset_uuids):
+        return {"http://neurobagel.org/vocab/12345": 200}
 
     return mockreturn
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,17 +111,25 @@ def mock_query_matching_dataset_sizes():
     in order to test how the response from the graph is processed by the API (crud.get).
     """
 
-    def mockreturn(dataset_uuids):
+    def _mock_query_matching_dataset_sizes(dataset_uuids):
         return {"http://neurobagel.org/vocab/12345": 200}
 
-    return mockreturn
+    return _mock_query_matching_dataset_sizes
 
 
 @pytest.fixture
 def mock_get_with_exception(request):
-    """Mock get function that raises a specified exception."""
+    """
+    Mock get function that raises a specified exception.
 
-    async def mockreturn(
+    A parameter passed to this fixture via indirect parametrization is received by the internal factory function before it is passed to a test.
+
+    Example usage in test function:
+        @pytest.mark.parametrize("mock_get_with_exception", [HTTPException(500)], indirect=True)
+        (this tells mock_get_with_exception to raise an HTTPException)
+    """
+
+    async def _mock_get_with_exception(
         min_age,
         max_age,
         sex,
@@ -134,14 +142,22 @@ def mock_get_with_exception(request):
     ):
         raise request.param
 
-    return mockreturn
+    return _mock_get_with_exception
 
 
 @pytest.fixture
 def mock_get(request):
-    """Mock get function that returns an arbitrary response or value (can be None). Can be used to testing error handling of bad requests."""
+    """
+    Mock get function that returns an arbitrary response or value (can be None). Can be used to testing error handling of bad requests.
 
-    async def mockreturn(
+    A parameter passed to this fixture via indirect parametrization is received by the internal factory function before it is passed to a test.
+
+    Example usage in test function:
+        @pytest.mark.parametrize("mock_get", [None], indirect=True)
+        (this tells mock_get to return None)
+    """
+
+    async def _mock_get(
         min_age,
         max_age,
         sex,
@@ -154,14 +170,14 @@ def mock_get(request):
     ):
         return request.param
 
-    return mockreturn
+    return _mock_get
 
 
 @pytest.fixture
 def mock_successful_get(test_data):
     """Mock get function that returns non-empty, valid aggregate query result data."""
 
-    async def mockreturn(
+    async def _mock_successful_get(
         min_age,
         max_age,
         sex,
@@ -174,7 +190,7 @@ def mock_successful_get(test_data):
     ):
         return test_data
 
-    return mockreturn
+    return _mock_successful_get
 
 
 @pytest.fixture()
@@ -194,7 +210,7 @@ def terms_test_data():
 def mock_successful_get_terms(terms_test_data):
     """Mock get_terms function that returns non-empty results."""
 
-    async def mockreturn(data_element_URI, term_labels_path):
+    async def _mock_successful_get_terms(data_element_URI, term_labels_path):
         return terms_test_data
 
-    return mockreturn
+    return _mock_successful_get_terms

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,8 +104,48 @@ def mock_post_query_to_graph():
 
 
 @pytest.fixture
+def mock_get_with_exception(request):
+    """Mock get function that raises a specified exception."""
+
+    async def mockreturn(
+        min_age,
+        max_age,
+        sex,
+        diagnosis,
+        is_control,
+        min_num_imaging_sessions,
+        min_num_phenotypic_sessions,
+        assessment,
+        image_modal,
+    ):
+        raise request.param
+
+    return mockreturn
+
+
+@pytest.fixture
+def mock_get(request):
+    """Mock get function that returns an arbitrary response or value (can be None). Can be used to testing error handling of bad requests."""
+
+    async def mockreturn(
+        min_age,
+        max_age,
+        sex,
+        diagnosis,
+        is_control,
+        min_num_imaging_sessions,
+        min_num_phenotypic_sessions,
+        assessment,
+        image_modal,
+    ):
+        return request.param
+
+    return mockreturn
+
+
+@pytest.fixture
 def mock_successful_get(test_data):
-    """Mock get function that returns non-empty query results."""
+    """Mock get function that returns non-empty, valid aggregate query result data."""
 
     async def mockreturn(
         min_age,
@@ -119,26 +159,6 @@ def mock_successful_get(test_data):
         image_modal,
     ):
         return test_data
-
-    return mockreturn
-
-
-@pytest.fixture
-def mock_invalid_get():
-    """Mock get function that does not return any response (for testing invalid parameter values)."""
-
-    async def mockreturn(
-        min_age,
-        max_age,
-        sex,
-        diagnosis,
-        is_control,
-        min_num_imaging_sessions,
-        min_num_phenotypic_sessions,
-        assessment,
-        image_modal,
-    ):
-        return None
 
     return mockreturn
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -52,9 +52,7 @@ def test_get_subjects_by_query(monkeypatch):
     }
 
 
-def test_null_modalities(
-    test_app, test_data, mock_post_query_to_graph, monkeypatch
-):
+def test_null_modalities(test_app, mock_post_query_to_graph, monkeypatch):
     """Given a response containing a dataset with no recorded modalities, returns an empty list for the imaging modalities."""
 
     def mock_query_matching_dataset_sizes(dataset_uuids):
@@ -114,6 +112,7 @@ def test_get_valid_age_single_bound(
     assert response.json() != []
 
 
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
 @pytest.mark.parametrize(
     "invalid_min_age, invalid_max_age",
     [
@@ -123,11 +122,11 @@ def test_get_valid_age_single_bound(
     ],
 )
 def test_get_invalid_age(
-    test_app, mock_invalid_get, invalid_min_age, invalid_max_age, monkeypatch
+    test_app, mock_get, invalid_min_age, invalid_max_age, monkeypatch
 ):
     """Given an invalid age range, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
         f"/query/?min_age={invalid_min_age}&max_age={invalid_max_age}"
     )
@@ -147,10 +146,11 @@ def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
     assert response.json() != []
 
 
-def test_get_invalid_sex(test_app, mock_invalid_get, monkeypatch):
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
+def test_get_invalid_sex(test_app, mock_get, monkeypatch):
     """Given an invalid sex string, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get("/query/?sex=apple")
     assert response.status_code == 422
 
@@ -169,15 +169,16 @@ def test_get_valid_diagnosis(
     assert response.json() != []
 
 
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
 @pytest.mark.parametrize(
     "invalid_diagnosis", ["sn0med:35489007", "apple", ":123456"]
 )
 def test_get_invalid_diagnosis(
-    test_app, mock_invalid_get, invalid_diagnosis, monkeypatch
+    test_app, mock_get, invalid_diagnosis, monkeypatch
 ):
     """Given an invalid diagnosis, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(f"/query/?diagnosis={invalid_diagnosis}")
     assert response.status_code == 422
 
@@ -194,20 +195,20 @@ def test_get_valid_iscontrol(
     assert response.json() != []
 
 
-def test_get_invalid_iscontrol(test_app, mock_invalid_get, monkeypatch):
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
+def test_get_invalid_iscontrol(test_app, mock_get, monkeypatch):
     """Given a non-boolean is_control value, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get("/query/?is_control=apple")
     assert response.status_code == 422
 
 
-def test_get_invalid_control_diagnosis_pair(
-    test_app, mock_invalid_get, monkeypatch
-):
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
+def test_get_invalid_control_diagnosis_pair(test_app, mock_get, monkeypatch):
     """Given a non-default diagnosis value and is_control value of True, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
         "/query/?diagnosis=snomed:35489007&is_control=True"
     )
@@ -241,6 +242,7 @@ def test_get_valid_min_num_sessions(
     assert response.json() != []
 
 
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
 @pytest.mark.parametrize(
     "session_param",
     ["min_num_phenotypic_sessions", "min_num_imaging_sessions"],
@@ -248,14 +250,14 @@ def test_get_valid_min_num_sessions(
 @pytest.mark.parametrize("invalid_min_num_sessions", [-3, 2.5, "apple"])
 def test_get_invalid_min_num_sessions(
     test_app,
-    mock_invalid_get,
+    mock_get,
     session_param,
     invalid_min_num_sessions,
     monkeypatch,
 ):
     """Given an invalid minimum number of imaging sessions, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
         f"/query/?{session_param}={invalid_min_num_sessions}"
     )
@@ -271,15 +273,16 @@ def test_get_valid_assessment(test_app, mock_successful_get, monkeypatch):
     assert response.json() != []
 
 
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
 @pytest.mark.parametrize(
     "invalid_assessment", ["bg01:cogAtlas-1234", "cogAtlas-1234"]
 )
 def test_get_invalid_assessment(
-    test_app, mock_invalid_get, invalid_assessment, monkeypatch
+    test_app, mock_get, invalid_assessment, monkeypatch
 ):
     """Given an invalid assessment, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(f"/query/?assessment={invalid_assessment}")
     assert response.status_code == 422
 
@@ -307,27 +310,15 @@ def test_get_valid_available_image_modal(
     assert response.json() != []
 
 
+@pytest.mark.parametrize("mock_get", [[]], indirect=True)
 @pytest.mark.parametrize(
     "valid_unavailable_image_modal",
     ["nidm:Flair", "owl:sameAs", "nb:FlowWeighted", "snomed:something"],
 )
 def test_get_valid_unavailable_image_modal(
-    test_app, valid_unavailable_image_modal, monkeypatch
+    test_app, valid_unavailable_image_modal, mock_get, monkeypatch
 ):
     """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and an empty list of results."""
-
-    async def mock_get(
-        min_age,
-        max_age,
-        sex,
-        diagnosis,
-        is_control,
-        min_num_imaging_sessions,
-        min_num_phenotypic_sessions,
-        assessment,
-        image_modal,
-    ):
-        return []
 
     monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
@@ -338,42 +329,36 @@ def test_get_valid_unavailable_image_modal(
     assert response.json() == []
 
 
+@pytest.mark.parametrize("mock_get", [None], indirect=True)
 @pytest.mark.parametrize(
     "invalid_image_modal", ["2nim:EEG", "apple", "some_thing:cool"]
 )
 def test_get_invalid_image_modal(
-    test_app, mock_invalid_get, invalid_image_modal, monkeypatch
+    test_app, mock_get, invalid_image_modal, monkeypatch
 ):
     """Given an invalid image modality, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_invalid_get)
+    monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(f"/query/?image_modal={invalid_image_modal}")
     assert response.status_code == 422
 
 
 @pytest.mark.parametrize(
+    "mock_get_with_exception", [HTTPException(500)], indirect=True
+)
+@pytest.mark.parametrize(
     "undefined_prefix_image_modal",
     ["dbo:abstract", "sex:apple", "something:cool"],
 )
 def test_get_undefined_prefix_image_modal(
-    test_app, undefined_prefix_image_modal, monkeypatch
+    test_app,
+    undefined_prefix_image_modal,
+    mock_get_with_exception,
+    monkeypatch,
 ):
     """Given a valid and undefined prefix image modality, returns a 500 status code."""
 
-    async def mock_get(
-        min_age,
-        max_age,
-        sex,
-        diagnosis,
-        is_control,
-        min_num_imaging_sessions,
-        min_num_phenotypic_sessions,
-        assessment,
-        image_modal,
-    ):
-        raise HTTPException(500)
-
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "get", mock_get_with_exception)
     response = test_app.get(
         f"/query/?image_modal={undefined_prefix_image_modal}"
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -366,13 +366,14 @@ def test_get_undefined_prefix_image_modal(
     assert response.status_code == 500
 
 
-def test_query_with_return_agg(
+def test_aggregate_query_response_structure(
     test_app,
     set_test_credentials,
     mock_post_query_to_graph,
     mock_query_matching_dataset_sizes,
     monkeypatch,
 ):
+    """Test that when aggregate results are enabled, a cohort query response has the expected structure."""
     monkeypatch.setenv(util.RETURN_AGG.name, "true")
     monkeypatch.setattr(crud, "post_query_to_graph", mock_post_query_to_graph)
     monkeypatch.setattr(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #126
- Closes #266 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Basic test added for structure of cohort query response when `RETURN_AGG=true`
- Turned mocked get function used across query tests into a few different fixtures, with variations based on the type of value/object to be returned by the mocked function
  - Specific return objects for the mocked function specified in test definitions via [indirect parametrization](https://docs.pytest.org/en/latest/example/parametrize.html#indirect-parametrization)
  - `mock_successful_get` (which depends on another fixture for the return object) kept a separate function to avoid overly complicated parametrization when writing tests (i.e., you cannot easily pass one fixture as a parameter to another fixture)
 
<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.