### PR TITLE
[REF] Make session count names clearer in query response

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please refer to our [**official documentation**](https://neurobagel.org/api/) fo
     - [Docker (recommended)](#docker)
     - [Python](#python)
 - [Testing](#testing)
+- [The default Neurobagel SPARQL query](#the-default-neurobagel-sparql-query)
 - [License](#license)
 
 
@@ -180,7 +181,7 @@ pytest tests
 
 ## The default Neurobagel SPARQL query
 
-`docs/default_neurobagel_query.rq` contains a sample default SPARQL query sent by the Neurobagel API to a graph database to retrieve all available phenotypic and imaging data.
+[docs/default_neurobagel_query.rq](docs/default_neurobagel_query.rq) contains a sample default SPARQL query sent by the Neurobagel API to a graph database to retrieve all available phenotypic and imaging data.
 This file is mainly intended for reference because in normal operations, 
 the API will always talk to the graph on behalf of the user.
 

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -175,8 +175,8 @@ async def get(
                         {
                             "sub_id": "first",
                             "session_id": "first",
-                            "num_phenotypic_sessions": "first",
-                            "num_imaging_sessions": "first",
+                            "num_matching_phenotypic_sessions": "first",
+                            "num_matching_imaging_sessions": "first",
                             "session_type": "first",
                             "age": "first",
                             "sex": "first",

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -57,8 +57,8 @@ class SessionResponse(BaseModel):
 
     sub_id: str
     session_id: str
-    num_phenotypic_sessions: int
-    num_imaging_sessions: int
+    num_matching_phenotypic_sessions: int
+    num_matching_imaging_sessions: int
     session_type: str
     age: Optional[float]
     sex: Optional[str]

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -141,12 +141,12 @@ def create_query(
     if min_num_phenotypic_sessions is not None:
         subject_level_filters += (
             "\n"
-            + f"FILTER (?num_phenotypic_sessions >= {min_num_phenotypic_sessions})."
+            + f"FILTER (?num_matching_phenotypic_sessions >= {min_num_phenotypic_sessions})."
         )
     if min_num_imaging_sessions is not None:
         subject_level_filters += (
             "\n"
-            + f"FILTER (?num_imaging_sessions >= {min_num_imaging_sessions})."
+            + f"FILTER (?num_matching_imaging_sessions >= {min_num_imaging_sessions})."
         )
 
     phenotypic_session_level_filters = ""
@@ -194,7 +194,7 @@ def create_query(
     query_string = textwrap.dedent(
         f"""
         SELECT DISTINCT ?dataset_uuid ?dataset_name ?dataset_portal_uri ?sub_id ?age ?sex
-        ?diagnosis ?subject_group ?num_phenotypic_sessions ?num_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
+        ?diagnosis ?subject_group ?num_matching_phenotypic_sessions ?num_matching_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
         WHERE {{
             ?dataset_uuid a nb:Dataset;
                     nb:hasLabel ?dataset_name;
@@ -229,7 +229,7 @@ def create_query(
                 ?session nb:hasAssessment ?assessment.
             }}
             {{
-                SELECT ?subject (count(distinct ?phenotypic_session) as ?num_phenotypic_sessions)
+                SELECT ?subject (count(distinct ?phenotypic_session) as ?num_matching_phenotypic_sessions)
                 WHERE {{
                     ?subject a nb:Subject.
                     OPTIONAL {{
@@ -255,7 +255,7 @@ def create_query(
                 }} GROUP BY ?subject
             }}
             {{
-                SELECT ?subject (count(distinct ?imaging_session) as ?num_imaging_sessions)
+                SELECT ?subject (count(distinct ?imaging_session) as ?num_matching_imaging_sessions)
                 WHERE {{
                     ?subject a nb:Subject.
                     OPTIONAL {{

--- a/docs/default_neurobagel_query.rq
+++ b/docs/default_neurobagel_query.rq
@@ -6,7 +6,7 @@ PREFIX nidm: <http://purl.org/nidash/nidm#>
 PREFIX snomed: <http://purl.bioontology.org/ontology/SNOMEDCT/>
 
 SELECT DISTINCT ?dataset_uuid ?dataset_name ?dataset_portal_uri ?sub_id ?age ?sex
-?diagnosis ?subject_group ?num_phenotypic_sessions ?num_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
+?diagnosis ?subject_group ?num_matching_phenotypic_sessions ?num_matching_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
 WHERE {
     ?dataset_uuid a nb:Dataset;
             nb:hasLabel ?dataset_name;
@@ -15,7 +15,7 @@ WHERE {
             nb:hasLabel ?sub_id;
             nb:hasSession ?session.
     ?session a ?session_type;
-                nb:hasLabel ?session_id.
+             nb:hasLabel ?session_id.
     OPTIONAL {
         ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
         OPTIONAL {
@@ -41,7 +41,7 @@ WHERE {
         ?session nb:hasAssessment ?assessment.
     }
     {
-        SELECT ?subject (count(distinct ?phenotypic_session) as ?num_phenotypic_sessions)
+        SELECT ?subject (count(distinct ?phenotypic_session) as ?num_matching_phenotypic_sessions)
         WHERE {
             ?subject a nb:Subject.
             OPTIONAL {
@@ -67,7 +67,7 @@ WHERE {
         } GROUP BY ?subject
     }
     {
-        SELECT ?subject (count(distinct ?imaging_session) as ?num_imaging_sessions)
+        SELECT ?subject (count(distinct ?imaging_session) as ?num_matching_imaging_sessions)
         WHERE {
             ?subject a nb:Subject.
             OPTIONAL {


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the PR process for Neurobagel repositories, see https://neurobagel.org/contributing/pull_requests/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #271 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Response model for a single matching session response updated
- Query template updated
- Default SPARQL query regenerated

Note that:
- the query parameters themselves have not been renamed (b/c `min_num_{phenotypic,imaging}_sessions` still makes more sense in a query). 
- we currently (still) do not have a field in a single session query response that indicates the *total* (not matching) num. of sessions available for a subject. however, this can be deduced from the number of session objects for a subject in the full response

<!-- To be checked off by reviewers -->
## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.