### PR TITLE
[FIX] Exclude sessions missing a queried property from matches

### DIFF
--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -212,13 +212,13 @@ def create_query(
         ?diagnosis ?subject_group ?num_matching_phenotypic_sessions ?num_matching_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
         WHERE {{
             ?dataset_uuid a nb:Dataset;
-                    nb:hasLabel ?dataset_name;
-                    nb:hasSamples ?subject.
+                nb:hasLabel ?dataset_name;
+                nb:hasSamples ?subject.
             ?subject a nb:Subject;
-                    nb:hasLabel ?sub_id;
-                    nb:hasSession ?session.
+                nb:hasLabel ?sub_id;
+                nb:hasSession ?session.
             ?session a ?session_type;
-                    nb:hasLabel ?session_id.
+                nb:hasLabel ?session_id.
             OPTIONAL {{
                 ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
                 OPTIONAL {{?session nb:hasFilePath ?session_file_path.}}
@@ -232,8 +232,7 @@ def create_query(
             {{
                 SELECT ?subject (count(distinct ?phenotypic_session) as ?num_matching_phenotypic_sessions)
                 WHERE {{
-                    ?subject a nb:Subject;
-                        nb:hasSession ?phenotypic_session.
+                    ?subject nb:hasSession ?phenotypic_session.
                     ?phenotypic_session a nb:PhenotypicSession.
 
                     OPTIONAL {{?phenotypic_session nb:hasAge ?age.}}
@@ -248,7 +247,6 @@ def create_query(
             {{
                 SELECT ?subject (count(distinct ?imaging_session) as ?num_matching_imaging_sessions)
                 WHERE {{
-                    ?subject a nb:Subject.
                     OPTIONAL {{
                         ?subject nb:hasSession ?imaging_session.
                         ?imaging_session a nb:ImagingSession;

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -97,6 +97,14 @@ def unpack_http_response_json_to_dicts(response: dict) -> list[dict]:
     ]
 
 
+def create_bound_filter(var: str) -> str:
+    """
+    Create a SPARQL filter substring for checking if a variable is bound
+    (meaning the variable actually has a corresponding value, e.g., the property exists).
+    """
+    return f"FILTER (BOUND(?{var})"
+
+
 def create_query(
     return_agg: bool,
     age: Optional[tuple] = (None, None),
@@ -153,36 +161,43 @@ def create_query(
 
     if age[0] is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"FILTER (?{AGE.var} >= {age[0]})."
+            "\n"
+            + f"{create_bound_filter({AGE.var})} && ?{AGE.var} >= {age[0]})."
         )
     if age[1] is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"FILTER (?{AGE.var} <= {age[1]})."
+            "\n"
+            + f"{create_bound_filter({AGE.var})} && ?{AGE.var} <= {age[1]})."
         )
 
     if sex is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"FILTER (?{SEX.var} = {sex})."
+            "\n" + f"{create_bound_filter({SEX.var})} && ?{SEX.var} = {sex})."
         )
 
     if diagnosis is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"FILTER (?{DIAGNOSIS.var} = {diagnosis})."
+            "\n"
+            + f"{create_bound_filter({DIAGNOSIS.var})} && ?{DIAGNOSIS.var} = {diagnosis})."
         )
 
     if is_control is not None:
         if is_control:
             phenotypic_session_level_filters += (
-                "\n" + f"FILTER (?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
+                "\n"
+                + f"{create_bound_filter({IS_CONTROL.var})} && ?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
             )
         else:
+            # TODO: Revisit - this logic seems odd, since in our current data model the session should not have this edge if it's not a control.
             phenotypic_session_level_filters += (
-                "\n" + f"FILTER (?{IS_CONTROL.var} != {IS_CONTROL_TERM})."
+                "\n"
+                + f"{create_bound_filter({IS_CONTROL.var})} && ?{IS_CONTROL.var} != {IS_CONTROL_TERM})."
             )
 
     if assessment is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"FILTER (?{ASSESSMENT.var} = {assessment})."
+            "\n"
+            + f"{create_bound_filter({ASSESSMENT.var})} && ?{ASSESSMENT.var} = {assessment})."
         )
 
     imaging_session_level_filters = ""
@@ -203,7 +218,7 @@ def create_query(
                     nb:hasLabel ?sub_id;
                     nb:hasSession ?session.
             ?session a ?session_type;
-                     nb:hasLabel ?session_id.
+                    nb:hasLabel ?session_id.
             OPTIONAL {{
                 ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
                 OPTIONAL {{?session nb:hasFilePath ?session_file_path.}}
@@ -217,17 +232,16 @@ def create_query(
             {{
                 SELECT ?subject (count(distinct ?phenotypic_session) as ?num_matching_phenotypic_sessions)
                 WHERE {{
-                    ?subject a nb:Subject.
-                    OPTIONAL {{
-                        ?subject nb:hasSession ?phenotypic_session.
-                        ?phenotypic_session a nb:PhenotypicSession.
+                    ?subject a nb:Subject;
+                        nb:hasSession ?phenotypic_session.
+                    ?phenotypic_session a nb:PhenotypicSession.
 
-                        OPTIONAL {{?phenotypic_session nb:hasAge ?age.}}
-                        OPTIONAL {{?phenotypic_session nb:hasSex ?sex.}}
-                        OPTIONAL {{?phenotypic_session nb:hasDiagnosis ?diagnosis.}}
-                        OPTIONAL {{?phenotypic_session nb:isSubjectGroup ?subject_group.}}
-                        OPTIONAL {{?phenotypic_session nb:hasAssessment ?assessment.}}
-                    }}
+                    OPTIONAL {{?phenotypic_session nb:hasAge ?age.}}
+                    OPTIONAL {{?phenotypic_session nb:hasSex ?sex.}}
+                    OPTIONAL {{?phenotypic_session nb:hasDiagnosis ?diagnosis.}}
+                    OPTIONAL {{?phenotypic_session nb:isSubjectGroup ?subject_group.}}
+                    OPTIONAL {{?phenotypic_session nb:hasAssessment ?assessment.}}
+
                     {phenotypic_session_level_filters}
                 }} GROUP BY ?subject
             }}
@@ -261,6 +275,7 @@ def create_query(
             + "} GROUP BY ?dataset_uuid ?dataset_name ?dataset_portal_uri ?sub_id ?image_modal"
         )
 
+    print(query_string)
     return "\n".join([create_context(), query_string])
 
 

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -273,7 +273,6 @@ def create_query(
             + "} GROUP BY ?dataset_uuid ?dataset_name ?dataset_portal_uri ?sub_id ?image_modal"
         )
 
-    print(query_string)
     return "\n".join([create_context(), query_string])
 
 

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -162,42 +162,42 @@ def create_query(
     if age[0] is not None:
         phenotypic_session_level_filters += (
             "\n"
-            + f"{create_bound_filter({AGE.var})} && ?{AGE.var} >= {age[0]})."
+            + f"{create_bound_filter(AGE.var)} && ?{AGE.var} >= {age[0]})."
         )
     if age[1] is not None:
         phenotypic_session_level_filters += (
             "\n"
-            + f"{create_bound_filter({AGE.var})} && ?{AGE.var} <= {age[1]})."
+            + f"{create_bound_filter(AGE.var)} && ?{AGE.var} <= {age[1]})."
         )
 
     if sex is not None:
         phenotypic_session_level_filters += (
-            "\n" + f"{create_bound_filter({SEX.var})} && ?{SEX.var} = {sex})."
+            "\n" + f"{create_bound_filter(SEX.var)} && ?{SEX.var} = {sex})."
         )
 
     if diagnosis is not None:
         phenotypic_session_level_filters += (
             "\n"
-            + f"{create_bound_filter({DIAGNOSIS.var})} && ?{DIAGNOSIS.var} = {diagnosis})."
+            + f"{create_bound_filter(DIAGNOSIS.var)} && ?{DIAGNOSIS.var} = {diagnosis})."
         )
 
     if is_control is not None:
         if is_control:
             phenotypic_session_level_filters += (
                 "\n"
-                + f"{create_bound_filter({IS_CONTROL.var})} && ?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
+                + f"{create_bound_filter(IS_CONTROL.var)} && ?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
             )
         else:
             # TODO: Revisit - this logic seems odd, since in our current data model the session should not have this edge if it's not a control.
             phenotypic_session_level_filters += (
                 "\n"
-                + f"{create_bound_filter({IS_CONTROL.var})} && ?{IS_CONTROL.var} != {IS_CONTROL_TERM})."
+                + f"{create_bound_filter(IS_CONTROL.var)} && ?{IS_CONTROL.var} != {IS_CONTROL_TERM})."
             )
 
     if assessment is not None:
         phenotypic_session_level_filters += (
             "\n"
-            + f"{create_bound_filter({ASSESSMENT.var})} && ?{ASSESSMENT.var} = {assessment})."
+            + f"{create_bound_filter(ASSESSMENT.var)} && ?{ASSESSMENT.var} = {assessment})."
         )
 
     imaging_session_level_filters = ""

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -52,9 +52,14 @@ def test_invalid_token_raises_error(invalid_token):
     [{}, {"Authorization": ""}, {"badheader": "badvalue"}],
 )
 def test_query_with_malformed_auth_header_fails(
-    test_app, set_mock_verify_token, invalid_auth_header
+    test_app, set_mock_verify_token, invalid_auth_header, monkeypatch
 ):
-    """Test that a request to the /query route with a missing or malformed authorization header, fails ."""
+    """
+    Test that when authentication is enabled, a request to the /query route with
+    a missing or malformed authorization header fails.
+    """
+    monkeypatch.setattr("app.api.security.CLIENT_ID", "foo.id")
+    monkeypatch.setattr("app.api.security.AUTH_ENABLED", True)
 
     response = test_app.get(
         "/query/",

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -60,3 +60,9 @@ def test_unpack_http_response_json_to_dicts():
             "total_subjects": "84",
         },
     ]
+
+
+def test_bound_filter_created_correctly():
+    """Test that the function creates a valid SPARQL filter substring given a variable name."""
+    var = "subject_group"
+    assert util.create_bound_filter(var) == "FILTER (BOUND(?subject_group)"


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #324

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Use the `BOUND` function in subquery for matching phenotypic sessions to exclude any results where a variable being filtered for does not have a value ("unbound" results - these are included by default, leading to inaccurate counts of matches)
  - e.g., because all phenotypic attributes are optional, when we query for healthy controls, the default matching behaviour _includes_ any sessions that do not have the `isSubjectGroup` edge - which would be any session that has diagnosis info, since these two properties are mutually exclusive
- Make having a phenotypic session non-optional in query (since subjects should not end up in the graph if they don't have any phenotypic info)
- Minor refactoring of query template for efficiency

This PR also includes a small fix to the context of an auth behaviour test that assumes authentication is enabled (this test was failing for me locally b/c I had auth turned off in development).

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
