### PR TITLE
[FIX] Ensure subjects without imaging sessions are considered in main query

### DIFF
--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -247,6 +247,7 @@ def create_query(
             {{
                 SELECT ?subject (count(distinct ?imaging_session) as ?num_matching_imaging_sessions)
                 WHERE {{
+                    ?subject a nb:Subject.
                     OPTIONAL {{
                         ?subject nb:hasSession ?imaging_session.
                         ?imaging_session a nb:ImagingSession;

--- a/docs/default_neurobagel_query.rq
+++ b/docs/default_neurobagel_query.rq
@@ -9,13 +9,13 @@ SELECT DISTINCT ?dataset_uuid ?dataset_name ?dataset_portal_uri ?sub_id ?age ?se
 ?diagnosis ?subject_group ?num_matching_phenotypic_sessions ?num_matching_imaging_sessions ?session_id ?session_type ?assessment ?image_modal ?session_file_path
 WHERE {
     ?dataset_uuid a nb:Dataset;
-            nb:hasLabel ?dataset_name;
-            nb:hasSamples ?subject.
+        nb:hasLabel ?dataset_name;
+        nb:hasSamples ?subject.
     ?subject a nb:Subject;
-            nb:hasLabel ?sub_id;
-            nb:hasSession ?session.
+        nb:hasLabel ?sub_id;
+        nb:hasSession ?session.
     ?session a ?session_type;
-             nb:hasLabel ?session_id.
+        nb:hasLabel ?session_id.
     OPTIONAL {
         ?session nb:hasAcquisition/nb:hasContrastType ?image_modal.
         OPTIONAL {?session nb:hasFilePath ?session_file_path.}
@@ -29,17 +29,15 @@ WHERE {
     {
         SELECT ?subject (count(distinct ?phenotypic_session) as ?num_matching_phenotypic_sessions)
         WHERE {
-            ?subject a nb:Subject.
-            OPTIONAL {
-                ?subject nb:hasSession ?phenotypic_session.
-                ?phenotypic_session a nb:PhenotypicSession.
+            ?subject nb:hasSession ?phenotypic_session.
+            ?phenotypic_session a nb:PhenotypicSession.
 
-                OPTIONAL {?phenotypic_session nb:hasAge ?age.}
-                OPTIONAL {?phenotypic_session nb:hasSex ?sex.}
-                OPTIONAL {?phenotypic_session nb:hasDiagnosis ?diagnosis.}
-                OPTIONAL {?phenotypic_session nb:isSubjectGroup ?subject_group.}
-                OPTIONAL {?phenotypic_session nb:hasAssessment ?assessment.}
-            }
+            OPTIONAL {?phenotypic_session nb:hasAge ?age.}
+            OPTIONAL {?phenotypic_session nb:hasSex ?sex.}
+            OPTIONAL {?phenotypic_session nb:hasDiagnosis ?diagnosis.}
+            OPTIONAL {?phenotypic_session nb:isSubjectGroup ?subject_group.}
+            OPTIONAL {?phenotypic_session nb:hasAssessment ?assessment.}
+
 
         } GROUP BY ?subject
     }


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #331

- This PR reverts a change to the query template introduced as part of https://github.com/neurobagel/api/pull/326

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Use left join approach for imaging session subquery to ensure that subjects without an imaging session are still included in the results (with a count of 0 imaging sessions)
  - otherwise, due to the aggregation used in the subquery (`GROUP BY ?subject`), when the results are joined back to the main query, subjects without imaging sessions may be excluded b/c there are no rows for them in the subquery results
- Note that this is not needed for the phenotypic session subquery, because all subjects must have >=1 phenotypic session
- Update serialization of default query (note that this also includes changes from https://github.com/neurobagel/api/pull/326) 

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
