### PR TITLE
[FIX] Allow only `"true"` or `None` for `is_control` query parameter

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -27,16 +27,20 @@ class QueryModel(BaseModel):
     # TODO: Check back if validating using a regex is too restrictive
     pipeline_version: constr(regex=VERSION_REGEX) = None
 
-    # TODO: If/once we migrate the n-API to Pydantic v2,
-    # instead of using the below approach to enforce a case-insensitive allowed value of "true" and convert it to a bool,
-    # we can probably use the new BeforeValidator method to do this directly in the query parameter definition.
-    # Context: Neither Enum nor Literal works as desired for enforcing True (boolean) or None only for a FastAPI query param,
-    # or case-insensitive "true" (str) or None. So, as a workaround, we set the type of the query parameter to generic str
-    # and do the validation/conversion afterwards).
-    # See also https://github.com/fastapi/fastapi/discussions/8966
     @validator("is_control")
     def convert_valid_is_control_values_to_bool(cls, v):
-        """Convert 'true' to boolean True; keep None as is."""
+        """
+        Convert case-insensitive values of 'true' to boolean True,
+        or raise a validation error for other string values.
+
+        TODO: If/once we migrate the n-API to Pydantic v2,
+        instead of using this approach to enforce a case-insensitive allowed value "true" and convert it to a bool,
+        we can use the new BeforeValidator method to do this directly in the query parameter definition.
+        Context: Enum and Literal both don't work well when we want allowed options of either True (bool) or None,
+        or even case-insensitive "true" (str) or None, for a FastAPI query param.
+        As a workaround, we set the type to str and do the validation/conversion afterwards.
+        See also https://github.com/fastapi/fastapi/discussions/8966
+        """
         if v is not None:
             # Ensure that the allowed value is case-insensitive
             if v.lower() != "true":

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -27,6 +27,13 @@ class QueryModel(BaseModel):
     # TODO: Check back if validating using a regex is too restrictive
     pipeline_version: constr(regex=VERSION_REGEX) = None
 
+    # TODO: If/once we migrate the n-API to Pydantic v2,
+    # instead of using the below approach to enforce a case-insensitive allowed value of "true" and convert it to a bool,
+    # we can probably use the new BeforeValidator method to do this directly in the query parameter definition.
+    # Context: Neither Enum nor Literal works as desired for enforcing True (boolean) or None only for a FastAPI query param,
+    # or case-insensitive "true" (str) or None. So, as a workaround, we set the type of the query parameter to generic str
+    # and do the validation/conversion afterwards).
+    # See also https://github.com/fastapi/fastapi/discussions/8966
     @validator("is_control")
     def convert_valid_is_control_values_to_bool(cls, v):
         """Convert 'true' to boolean True; keep None as is."""

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -48,8 +48,7 @@ class QueryModel(BaseModel):
                     status_code=422,
                     detail="'is_control' must be either set to 'true' or omitted from the query",
                 )
-            else:
-                return True
+            return True
         return None
 
     @root_validator()

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -190,18 +190,17 @@ def create_query(
             + f"{create_bound_filter(DIAGNOSIS.var)} && ?{DIAGNOSIS.var} = {diagnosis})."
         )
 
-    if is_control is not None:
-        if is_control:
-            phenotypic_session_level_filters += (
-                "\n"
-                + f"{create_bound_filter(IS_CONTROL.var)} && ?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
-            )
-        else:
-            # TODO: Revisit - this logic seems odd, since in our current data model the session should not have this edge if it's not a control.
-            phenotypic_session_level_filters += (
-                "\n"
-                + f"{create_bound_filter(IS_CONTROL.var)} && ?{IS_CONTROL.var} != {IS_CONTROL_TERM})."
-            )
+    # TODO: Simple equivalence to the URI for Healthy Control only works for the condition is_control=True,
+    # since otherwise the subject node wouldn't be expected to have the property nb:hasSubjectGroup at all.
+    # If we decide to support queries of is_control = False (i.e., give me all subjects that are *not* controls / have
+    # at least one diagnosis), we can use something like `FILTER (!BOUND(?{IS_CONTROL.var}))` to
+    # return only subjects missing the property nb:hasSubjectGroup.
+    # Related: https://github.com/neurobagel/api/issues/247
+    if is_control is True:
+        phenotypic_session_level_filters += (
+            "\n"
+            + f"{create_bound_filter(IS_CONTROL.var)} && ?{IS_CONTROL.var} = {IS_CONTROL_TERM})."
+        )
 
     if assessment is not None:
         phenotypic_session_level_filters += (

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -238,7 +238,7 @@ def test_get_invalid_diagnosis(
     assert response.status_code == 422
 
 
-@pytest.mark.parametrize("valid_iscontrol", [True, False])
+@pytest.mark.parametrize("valid_iscontrol", ["true", "True", "TRUE"])
 def test_get_valid_iscontrol(
     test_app,
     mock_successful_get,
@@ -258,16 +258,23 @@ def test_get_valid_iscontrol(
 
 
 @pytest.mark.parametrize("mock_get", [None], indirect=True)
+@pytest.mark.parametrize("invalid_iscontrol", ["false", "FALSE", "all"])
 def test_get_invalid_iscontrol(
-    test_app, mock_get, monkeypatch, mock_auth_header, set_mock_verify_token
+    test_app,
+    mock_get,
+    monkeypatch,
+    mock_auth_header,
+    set_mock_verify_token,
+    invalid_iscontrol,
 ):
     """Given a non-boolean is_control value, returns a 422 status code."""
 
     monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
-        f"{ROUTE}?is_control=apple", headers=mock_auth_header
+        f"{ROUTE}?is_control={invalid_iscontrol}", headers=mock_auth_header
     )
     assert response.status_code == 422
+    assert "must be either set to 'true' or omitted" in response.text
 
 
 @pytest.mark.parametrize("mock_get", [None], indirect=True)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 
 import app.api.utility as util
 from app.api import crud
+from app.api.models import QueryModel
 
 ROUTE = "/query"
 
@@ -255,6 +256,14 @@ def test_get_valid_iscontrol(
     )
     assert response.status_code == 200
     assert response.json() != []
+
+
+@pytest.mark.parametrize("valid_iscontrol", ["true", "True", "TRUE"])
+def test_valid_iscontrol_parsed_as_bool(valid_iscontrol):
+    """Test that valid is_control values do not produce a validation error and are parsed as booleans."""
+
+    example_query = QueryModel(is_control=valid_iscontrol)
+    assert example_query.is_control is True
 
 
 @pytest.mark.parametrize("mock_get", [None], indirect=True)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -276,7 +276,7 @@ def test_get_invalid_iscontrol(
     set_mock_verify_token,
     invalid_iscontrol,
 ):
-    """Given a non-boolean is_control value, returns a 422 status code."""
+    """Given an invalid is_control value, returns a 422 status code and informative error."""
 
     monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #332 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- `is_control` query param now accepts `str`, with allowed values being either `"true"` (case-insensitive) or `None` via custom validation
  - `str` used b/c using `Literal` to enforce allowed values of `True` or `None` doesn't play well in a query parameter (see comment in code)
  - `"true"` values transformed to boolean internally
- SPARQL query now only adds filter if `is_control=True` in query

Note: the default SPARQL query file hasn't changed in this case b/c it assumes no filters are applied

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
