### PR TITLE
[ENH] Make `root_path` for app configurable

### DIFF
--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -10,6 +10,10 @@ from typing import Optional
 # Request constants
 EnvVar = namedtuple("EnvVar", ["name", "val"])
 
+ROOT_PATH = EnvVar(
+    "NB_NAPI_ROOT_PATH", os.environ.get("NB_NAPI_ROOT_PATH", "")
+)
+
 ALLOWED_ORIGINS = EnvVar(
     "NB_API_ALLOWED_ORIGINS", os.environ.get("NB_API_ALLOWED_ORIGINS", "")
 )

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -25,12 +25,12 @@ GRAPH_PASSWORD = EnvVar(
     "NB_GRAPH_PASSWORD", os.environ.get("NB_GRAPH_PASSWORD")
 )
 GRAPH_ADDRESS = EnvVar(
-    "NB_GRAPH_ADDRESS", os.environ.get("NB_GRAPH_ADDRESS", "206.12.99.17")
+    "NB_GRAPH_ADDRESS", os.environ.get("NB_GRAPH_ADDRESS", "127.0.0.1")
 )
 GRAPH_DB = EnvVar(
-    "NB_GRAPH_DB", os.environ.get("NB_GRAPH_DB", "test_data/query")
+    "NB_GRAPH_DB", os.environ.get("NB_GRAPH_DB", "repositories/my_db")
 )
-GRAPH_PORT = EnvVar("NB_GRAPH_PORT", os.environ.get("NB_GRAPH_PORT", 5820))
+GRAPH_PORT = EnvVar("NB_GRAPH_PORT", os.environ.get("NB_GRAPH_PORT", 7200))
 # TODO: Environment variables can't be parsed as bool so this is a workaround but isn't ideal.
 # Another option is to switch this to a command-line argument, but that would require changing the
 # Dockerfile also since Uvicorn can't accept custom command-line args.

--- a/app/main.py
+++ b/app/main.py
@@ -104,8 +104,6 @@ async def auth_check():
 async def allowed_origins_check():
     """Raises warning if allowed origins environment variable has not been set or is an empty string."""
     if os.environ.get(util.ALLOWED_ORIGINS.name, "") == "":
-        # TODO: For debugging - remove
-        print(util.ROOT_PATH.val)
         warnings.warn(
             f"The API was launched without providing any values for the {util.ALLOWED_ORIGINS.name} environment variable. "
             "This means that the API will only be accessible from the same origin it is hosted from: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy. "

--- a/app/main.py
+++ b/app/main.py
@@ -42,7 +42,7 @@ def root(request: Request):
     <html>
         <body>
             <h1>Welcome to the Neurobagel REST API!</h1>
-            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">documentation</a> to view available API endpoints.</p>
+            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">API documentation</a> to view available API endpoints.</p>
         </body>
     </html>
     """

--- a/app/main.py
+++ b/app/main.py
@@ -34,15 +34,15 @@ app.add_middleware(
 
 
 @app.get("/", response_class=HTMLResponse)
-def root():
+def root(request: Request):
     """
     Display a welcome message and a link to the API documentation.
     """
-    return """
+    return f"""
     <html>
         <body>
             <h1>Welcome to the Neurobagel REST API!</h1>
-            <p>Please visit the <a href="/docs">documentation</a> to view available API endpoints.</p>
+            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">documentation</a> to view available API endpoints.</p>
         </body>
     </html>
     """
@@ -61,9 +61,8 @@ def overridden_swagger(request: Request):
     """
     Overrides the Swagger UI HTML for the "/docs" endpoint.
     """
-    root_path = request.scope.get("root_path", "")
     return get_swagger_ui_html(
-        openapi_url=f"{root_path}/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel API",
         swagger_favicon_url=favicon_url,
     )
@@ -74,9 +73,8 @@ def overridden_redoc(request: Request):
     """
     Overrides the Redoc HTML for the "/redoc" endpoint.
     """
-    root_path = request.scope.get("root_path", "")
     return get_redoc_html(
-        openapi_url=f"{root_path}/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel API",
         redoc_favicon_url=favicon_url,
     )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -10,13 +10,13 @@ from app.main import app
 )
 def test_root(test_app, route, monkeypatch):
     """Given a GET request to the root endpoint, Check for 200 status and expected content."""
-    # root_path determines the docs link on the welcome page
+    # root_path determines the path prefix for the docs link on the welcome page
     monkeypatch.setattr(app, "root_path", "")
     response = test_app.get(route, follow_redirects=False)
 
     assert response.status_code == 200
     assert "Welcome to the Neurobagel REST API!" in response.text
-    assert '<a href="/docs">documentation</a>' in response.text
+    assert '<a href="/docs">API documentation</a>' in response.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #392
- Closes #356 

- Todo: https://github.com/neurobagel/recipes/issues/102
<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- The root path for the FastAPI app is now configurable via an optional environment variable `NB_NAPI_ROOT_PATH`
  - Meant for use in deployment scenarios with proxy servers that use a stripped path prefix

To test the behaviour locally using NGINX, I followed these steps:

1. Install NGINX:
```bash
sudo apt update && sudo apt install nginx
```
2. Create an NGINX config file for the host in `/etc/nginx/sites-available/fastapi_test`:
```
server {
    listen 8080; # Nginx will listen on port 8080 locally

    location /api/ {
        proxy_pass http://127.0.0.1:8000/; # Forward to FastAPI app and strip `/api`
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Prefix /api;
    }
}
```
3. Apply changes
```bash
sudo service nginx restart
```
5. Set environment variables including `NB_NAPI_ROOT_PATH=/api` and launch FastAPI app locally
6. As a check, ensure that the following URLs work:
- http://127.0.0.1:8080/api/
- http://127.0.0.1:8080/api/docs
- http://127.0.0.1:8080/api/assessments/vocab

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Make the root path for the app configurable via the NB_NAPI_ROOT_PATH environment variable. Update the documentation links to reflect the configured root path.

Enhancements:
- Update the root endpoint to handle requests with or without a trailing slash.

Tests:
- Add tests to verify that the documentation works correctly with the defined root path.