### PR TITLE
[REF] Move environment variable handling to Pydantic `BaseSettings` class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           - --safe
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
       - id: flake8
         language_version: python3

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Neurobagel API
 
-![GitHub branch check runs](https://img.shields.io/github/check-runs/neurobagel/api/main?style=flat-square)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/neurobagel/api/test.yaml?branch=main&style=flat-square&label=tests)
-![Codecov](https://img.shields.io/codecov/c/github/neurobagel/api?token=ZEOGQFFZMJ&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Fapi)
-![Static Badge](https://img.shields.io/badge/python-3.10-blue?style=flat-square&logo=python)
-![GitHub License](https://img.shields.io/github/license/neurobagel/api?style=flat-square&color=purple&link=LICENSE)
-![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/api/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fapi%2Ftags)
-![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/api?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fapi%2Ftags)
+[![Main branch check status](https://img.shields.io/github/check-runs/neurobagel/api/main?style=flat-square)](https://github.com/neurobagel/api/actions?query=branch:main)
+[![Tests Status](https://img.shields.io/github/actions/workflow/status/neurobagel/api/test.yaml?branch=main&style=flat-square&label=tests)](https://github.com/neurobagel/api/actions/workflows/test.yaml)
+[![Codecov](https://img.shields.io/codecov/c/github/neurobagel/api?token=ZEOGQFFZMJ&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Fapi)](https://app.codecov.io/gh/neurobagel/api)
+[![Python versions static](https://img.shields.io/badge/python-3.10-blue?style=flat-square&logo=python)](https://www.python.org)
+[![License](https://img.shields.io/github/license/neurobagel/api?style=flat-square&color=purple&link=LICENSE)](LICENSE)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/api/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fapi%2Ftags)](https://hub.docker.com/r/neurobagel/api/tags)
+[![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/api?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fapi%2Ftags)](https://hub.docker.com/r/neurobagel/api/tags)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Neurobagel API
 
-[![Main branch check status](https://img.shields.io/github/check-runs/neurobagel/api/main?style=flat-square)](https://github.com/neurobagel/api/actions?query=branch:main)
-[![Tests Status](https://img.shields.io/github/actions/workflow/status/neurobagel/api/test.yaml?branch=main&style=flat-square&label=tests)](https://github.com/neurobagel/api/actions/workflows/test.yaml)
+[![Main branch check status](https://img.shields.io/github/check-runs/neurobagel/api/main?style=flat-square&logo=github)](https://github.com/neurobagel/api/actions?query=branch:main)
+[![Tests Status](https://img.shields.io/github/actions/workflow/status/neurobagel/api/test.yaml?branch=main&style=flat-square&logo=github&label=tests)](https://github.com/neurobagel/api/actions/workflows/test.yaml)
 [![Codecov](https://img.shields.io/codecov/c/github/neurobagel/api?token=ZEOGQFFZMJ&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Fapi)](https://app.codecov.io/gh/neurobagel/api)
 [![Python versions static](https://img.shields.io/badge/python-3.10-blue?style=flat-square&logo=python)](https://www.python.org)
 [![License](https://img.shields.io/github/license/neurobagel/api?style=flat-square&color=purple&link=LICENSE)](LICENSE)

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,5 +1,5 @@
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -7,13 +7,13 @@ class Settings(BaseSettings):
 
     # TODO: Make case-sensitive?
     # We don't want Pydantic errors to be raised when the environment variables are not set
-    model_config = SettingsConfigDict(validate_default=False)
+    # model_config = SettingsConfigDict(validate_default=False)
 
     root_path: str = Field(alias="NB_NAPI_BASE_PATH", default="")
     allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
     # TODO: Figure out what to do about defaults for username/password
-    graph_username: str = Field(alias="NB_GRAPH_USERNAME", default=None)
-    graph_password: str = Field(alias="NB_GRAPH_PASSWORD", default=None)
+    graph_username: str | None = Field(alias="NB_GRAPH_USERNAME", default=None)
+    graph_password: str | None = Field(alias="NB_GRAPH_PASSWORD", default=None)
     graph_address: str = Field(alias="NB_GRAPH_ADDRESS", default="127.0.0.1")
     graph_db: str = Field(alias="NB_GRAPH_DB", default="repositories/my_db")
     graph_port: int = Field(alias="NB_GRAPH_PORT", default=7200)
@@ -22,9 +22,9 @@ class Settings(BaseSettings):
     # Double check how this is parsed from environment
     min_cell_size: int = Field(alias="NB_MIN_CELL_SIZE", default=0)
     auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=True)
-    client_id: str = Field(alias="NB_QUERY_CLIENT_ID", default=None)
+    client_id: str | None = Field(alias="NB_QUERY_CLIENT_ID", default=None)
 
-    # TODO: Add query url and query header?
+    # TODO: Add query url as computed field and query header as constant
 
 
 settings = Settings()

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings
 
 
@@ -6,9 +6,6 @@ class Settings(BaseSettings):
     """Data model for settings."""
 
     # TODO: Make case-sensitive?
-    # We don't want Pydantic errors to be raised when the environment variables are not set
-    # model_config = SettingsConfigDict(validate_default=False)
-
     root_path: str = Field(alias="NB_NAPI_BASE_PATH", default="")
     allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
     # TODO: Figure out what to do about defaults for username/password
@@ -24,7 +21,9 @@ class Settings(BaseSettings):
     auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=True)
     client_id: str | None = Field(alias="NB_QUERY_CLIENT_ID", default=None)
 
-    # TODO: Add query url as computed field and query header as constant
+    @computed_field
+    def query_url(self) -> str:
+        return f"http://{self.graph_address}:{self.graph_port}/{self.graph_db}"
 
 
 settings = Settings()

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     client_id: str | None = Field(alias="NB_QUERY_CLIENT_ID", default=None)
 
     @computed_field
+    @property
     def query_url(self) -> str:
         """Construct the URL of the graph store to be queried."""
         return f"http://{self.graph_address}:{self.graph_port}/{self.graph_db}"

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,0 +1,17 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Data model for settings."""
+
+    nb_napi_base_path: str = ""
+    nb_api_allowed_origins: str = ""
+    nb_graph_username: str
+    nb_graph_password: str
+    nb_graph_address: str = "127.0.0.1"
+    nb_graph_db: str = "repositories/my_db"
+    nb_graph_port: int = 7200
+    # Double check how this is parsed from environment
+    nb_return_agg: bool = True
+    # Double check how this is parsed from environment
+    nb_min_cell_size: int = 0

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,28 +1,29 @@
+"""Configuration environment variables for the API."""
+
 from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    """Data model for settings."""
+    """Data model for configurable API settings."""
 
-    # TODO: Make case-sensitive?
+    # NOTE: Environment variables are case-insensitive by default
+    # (see https://docs.pydantic.dev/latest/concepts/pydantic_settings/#case-sensitivity)
     root_path: str = Field(alias="NB_NAPI_BASE_PATH", default="")
     allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
-    # TODO: Figure out what to do about defaults for username/password
     graph_username: str | None = Field(alias="NB_GRAPH_USERNAME", default=None)
     graph_password: str | None = Field(alias="NB_GRAPH_PASSWORD", default=None)
     graph_address: str = Field(alias="NB_GRAPH_ADDRESS", default="127.0.0.1")
     graph_db: str = Field(alias="NB_GRAPH_DB", default="repositories/my_db")
     graph_port: int = Field(alias="NB_GRAPH_PORT", default=7200)
-    # Double check how this is parsed from environment
     return_agg: bool = Field(alias="NB_RETURN_AGG", default=True)
-    # Double check how this is parsed from environment
     min_cell_size: int = Field(alias="NB_MIN_CELL_SIZE", default=0)
     auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=True)
     client_id: str | None = Field(alias="NB_QUERY_CLIENT_ID", default=None)
 
     @computed_field
     def query_url(self) -> str:
+        """Construct the URL of the graph store to be queried."""
         return f"http://{self.graph_address}:{self.graph_port}/{self.graph_db}"
 
 

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -9,7 +9,11 @@ class Settings(BaseSettings):
 
     # NOTE: Environment variables are case-insensitive by default
     # (see https://docs.pydantic.dev/latest/concepts/pydantic_settings/#case-sensitivity)
-    root_path: str = Field(alias="NB_NAPI_BASE_PATH", default="")
+    root_path: str = Field(
+        alias="NB_NAPI_BASE_PATH",
+        default="",
+        description="The base URL path prefix for the API. When deployed behind a reverse proxy, set this to the subpath at which the app is mounted (if any), and configure the proxy to strip this prefix from incoming requests.",
+    )
     allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
     graph_username: str | None = Field(alias="NB_GRAPH_USERNAME", default=None)
     graph_password: str | None = Field(alias="NB_GRAPH_PASSWORD", default=None)

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,17 +1,30 @@
-from pydantic_settings import BaseSettings
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Data model for settings."""
 
-    nb_napi_base_path: str = ""
-    nb_api_allowed_origins: str = ""
-    nb_graph_username: str
-    nb_graph_password: str
-    nb_graph_address: str = "127.0.0.1"
-    nb_graph_db: str = "repositories/my_db"
-    nb_graph_port: int = 7200
+    # TODO: Make case-sensitive?
+    # We don't want Pydantic errors to be raised when the environment variables are not set
+    model_config = SettingsConfigDict(validate_default=False)
+
+    root_path: str = Field(alias="NB_NAPI_BASE_PATH", default="")
+    allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
+    # TODO: Figure out what to do about defaults for username/password
+    graph_username: str = Field(alias="NB_GRAPH_USERNAME", default=None)
+    graph_password: str = Field(alias="NB_GRAPH_PASSWORD", default=None)
+    graph_address: str = Field(alias="NB_GRAPH_ADDRESS", default="127.0.0.1")
+    graph_db: str = Field(alias="NB_GRAPH_DB", default="repositories/my_db")
+    graph_port: int = Field(alias="NB_GRAPH_PORT", default=7200)
     # Double check how this is parsed from environment
-    nb_return_agg: bool = True
+    return_agg: bool = Field(alias="NB_RETURN_AGG", default=True)
     # Double check how this is parsed from environment
-    nb_min_cell_size: int = 0
+    min_cell_size: int = Field(alias="NB_MIN_CELL_SIZE", default=0)
+    auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=True)
+    client_id: str = Field(alias="NB_QUERY_CLIENT_ID", default=None)
+
+    # TODO: Add query url and query header?
+
+
+settings = Settings()

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -41,7 +41,7 @@ def post_query_to_graph(query: str, timeout: float = None) -> dict:
     """
     try:
         response = httpx.post(
-            url=util.QUERY_URL,
+            url=settings.query_url,
             content=query,
             headers=util.QUERY_HEADER,
             auth=httpx.BasicAuth(

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException, status
 from . import utility as util
 from .models import CohortQueryResponse, SessionResponse, VocabLabelsResponse
 
-ALL_SUBJECT_ATTRIBUTES = list(SessionResponse.__fields__.keys()) + [
+ALL_SUBJECT_ATTRIBUTES = list(SessionResponse.model_fields.keys()) + [
     "dataset_uuid",
     "dataset_name",
     "dataset_portal_uri",

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -5,7 +5,8 @@ from typing import Annotated, List
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.security import OAuth2
 
-from .. import crud, security
+from .. import crud
+from ..config import settings
 from ..models import CohortQueryResponse, QueryModel
 from ..security import verify_token
 
@@ -36,7 +37,7 @@ async def get_query(
     token: str | None = Depends(oauth2_scheme),
 ):
     """When a GET request is sent, return list of dicts corresponding to subject-level metadata aggregated by dataset."""
-    if security.AUTH_ENABLED:
+    if settings.auth_enabled:
         if token is None:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -7,6 +7,8 @@ from fastapi import HTTPException, status
 from fastapi.security.utils import get_authorization_scheme_param
 from jwt import PyJWKClient, PyJWTError
 
+from .config import Settings, settings
+
 AUTH_ENABLED = os.environ.get("NB_ENABLE_AUTH", "True").lower() == "true"
 CLIENT_ID = os.environ.get("NB_QUERY_CLIENT_ID", None)
 
@@ -21,9 +23,9 @@ JWKS_CLIENT = PyJWKClient(KEYS_URL)
 def check_client_id():
     """Check if the CLIENT_ID environment variable is set."""
     # The CLIENT_ID is needed to verify the audience claim of ID tokens.
-    if AUTH_ENABLED and CLIENT_ID is None:
+    if settings.auth_enabled and settings.client_id is None:
         raise RuntimeError(
-            "Authentication has been enabled (NB_ENABLE_AUTH) but the environment variable NB_QUERY_CLIENT_ID is not set. "
+            f"Authentication has been enabled ({Settings.model_fields['auth_enabled'].alias}) but the environment variable NB_QUERY_CLIENT_ID is not set. "
             "Please set NB_QUERY_CLIENT_ID to the client ID for your Neurobagel query tool deployment, to verify the audience claim of ID tokens."
         )
 

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -20,8 +20,8 @@ def check_client_id():
     # The client ID is needed to verify the audience claim of ID tokens.
     if settings.auth_enabled and settings.client_id is None:
         raise RuntimeError(
-            f"Authentication has been enabled ({Settings.model_fields['auth_enabled'].alias}) but the environment variable NB_QUERY_CLIENT_ID is not set. "
-            "Please set NB_QUERY_CLIENT_ID to the client ID for your Neurobagel query tool deployment, to verify the audience claim of ID tokens."
+            f"Authentication has been enabled ({Settings.model_fields['auth_enabled'].alias}) but the environment variable {Settings.model_fields['client_id'].alias} is not set. "
+            f"Please set {Settings.model_fields['client_id'].alias} to the client ID for your Neurobagel query tool deployment, to verify the audience claim of ID tokens."
         )
 
 

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -1,16 +1,11 @@
 """Functions for handling authentication. Same ones as used in Neurobagel's federation API."""
 
-import os
-
 import jwt
 from fastapi import HTTPException, status
 from fastapi.security.utils import get_authorization_scheme_param
 from jwt import PyJWKClient, PyJWTError
 
 from .config import Settings, settings
-
-AUTH_ENABLED = os.environ.get("NB_ENABLE_AUTH", "True").lower() == "true"
-CLIENT_ID = os.environ.get("NB_QUERY_CLIENT_ID", None)
 
 KEYS_URL = "https://neurobagel.ca.auth0.com/.well-known/jwks.json"
 ISSUER = "https://neurobagel.ca.auth0.com/"
@@ -21,8 +16,8 @@ JWKS_CLIENT = PyJWKClient(KEYS_URL)
 
 
 def check_client_id():
-    """Check if the CLIENT_ID environment variable is set."""
-    # The CLIENT_ID is needed to verify the audience claim of ID tokens.
+    """Check if the app client ID environment variable is set."""
+    # The client ID is needed to verify the audience claim of ID tokens.
     if settings.auth_enabled and settings.client_id is None:
         raise RuntimeError(
             f"Authentication has been enabled ({Settings.model_fields['auth_enabled'].alias}) but the environment variable NB_QUERY_CLIENT_ID is not set. "
@@ -49,7 +44,7 @@ def verify_token(token: str):
                 "verify_signature": True,
                 "require": ["aud", "iss", "exp", "iat"],
             },
-            audience=CLIENT_ID,
+            audience=settings.client_id,
             issuer=ISSUER,
         )
     except (PyJWTError, ValueError) as exc:

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -1,23 +1,11 @@
 """Constants for graph server connection and utility functions for writing the SPARQL query."""
 
 import json
-import os
 import textwrap
 from collections import namedtuple
 from pathlib import Path
 from typing import Optional
 
-# Request constants
-EnvVar = namedtuple("EnvVar", ["name", "val"])
-GRAPH_ADDRESS = EnvVar(
-    "NB_GRAPH_ADDRESS", os.environ.get("NB_GRAPH_ADDRESS", "127.0.0.1")
-)
-GRAPH_DB = EnvVar(
-    "NB_GRAPH_DB", os.environ.get("NB_GRAPH_DB", "repositories/my_db")
-)
-GRAPH_PORT = EnvVar("NB_GRAPH_PORT", os.environ.get("NB_GRAPH_PORT", 7200))
-
-QUERY_URL = f"http://{GRAPH_ADDRESS.val}:{GRAPH_PORT.val}/{GRAPH_DB.val}"
 QUERY_HEADER = {
     "Content-Type": "application/sparql-query",
     "Accept": "application/sparql-results+json",

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -9,21 +9,6 @@ from typing import Optional
 
 # Request constants
 EnvVar = namedtuple("EnvVar", ["name", "val"])
-
-ROOT_PATH = EnvVar(
-    "NB_NAPI_BASE_PATH", os.environ.get("NB_NAPI_BASE_PATH", "")
-)
-
-ALLOWED_ORIGINS = EnvVar(
-    "NB_API_ALLOWED_ORIGINS", os.environ.get("NB_API_ALLOWED_ORIGINS", "")
-)
-
-GRAPH_USERNAME = EnvVar(
-    "NB_GRAPH_USERNAME", os.environ.get("NB_GRAPH_USERNAME")
-)
-GRAPH_PASSWORD = EnvVar(
-    "NB_GRAPH_PASSWORD", os.environ.get("NB_GRAPH_PASSWORD")
-)
 GRAPH_ADDRESS = EnvVar(
     "NB_GRAPH_ADDRESS", os.environ.get("NB_GRAPH_ADDRESS", "127.0.0.1")
 )
@@ -31,15 +16,6 @@ GRAPH_DB = EnvVar(
     "NB_GRAPH_DB", os.environ.get("NB_GRAPH_DB", "repositories/my_db")
 )
 GRAPH_PORT = EnvVar("NB_GRAPH_PORT", os.environ.get("NB_GRAPH_PORT", 7200))
-# TODO: Environment variables can't be parsed as bool so this is a workaround but isn't ideal.
-# Another option is to switch this to a command-line argument, but that would require changing the
-# Dockerfile also since Uvicorn can't accept custom command-line args.
-RETURN_AGG = EnvVar(
-    "NB_RETURN_AGG", os.environ.get("NB_RETURN_AGG", "True").lower() == "true"
-)
-MIN_CELL_SIZE = EnvVar(
-    "NB_MIN_CELL_SIZE", int(os.environ.get("NB_MIN_CELL_SIZE", 0))
-)
 
 QUERY_URL = f"http://{GRAPH_ADDRESS.val}:{GRAPH_PORT.val}/{GRAPH_DB.val}"
 QUERY_HEADER = {
@@ -303,7 +279,7 @@ def create_query(
     """
     )
 
-    # The query defined above will return all subject-level attributes from the graph. If RETURN_AGG variable has been set to true,
+    # The query defined above will return all subject-level attributes from the graph. If aggregate results have been enabled,
     # wrap query in an aggregating statement so data returned from graph include only attributes needed for dataset-level aggregate metadata.
     if return_agg:
         query_string = (

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ def validate_environment_variables():
     Ensures that the username and password for the graph database are provided.
     If not, raises a RuntimeError to prevent the application from running without valid credentials.
 
-    Also checks that ALLOWED_ORIGINS is properly set. If missing, a warning is issued, but the app continues running.
+    Also checks that allowed origins are properly set. If missing, a warning is issued, but the app continues running.
     """
     if settings.graph_username is None or settings.graph_password is None:
         raise RuntimeError(

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 import os
 import warnings
+from functools import lru_cache
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -12,6 +13,7 @@ from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse, ORJSONResponse, RedirectResponse
 
 from .api import utility as util
+from .api.config import Settings
 from .api.routers import assessments, attributes, diagnoses, pipelines, query
 from .api.security import check_client_id
 
@@ -31,6 +33,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@lru_cache
+def get_settings():
+    return Settings()
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,6 @@
 
 import warnings
 from contextlib import asynccontextmanager
-
-# from functools import lru_cache
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -17,10 +15,6 @@ from .api import utility as util
 from .api.config import Settings, settings
 from .api.routers import assessments, attributes, diagnoses, pipelines, query
 from .api.security import check_client_id
-
-# @lru_cache
-# def get_settings():
-#     return Settings()
 
 
 def validate_environment_variables():

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,11 @@ markers =
     integration: mark integration tests that need the test graph to run
 ; Default to not running tests with the integration marker
 addopts = -m "not integration"
-; Note: The following environment variables are set before any tests
+; NOTE: The following environment variables are set to non-default values before any tests are run,
+; allowing us to actually test that user-provided values are parsed accurately from the environment
+; while avoiding issues related to import order in tests.
+; In individual tests, these values may then be overridden as needed to test downstream logic
+; by monkeypatching attributes of the global settings object
 env =
     NB_API_ALLOWED_ORIGINS=*
     NB_GRAPH_USERNAME=DBUSER

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,8 +6,11 @@ addopts = -m "not integration"
 ; Note: The following environment variables are set before any tests
 env =
     NB_API_ALLOWED_ORIGINS=*
-    NB_GRAPH_USERNAME=bic_user
-    NB_GRAPH_PASSWORD=12345
+    NB_GRAPH_USERNAME=DBUSER
+    NB_GRAPH_PASSWORD=DBPASSWORD
     NB_GRAPH_PORT=7201
     NB_RETURN_AGG=False
+    ; NOTE: We set the minimum cell size to a different value than the default (0) here
+    ; to confirm that it is still read in correctly as an int
+    ; but we choose 1 so as to avoid filtering out any results being returned as part of the tests
     NB_MIN_CELL_SIZE=1

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,10 @@ markers =
     integration: mark integration tests that need the test graph to run
 ; Default to not running tests with the integration marker
 addopts = -m "not integration"
+env =
+    NB_API_ALLOWED_ORIGINS=*
+    NB_GRAPH_USERNAME=bic_user
+    NB_GRAPH_PASSWORD=12345
+    NB_GRAPH_PORT=7201
+    NB_RETURN_AGG=False
+    NB_MIN_CELL_SIZE=5

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,10 +3,11 @@ markers =
     integration: mark integration tests that need the test graph to run
 ; Default to not running tests with the integration marker
 addopts = -m "not integration"
+; Note: The following environment variables are set before any tests
 env =
     NB_API_ALLOWED_ORIGINS=*
     NB_GRAPH_USERNAME=bic_user
     NB_GRAPH_PASSWORD=12345
     NB_GRAPH_PORT=7201
     NB_RETURN_AGG=False
-    NB_MIN_CELL_SIZE=5
+    NB_MIN_CELL_SIZE=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ orjson==3.9.15
 packaging==21.3
 pandas==1.5.2
 platformdirs==2.5.4
-pluggy==1.0.0
+pluggy==1.5.0
 pre-commit==3.6.0
 pyasn1==0.6.0
 pyasn1_modules==0.4.0
@@ -36,7 +36,8 @@ pydantic-settings==2.7.1
 pydantic_core==2.27.2
 PyJWT==2.10.1
 pyparsing==3.0.9
-pytest==7.2.0
+pytest==8.3.4
+pytest-env==1.1.5
 python-dateutil==2.8.2
 python-dotenv==1.0.1
 pytz==2022.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 import pytest
 from starlette.testclient import TestClient
 
-from app.api import utility as util
-from app.main import app
+from app.main import app, settings
 
 
 @pytest.fixture(scope="module")
@@ -14,7 +13,7 @@ def test_app():
 @pytest.fixture
 def enable_auth(monkeypatch):
     """Enable the authentication requirement for the API."""
-    monkeypatch.setattr("app.api.security.AUTH_ENABLED", True)
+    monkeypatch.setattr(settings, "auth_enabled", True)
 
 
 @pytest.fixture
@@ -23,14 +22,15 @@ def disable_auth(monkeypatch):
     Disable the authentication requirement for the API to skip startup checks
     (for when the tested route does not require authentication).
     """
-    monkeypatch.setattr("app.api.security.AUTH_ENABLED", False)
+    monkeypatch.setattr(settings, "auth_enabled", False)
 
 
+# TODO: See if we can remove this fixture now that we are using pytest.ini
 @pytest.fixture(scope="function")
 def set_test_credentials(monkeypatch):
     """Set random username and password to avoid error from startup check for set credentials."""
-    monkeypatch.setenv(util.GRAPH_USERNAME.name, "DBUSER")
-    monkeypatch.setenv(util.GRAPH_PASSWORD.name, "DBPASSWORD")
+    monkeypatch.setattr(settings, "graph_username", "DBUSER")
+    monkeypatch.setattr(settings, "graph_password", "DBPASSWORD")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,14 +25,6 @@ def disable_auth(monkeypatch):
     monkeypatch.setattr(settings, "auth_enabled", False)
 
 
-# TODO: See if we can remove this fixture now that we are using pytest.ini
-@pytest.fixture(scope="function")
-def set_test_credentials(monkeypatch):
-    """Set random username and password to avoid error from startup check for set credentials."""
-    monkeypatch.setattr(settings, "graph_username", "DBUSER")
-    monkeypatch.setattr(settings, "graph_password", "DBPASSWORD")
-
-
 @pytest.fixture()
 def mock_verify_token():
     """Mock a successful token verification that does not raise any exceptions."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,19 @@ def mock_auth_header() -> dict:
 
 
 @pytest.fixture()
+def set_graph_url_vars_for_integration_tests(monkeypatch):
+    """
+    Set the graph URL to the default value for integration tests.
+
+    NOTE: These should correspond to the default configuration values, but are set explicitly here for clarity and
+    to override any environment defined in pytest.ini.
+    """
+    monkeypatch.setattr(settings, "graph_address", "localhost")
+    monkeypatch.setattr(settings, "graph_port", 7200)
+    monkeypatch.setattr(settings, "graph_db", "repositories/my_db")
+
+
+@pytest.fixture()
 def test_data():
     """Create valid aggregate response data for two toy datasets for testing."""
     return [

--- a/tests/test_app_events.py
+++ b/tests/test_app_events.py
@@ -2,7 +2,6 @@
 
 import warnings
 
-import httpx
 import pytest
 
 from app.api import utility as util
@@ -24,26 +23,6 @@ def test_start_app_without_environment_vars_fails(
         "could not find the NB_GRAPH_USERNAME and / or NB_GRAPH_PASSWORD environment variables"
         in str(e_info.value)
     )
-
-
-# TODO: Check that this test is actually useful - it assumes that a graph user already exists.
-# This would probably make more sense as an integration test
-# Previously, this test was likely passing because the monkeypatched environment variables were not actually being used
-# due to import order issues?
-@pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
-def test_app_with_invalid_environment_vars(
-    test_app, monkeypatch, mock_auth_header, set_mock_verify_token
-):
-    """Given invalid environment variables for the graph, returns a 401 status code."""
-    monkeypatch.setattr(settings, "graph_username", "something")
-    monkeypatch.setattr(settings, "graph_password", "cool")
-
-    def mock_httpx_post(**kwargs):
-        return httpx.Response(status_code=401)
-
-    monkeypatch.setattr(httpx, "post", mock_httpx_post)
-    response = test_app.get("/query", headers=mock_auth_header)
-    assert response.status_code == 401
 
 
 def test_app_with_unset_allowed_origins(

--- a/tests/test_app_events.py
+++ b/tests/test_app_events.py
@@ -35,8 +35,8 @@ def test_app_with_invalid_environment_vars(
     test_app, monkeypatch, mock_auth_header, set_mock_verify_token
 ):
     """Given invalid environment variables for the graph, returns a 401 status code."""
-    monkeypatch.setenv(util.GRAPH_USERNAME.name, "something")
-    monkeypatch.setenv(util.GRAPH_PASSWORD.name, "cool")
+    monkeypatch.setattr(settings, "graph_username", "something")
+    monkeypatch.setattr(settings, "graph_password", "cool")
 
     def mock_httpx_post(**kwargs):
         return httpx.Response(status_code=401)

--- a/tests/test_attribute_factory_routes.py
+++ b/tests/test_attribute_factory_routes.py
@@ -7,7 +7,6 @@ from app.api import utility as util
 def test_get_instances_endpoint_with_vocab_lookup(
     test_app,
     monkeypatch,
-    set_test_credentials,
     # Since this test runs the API startup events to fetch the vocabularies used in the test,
     # we need to disable auth to avoid startup errors about unset auth-related environment variables.
     disable_auth,
@@ -68,9 +67,7 @@ def test_get_instances_endpoint_with_vocab_lookup(
     }
 
 
-def test_get_instances_endpoint_without_vocab_lookup(
-    test_app, monkeypatch, set_test_credentials
-):
+def test_get_instances_endpoint_without_vocab_lookup(test_app, monkeypatch):
     """
     Given a GET request to /pipelines/ (attribute without a vocabulary lookup file available),
     test that the endpoint correctly returns the found graph instances as prefixed term URIs with empty label fields.
@@ -130,7 +127,6 @@ def test_get_instances_endpoint_without_vocab_lookup(
 def test_get_vocab_endpoint(
     test_app,
     monkeypatch,
-    set_test_credentials,
     attribute,
     expected_vocab_name,
     expected_namespace_pfx,

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -6,7 +6,6 @@ import httpx
 def test_get_attributes(
     test_app,
     monkeypatch,
-    set_test_credentials,
 ):
     """Given a GET request to the /attributes endpoint, successfully returns controlled term attributes with namespaces abbrieviated and as a list."""
     mock_response_json = {

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -3,9 +3,7 @@ from app.api import crud
 BASE_ROUTE = "/pipelines"
 
 
-def test_get_pipeline_versions_response(
-    test_app, monkeypatch, set_test_credentials
-):
+def test_get_pipeline_versions_response(test_app, monkeypatch):
     """
     Given a request to /pipelines/{pipeline_term}/versions with a valid pipeline name,
     returns a dict where the key is the pipeline resource and the value is a list of pipeline versions.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,7 +3,6 @@
 import pytest
 from fastapi import HTTPException
 
-import app.api.utility as util
 from app.api import crud
 from app.api.models import QueryModel
 from app.main import settings
@@ -656,10 +655,10 @@ def test_integration_query_without_auth_succeeds(
     Running a test against a real local test graph
     should succeed when authentication is disabled.
     """
-    # Patching the QUERY_URL directly means we don't need to worry about the constituent
+    # Patching the query URL directly means we don't need to worry about the constituent
     # graph environment variables
     monkeypatch.setattr(
-        util, "QUERY_URL", "http://localhost:7200/repositories/my_db"
+        settings, "query_url", "http://localhost:7200/repositories/my_db"
     )
 
     response = test_app.get(ROUTE)
@@ -735,7 +734,7 @@ def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
     """
     monkeypatch.setattr(settings, "return_agg", False)
     monkeypatch.setattr(
-        util, "QUERY_URL", "http://localhost:7200/repositories/my_db"
+        settings, "query_url", "http://localhost:7200/repositories/my_db"
     )
 
     response = test_app.get(ROUTE)
@@ -764,7 +763,7 @@ def test_min_cell_size_removes_results(test_app, monkeypatch, disable_auth):
     """
     monkeypatch.setattr(settings, "min_cell_size", 100)
     monkeypatch.setattr(
-        util, "QUERY_URL", "http://localhost:7200/repositories/my_db"
+        settings, "query_url", "http://localhost:7200/repositories/my_db"
     )
 
     response = test_app.get(ROUTE)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -649,18 +649,15 @@ def test_query_without_token_succeeds_when_auth_disabled(
 
 @pytest.mark.integration
 def test_integration_query_without_auth_succeeds(
-    test_app, monkeypatch, disable_auth
+    test_app,
+    monkeypatch,
+    disable_auth,
+    set_graph_url_vars_for_integration_tests,
 ):
     """
     Running a test against a real local test graph
     should succeed when authentication is disabled.
     """
-    # Patching the query URL directly means we don't need to worry about the constituent
-    # graph environment variables
-    monkeypatch.setattr(
-        settings, "query_url", "http://localhost:7200/repositories/my_db"
-    )
-
     response = test_app.get(ROUTE)
     assert response.status_code == 200
 
@@ -727,15 +724,15 @@ def test_missing_derivatives_info_handled_by_nonagg_api_response(
 
 @pytest.mark.integration
 def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
-    test_app, monkeypatch, disable_auth
+    test_app,
+    monkeypatch,
+    disable_auth,
+    set_graph_url_vars_for_integration_tests,
 ):
     """
     Test that only sessions of type PhenotypicSession and ImagingSession are returned in an unaggregated query response.
     """
     monkeypatch.setattr(settings, "return_agg", False)
-    monkeypatch.setattr(
-        settings, "query_url", "http://localhost:7200/repositories/my_db"
-    )
 
     response = test_app.get(ROUTE)
     assert response.status_code == 200
@@ -757,14 +754,16 @@ def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
 
 
 @pytest.mark.integration
-def test_min_cell_size_removes_results(test_app, monkeypatch, disable_auth):
+def test_min_cell_size_removes_results(
+    test_app,
+    monkeypatch,
+    disable_auth,
+    set_graph_url_vars_for_integration_tests,
+):
     """
     If the minimum cell size is large enough, all results should be filtered out
     """
     monkeypatch.setattr(settings, "min_cell_size", 100)
-    monkeypatch.setattr(
-        settings, "query_url", "http://localhost:7200/repositories/my_db"
-    )
 
     response = test_app.get(ROUTE)
     assert response.status_code == 200

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -617,7 +617,6 @@ def test_get_valid_pipeline_name_version(
 
 def test_aggregate_query_response_structure(
     test_app,
-    set_test_credentials,
     mock_post_agg_query_to_graph,
     mock_query_matching_dataset_sizes,
     monkeypatch,
@@ -642,11 +641,7 @@ def test_aggregate_query_response_structure(
 
 
 def test_query_without_token_succeeds_when_auth_disabled(
-    test_app,
-    mock_successful_get,
-    monkeypatch,
-    disable_auth,
-    set_test_credentials,
+    test_app, mock_successful_get, monkeypatch, disable_auth
 ):
     """
     Test that when authentication is disabled, a request to the /query route without a token succeeds.
@@ -658,7 +653,7 @@ def test_query_without_token_succeeds_when_auth_disabled(
 
 @pytest.mark.integration
 def test_integration_query_without_auth_succeeds(
-    test_app, monkeypatch, disable_auth, set_test_credentials
+    test_app, monkeypatch, disable_auth
 ):
     """
     Running a test against a real local test graph
@@ -740,7 +735,7 @@ def test_missing_derivatives_info_handled_by_nonagg_api_response(
 
 @pytest.mark.integration
 def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
-    test_app, monkeypatch, disable_auth, set_test_credentials
+    test_app, monkeypatch, disable_auth
 ):
     """
     Test that only sessions of type PhenotypicSession and ImagingSession are returned in an unaggregated query response.
@@ -772,9 +767,7 @@ def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
 
 
 @pytest.mark.integration
-def test_min_cell_size_removes_results(
-    test_app, monkeypatch, disable_auth, set_test_credentials
-):
+def test_min_cell_size_removes_results(test_app, monkeypatch, disable_auth):
     """
     If MIN_CELL_SIZE is high enough, all results should be filtered out
     """

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 import app.api.utility as util
 from app.api import crud
 from app.api.models import QueryModel
+from app.main import settings
 
 ROUTE = "/query"
 
@@ -65,9 +66,7 @@ def test_null_modalities(
     set_mock_verify_token,
 ):
     """Given a response containing a dataset with no recorded modalities, returns an empty list for the imaging modalities."""
-    monkeypatch.setattr(
-        util, "RETURN_AGG", util.EnvVar(util.RETURN_AGG.name, True)
-    )
+    monkeypatch.setattr(settings, "return_agg", True)
     monkeypatch.setattr(
         crud, "post_query_to_graph", mock_post_agg_query_to_graph
     )
@@ -624,9 +623,7 @@ def test_aggregate_query_response_structure(
     set_mock_verify_token,
 ):
     """Test that when aggregate results are enabled, a cohort query response has the expected structure."""
-    monkeypatch.setattr(
-        util, "RETURN_AGG", util.EnvVar(util.RETURN_AGG.name, True)
-    )
+    monkeypatch.setattr(settings, "return_agg", True)
     monkeypatch.setattr(
         crud, "post_query_to_graph", mock_post_agg_query_to_graph
     )
@@ -681,9 +678,7 @@ def test_derivatives_info_handled_by_agg_api_response(
     Test that in the aggregated API mode, pipeline information for matching subjects
     is correctly parsed and formatted in the API response.
     """
-    monkeypatch.setattr(
-        util, "RETURN_AGG", util.EnvVar(util.RETURN_AGG.name, True)
-    )
+    monkeypatch.setattr(settings, "return_agg", True)
     monkeypatch.setattr(
         crud, "post_query_to_graph", mock_post_agg_query_to_graph
     )
@@ -714,9 +709,7 @@ def test_missing_derivatives_info_handled_by_nonagg_api_response(
     Test that in the non-aggregated API mode, when all matching subjects lack pipeline information,
     the API does not error out and pipeline variables in the API response still have the expected structure.
     """
-    monkeypatch.setattr(
-        util, "RETURN_AGG", util.EnvVar(util.RETURN_AGG.name, False)
-    )
+    monkeypatch.setattr(settings, "return_agg", False)
     monkeypatch.setattr(
         crud, "post_query_to_graph", mock_post_nonagg_query_to_graph
     )
@@ -740,9 +733,7 @@ def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
     """
     Test that only sessions of type PhenotypicSession and ImagingSession are returned in an unaggregated query response.
     """
-    monkeypatch.setattr(
-        util, "RETURN_AGG", util.EnvVar(util.RETURN_AGG.name, False)
-    )
+    monkeypatch.setattr(settings, "return_agg", False)
     monkeypatch.setattr(
         util, "QUERY_URL", "http://localhost:7200/repositories/my_db"
     )
@@ -769,11 +760,9 @@ def test_only_imaging_and_phenotypic_sessions_returned_in_query_response(
 @pytest.mark.integration
 def test_min_cell_size_removes_results(test_app, monkeypatch, disable_auth):
     """
-    If MIN_CELL_SIZE is high enough, all results should be filtered out
+    If the minimum cell size is large enough, all results should be filtered out
     """
-    monkeypatch.setattr(
-        util, "MIN_CELL_SIZE", util.EnvVar(util.MIN_CELL_SIZE.name, 100)
-    )
+    monkeypatch.setattr(settings, "min_cell_size", 100)
     monkeypatch.setattr(
         util, "QUERY_URL", "http://localhost:7200/repositories/my_db"
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -648,6 +648,19 @@ def test_query_without_token_succeeds_when_auth_disabled(
 
 
 @pytest.mark.integration
+@pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
+def test_app_with_invalid_environment_vars(
+    test_app, monkeypatch, mock_auth_header, set_mock_verify_token
+):
+    """Given invalid credentials for the graph, returns a 401 status code."""
+    monkeypatch.setattr(settings, "graph_username", "wrong_username")
+    monkeypatch.setattr(settings, "graph_password", "wrong_password")
+
+    response = test_app.get("/query", headers=mock_auth_header)
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
 def test_integration_query_without_auth_succeeds(
     test_app,
     monkeypatch,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -650,13 +650,16 @@ def test_query_without_token_succeeds_when_auth_disabled(
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
 def test_app_with_invalid_environment_vars(
-    test_app, monkeypatch, mock_auth_header, set_mock_verify_token
+    test_app,
+    monkeypatch,
+    disable_auth,
+    set_graph_url_vars_for_integration_tests,
 ):
     """Given invalid credentials for the graph, returns a 401 status code."""
     monkeypatch.setattr(settings, "graph_username", "wrong_username")
     monkeypatch.setattr(settings, "graph_password", "wrong_password")
 
-    response = test_app.get("/query", headers=mock_auth_header)
+    response = test_app.get("/query")
     assert response.status_code == 401
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
+from app.api.config import settings
 from app.api.security import verify_token
 
 
@@ -9,10 +10,10 @@ def test_missing_client_id_raises_error_when_auth_enabled(
     monkeypatch, test_app, enable_auth
 ):
     """Test that a missing client ID raises an error on startup when authentication is enabled."""
-    # We're using what should be default values of CLIENT_ID and AUTH_ENABLED here
+    # We're using what should be default values of client_id and auth_enabled here
     # (if the corresponding environment variables are unset),
     # but we set the values explicitly here for clarity
-    monkeypatch.setattr("app.api.security.CLIENT_ID", None)
+    monkeypatch.setattr(settings, "client_id", None)
 
     with pytest.raises(RuntimeError) as exc_info:
         with test_app:
@@ -24,8 +25,8 @@ def test_missing_client_id_raises_error_when_auth_enabled(
 @pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
 def test_missing_client_id_ignored_when_auth_disabled(monkeypatch, test_app):
     """Test that a missing client ID does not raise an error when authentication is disabled."""
-    monkeypatch.setattr("app.api.security.CLIENT_ID", None)
-    monkeypatch.setattr("app.api.security.AUTH_ENABLED", False)
+    monkeypatch.setattr(settings, "client_id", None)
+    monkeypatch.setattr(settings, "auth_enabled", False)
 
     with test_app:
         pass
@@ -59,7 +60,7 @@ def test_query_with_malformed_auth_header_fails(
     Test that when authentication is enabled, a request to the /query route with a
     missing or malformed authorization header fails.
     """
-    monkeypatch.setattr("app.api.security.CLIENT_ID", "foo.id")
+    monkeypatch.setattr(settings, "client_id", "foo.id")
 
     response = test_app.get(
         "/query",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,7 +6,7 @@ from app.api.security import verify_token
 
 @pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
 def test_missing_client_id_raises_error_when_auth_enabled(
-    monkeypatch, test_app, set_test_credentials, enable_auth
+    monkeypatch, test_app, enable_auth
 ):
     """Test that a missing client ID raises an error on startup when authentication is enabled."""
     # We're using what should be default values of CLIENT_ID and AUTH_ENABLED here
@@ -22,9 +22,7 @@ def test_missing_client_id_raises_error_when_auth_enabled(
 
 
 @pytest.mark.filterwarnings("ignore:.*NB_API_ALLOWED_ORIGINS")
-def test_missing_client_id_ignored_when_auth_disabled(
-    monkeypatch, test_app, set_test_credentials
-):
+def test_missing_client_id_ignored_when_auth_disabled(monkeypatch, test_app):
     """Test that a missing client ID does not raise an error when authentication is disabled."""
     monkeypatch.setattr("app.api.security.CLIENT_ID", None)
     monkeypatch.setattr("app.api.security.AUTH_ENABLED", False)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,4 +18,4 @@ def test_settings_read_correctly():
     assert settings.graph_password == "12345"
     assert settings.graph_port == 7201
     assert settings.return_agg is False
-    assert settings.min_cell_size == 5
+    assert settings.min_cell_size == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,10 +12,10 @@ def test_settings_read_correctly():
     assert settings.auth_enabled is True
     assert settings.client_id is None
 
-    # Check that set environment variables are read correctly
+    # Check that set environment variables are read and typed correctly
     assert settings.allowed_origins == "*"
-    assert settings.graph_username == "bic_user"
-    assert settings.graph_password == "12345"
+    assert settings.graph_username == "DBUSER"
+    assert settings.graph_password == "DBPASSWORD"
     assert settings.graph_port == 7201
     assert settings.return_agg is False
     assert settings.min_cell_size == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,21 @@
+from app.api.config import Settings
+
+
+def test_settings_read_correctly():
+    """Ensure that settings are read correctly from environment variables, with correct types and default values."""
+    settings = Settings()
+
+    # Check that defaults are applied correctly for undefined environment variables
+    assert settings.root_path == ""
+    assert settings.graph_address == "127.0.0.1"
+    assert settings.graph_db == "repositories/my_db"
+    assert settings.auth_enabled is True
+    assert settings.client_id is None
+
+    # Check that set environment variables are read correctly
+    assert settings.allowed_origins == "*"
+    assert settings.graph_username == "bic_user"
+    assert settings.graph_password == "12345"
+    assert settings.graph_port == 7201
+    assert settings.return_agg is False
+    assert settings.min_cell_size == 5


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #316 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Replace all global variables for environment variables with a single `Settings` class using [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
- Use [pytest-env](https://github.com/pytest-dev/pytest-env) to set a subset of environment vars to non-default values in the environment before any tests run, to allow basic test that environment variables are read in correctly
  - otherwise, since environment variables are read in on app startup (meaning the TestClient used by tests already has a settings instance), modifying settings values are done through simply monkeypatching attributes
- Change dummy test of invalid credentials to a meaningful integration test

Housekeeping:
- Update some leftover Pydantic v1 syntax
- Update README badges

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

This pull request refactors the application to use Pydantic's `BaseSettings` for managing environment variables. This change improves code maintainability and type safety by centralizing environment variable configuration and validation within a dedicated settings class. The application now uses a settings object to access environment variables, and tests have been updated to reflect this change.

Enhancements:
- Migrated environment variable handling to Pydantic `BaseSettings` class for improved type safety and validation.
- Replaced direct access to environment variables with the new settings object.

Tests:
- Updated tests to use the new settings object instead of directly patching environment variables.
- Added a new test module to verify that settings are read correctly from environment variables.

## Summary by Sourcery

Refactors the application to use Pydantic's `BaseSettings` for managing environment variables, improving code maintainability and type safety. Tests have been updated to reflect this change.

Enhancements:
- Migrated environment variable handling to Pydantic `BaseSettings` class for improved type safety and validation.
- Replaced direct access to environment variables with a settings object.

Tests:
- Updated tests to use the new settings object instead of directly patching environment variables.
- Added a new test module to verify that settings are read correctly from environment variables.
- Added an integration test to verify that the app returns a 401 status code when given invalid credentials for the graph.

Chores:
- Updated some leftover Pydantic v1 syntax.