### PR TITLE
[FIX] Ensure defaults are correctly applied for environment variables set to empty strings

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -17,7 +17,9 @@ class Settings(BaseSettings):
         default="",
         description="The base URL path prefix for the API. When deployed behind a reverse proxy, set this to the subpath at which the app is mounted (if any), and configure the proxy to strip this prefix from incoming requests.",
     )
-    allowed_origins: str = Field(alias="NB_API_ALLOWED_ORIGINS", default="")
+    allowed_origins: str | None = Field(
+        alias="NB_API_ALLOWED_ORIGINS", default=None
+    )
     graph_username: str | None = Field(alias="NB_GRAPH_USERNAME", default=None)
     graph_password: str | None = Field(alias="NB_GRAPH_PASSWORD", default=None)
     graph_address: str = Field(alias="NB_GRAPH_ADDRESS", default="127.0.0.1")

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,11 +1,14 @@
 """Configuration environment variables for the API."""
 
 from pydantic import Field, computed_field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Data model for configurable API settings."""
+
+    # Ignore environment variables that are set to empty strings
+    model_config = SettingsConfigDict(env_ignore_empty=True)
 
     # NOTE: Environment variables are case-insensitive by default
     # (see https://docs.pydantic.dev/latest/concepts/pydantic_settings/#case-sensitivity)

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -42,9 +42,9 @@ BACKUP_VOCAB_DIR = (
 )
 
 
-def parse_origins_as_list(allowed_origins: str) -> list:
+def parse_origins_as_list(allowed_origins: str | None) -> list:
     """Returns user-defined allowed origins as a list."""
-    return list(allowed_origins.split(" "))
+    return list(allowed_origins.split(" ")) if allowed_origins else []
 
 
 def create_context() -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -31,7 +31,7 @@ def validate_environment_variables():
             f"The application was launched but could not find the {Settings.model_fields['graph_username'].alias} and / or {Settings.model_fields['graph_password'].alias} environment variables."
         )
 
-    if settings.allowed_origins == "":
+    if settings.allowed_origins is None:
         warnings.warn(
             f"The API was launched without providing any values for the {Settings.model_fields['allowed_origins'].alias} environment "
             f"variable."

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,9 @@ env =
     NB_API_ALLOWED_ORIGINS=*
     NB_GRAPH_USERNAME=DBUSER
     NB_GRAPH_PASSWORD=DBPASSWORD
+    ; NOTE: We set the database name to an empty string here 
+    ; to confirm that it is ignored and the correct default is used
+    NB_GRAPH_DB=
     NB_GRAPH_PORT=7201
     NB_RETURN_AGG=False
     ; NOTE: We set the minimum cell size to a different value than the default (0) here

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,8 @@ addopts = -m "not integration"
 ; setting the env variables here avoids issues related to import order in tests.
 ; In individual tests, these values may then be overridden as needed to test downstream logic
 ; by monkeypatching attributes of the global settings object
+;
+; Values are read in as literal strings, so quotes are not needed!
 env =
     NB_API_ALLOWED_ORIGINS=*
     NB_GRAPH_USERNAME=DBUSER

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,8 @@ def test_settings_read_correctly():
     """Ensure that settings are read correctly from environment variables, with correct types and default values."""
     settings = Settings()
 
-    # Check that defaults are applied correctly for undefined environment variables
+    # Check that defaults are applied correctly for environment variables that are undefined
+    # or have been set to empty strings
     assert settings.root_path == ""
     assert settings.graph_address == "127.0.0.1"
     assert settings.graph_db == "repositories/my_db"


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #411 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Ignore environment variables set to empty strings (i.e., treat them as unset) so that defaults can be applied correctly
- Change default for `NB_API_ALLOWED_ORIGINS` from `""` to `None` to match behaviour of similar variables (a default allowed origins list of `[]` also makes more sense than `[""]`)

Housekeeping:
- Remove redundant test case

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Fixes a bug where environment variables set to empty strings were not being treated as unset, preventing the application from using default values. Updates the application configuration to ignore empty strings for environment variables and modifies the allowed origins parsing to handle None values.

Bug Fixes:
- Fixes a bug where environment variables set to empty strings were not being treated as unset, preventing the application from using default values.
- Ensures that the application correctly applies default values when environment variables are set to empty strings.

## Summary by Sourcery

Fixes a bug where environment variables set to empty strings were not being treated as unset, preventing the application from using default values. Updates the application configuration to ignore empty strings for environment variables and modifies the allowed origins parsing to handle None values.

Bug Fixes:
- Fixes a bug where environment variables set to empty strings were not being treated as unset, preventing the application from using default values.
- Ensures that the application correctly applies default values when environment variables are set to empty strings.
- Updates the application configuration to ignore empty strings for environment variables.
- Modifies the allowed origins parsing to handle None values.