### PR TITLE
[ENH] Create `POST /datasets` endpoint

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -91,7 +91,7 @@ def query_matching_dataset_sizes(dataset_uuids: list) -> dict:
     }
 
 
-async def get(
+async def query_records(
     min_age: float,
     max_age: float,
     sex: str,

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -3,13 +3,16 @@
 from enum import Enum
 from typing import Annotated, Literal, Optional, Union
 
-from fastapi import Query
 from fastapi.exceptions import HTTPException
-from pydantic import BaseModel, BeforeValidator, model_validator
-from pydantic.types import StringConstraints
+from pydantic import BaseModel, BeforeValidator, model_validator, Field
 from typing_extensions import Self
 
 CONTROLLED_TERM_REGEX = r"^[a-zA-Z]+[:]\S+$"
+
+# TODO: Check if version regex is too restrictive
+# Constrain version numbers to be in the following format:
+# Exactly three dot-separated segments, where the first and third segments can be letters, numbers, or hyphens (at least one character each),
+# and the middle segment must be purely digits (one or more).
 VERSION_REGEX = r"^([A-Za-z0-9-]+)\.(\d+)\.([A-Za-z0-9-]+)$"
 
 
@@ -34,34 +37,23 @@ class QueryModel(BaseModel):
     """Data model and dependency for API that stores the query parameters to be accepted and validated."""
 
     # NOTE: extra query parameters are just ignored/have no effect
+    # NOTE: Explicit examples are needed for fields requiring a URI to avoid random-string examples being generated 
+    # for the example request body in the interactive docs
 
-    min_age: float = Query(default=None, ge=0)
-    max_age: float = Query(default=None, ge=0)
-    sex: Annotated[str, StringConstraints(pattern=CONTROLLED_TERM_REGEX)] = (
-        None
-    )
-    diagnosis: Annotated[
-        str, StringConstraints(pattern=CONTROLLED_TERM_REGEX)
-    ] = None
+    min_age: float = Field(default=None, ge=0)
+    max_age: float = Field(default=None, ge=0)
+    sex: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
+    diagnosis: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
     is_control: Annotated[
         Literal[True, None],
         BeforeValidator(convert_valid_is_control_values_to_bool),
     ] = None
-    min_num_imaging_sessions: int = Query(default=None, ge=0)
-    min_num_phenotypic_sessions: int = Query(default=None, ge=0)
-    assessment: Annotated[
-        str, StringConstraints(pattern=CONTROLLED_TERM_REGEX)
-    ] = None
-    image_modal: Annotated[
-        str, StringConstraints(pattern=CONTROLLED_TERM_REGEX)
-    ] = None
-    pipeline_name: Annotated[
-        str, StringConstraints(pattern=CONTROLLED_TERM_REGEX)
-    ] = None
-    # TODO: Check back if validating using a regex is too restrictive
-    pipeline_version: Annotated[
-        str, StringConstraints(pattern=VERSION_REGEX)
-    ] = None
+    min_num_imaging_sessions: int = Field(default=None, ge=0)
+    min_num_phenotypic_sessions: int = Field(default=None, ge=0)
+    assessment: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
+    image_modal: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
+    pipeline_name: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
+    pipeline_version: str = Field(default=None, pattern=VERSION_REGEX, examples=["1.0.0"])
 
     @model_validator(mode="after")
     def check_maxage_ge_minage(self) -> Self:

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -114,8 +114,8 @@ class SessionResponse(BaseModel):
     completed_pipelines: dict
 
 
-class CohortQueryResponse(BaseModel):
-    """Data model for query results for one matching dataset (i.e., a cohort)."""
+class DatasetQueryResponse(BaseModel):
+    """Data model for metadata of datasets matching a query."""
 
     dataset_uuid: str
     # dataset_file_path: str  # TODO: Revisit this field once we have datasets without imaging info/sessions.
@@ -124,9 +124,14 @@ class CohortQueryResponse(BaseModel):
     dataset_total_subjects: int
     records_protected: bool
     num_matching_subjects: int
-    subject_data: Union[list[SessionResponse], str]
     image_modals: list
     available_pipelines: dict
+
+
+class SubjectsQueryResponse(DatasetQueryResponse):
+    """Data model for subject data matching a query."""
+
+    subject_data: Union[list[SessionResponse], str]
 
 
 class DataElementURI(str, Enum):

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Annotated, Literal, Optional, Union
 
 from fastapi.exceptions import HTTPException
-from pydantic import BaseModel, BeforeValidator, model_validator, Field
+from pydantic import BaseModel, BeforeValidator, Field, model_validator
 from typing_extensions import Self
 
 CONTROLLED_TERM_REGEX = r"^[a-zA-Z]+[:]\S+$"
@@ -37,23 +37,35 @@ class QueryModel(BaseModel):
     """Data model and dependency for API that stores the query parameters to be accepted and validated."""
 
     # NOTE: extra query parameters are just ignored/have no effect
-    # NOTE: Explicit examples are needed for fields requiring a URI to avoid random-string examples being generated 
+    # NOTE: Explicit examples are needed for fields requiring a URI to avoid random-string examples being generated
     # for the example request body in the interactive docs
 
     min_age: float = Field(default=None, ge=0)
     max_age: float = Field(default=None, ge=0)
-    sex: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
-    diagnosis: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
+    sex: str = Field(
+        default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"]
+    )
+    diagnosis: str = Field(
+        default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"]
+    )
     is_control: Annotated[
         Literal[True, None],
         BeforeValidator(convert_valid_is_control_values_to_bool),
     ] = None
     min_num_imaging_sessions: int = Field(default=None, ge=0)
     min_num_phenotypic_sessions: int = Field(default=None, ge=0)
-    assessment: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
-    image_modal: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
-    pipeline_name: str = Field(default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"])
-    pipeline_version: str = Field(default=None, pattern=VERSION_REGEX, examples=["1.0.0"])
+    assessment: str = Field(
+        default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"]
+    )
+    image_modal: str = Field(
+        default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"]
+    )
+    pipeline_name: str = Field(
+        default=None, pattern=CONTROLLED_TERM_REGEX, examples=["vocab:12345"]
+    )
+    pipeline_version: str = Field(
+        default=None, pattern=VERSION_REGEX, examples=["1.0.0"]
+    )
 
     @model_validator(mode="after")
     def check_maxage_ge_minage(self) -> Self:

--- a/app/api/routers/datasets.py
+++ b/app/api/routers/datasets.py
@@ -21,9 +21,9 @@ oauth2_scheme = OAuth2(
 )
 
 
-@router.get("", response_model=List[DatasetQueryResponse])
-async def get_query(
-    query: Annotated[QueryModel, Query()],
+@router.post("", response_model=List[DatasetQueryResponse])
+async def post_datasets_query(
+    query: QueryModel,
     token: str | None = Depends(oauth2_scheme),
 ):
     """When a GET request is sent, return list of dicts corresponding to subject-level metadata aggregated by dataset."""

--- a/app/api/routers/datasets.py
+++ b/app/api/routers/datasets.py
@@ -1,5 +1,3 @@
-"""Router for query path operations."""
-
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -7,14 +5,11 @@ from fastapi.security import OAuth2
 
 from .. import crud
 from ..config import settings
-from ..models import QueryModel, SubjectsQueryResponse
+from ..models import DatasetQueryResponse, QueryModel
 from ..security import verify_token
 
-router = APIRouter(prefix="/query", tags=["query"])
+router = APIRouter(prefix="/datasets", tags=["datasets"])
 
-# Adapted from info in https://github.com/tiangolo/fastapi/discussions/9137#discussioncomment-5157382
-# I believe for us this is purely for documentatation/a nice looking interactive API docs page,
-# and doesn't actually have any bearing on the ID token validation process.
 oauth2_scheme = OAuth2(
     flows={
         "implicit": {
@@ -26,12 +21,7 @@ oauth2_scheme = OAuth2(
 )
 
 
-# We (unconventionally) use an "" path prefix here because we have globally disabled
-# redirection of trailing slashes in the main app file. We use an empty string here
-# to ensure that a request without a trailing slash (e.g., to /query instead of /query/)
-# is correctly routed to this endpoint.
-# For more context, see https://github.com/neurobagel/api/issues/327.
-@router.get("", response_model=List[SubjectsQueryResponse])
+@router.get("", response_model=List[DatasetQueryResponse])
 async def get_query(
     query: Annotated[QueryModel, Query()],
     token: str | None = Depends(oauth2_scheme),

--- a/app/api/routers/datasets.py
+++ b/app/api/routers/datasets.py
@@ -26,7 +26,7 @@ async def post_datasets_query(
     query: QueryModel,
     token: str | None = Depends(oauth2_scheme),
 ):
-    """When a GET request is sent, return list of dicts corresponding to subject-level metadata aggregated by dataset."""
+    """When a POST request is sent, return list of dicts corresponding to metadata for datasets matching the query."""
     if settings.auth_enabled:
         if token is None:
             raise HTTPException(
@@ -35,8 +35,8 @@ async def post_datasets_query(
             )
         verify_token(token)
 
-    # TODO: See if we can pass the query object directly to crud.get() instead of unpacking it
-    response = await crud.get(
+    # TODO: See if we can pass the query object directly to crud.query_records() instead of unpacking it
+    response = await crud.query_records(
         min_age=query.min_age,
         max_age=query.max_age,
         sex=query.sex,

--- a/app/api/routers/datasets.py
+++ b/app/api/routers/datasets.py
@@ -1,6 +1,6 @@
-from typing import Annotated, List
+from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2
 
 from .. import crud

--- a/app/api/routers/datasets.py
+++ b/app/api/routers/datasets.py
@@ -35,18 +35,20 @@ async def get_query(
             )
         verify_token(token)
 
+    # TODO: See if we can pass the query object directly to crud.get() instead of unpacking it
     response = await crud.get(
-        query.min_age,
-        query.max_age,
-        query.sex,
-        query.diagnosis,
-        query.is_control,
-        query.min_num_imaging_sessions,
-        query.min_num_phenotypic_sessions,
-        query.assessment,
-        query.image_modal,
-        query.pipeline_name,
-        query.pipeline_version,
+        min_age=query.min_age,
+        max_age=query.max_age,
+        sex=query.sex,
+        diagnosis=query.diagnosis,
+        is_control=query.is_control,
+        min_num_imaging_sessions=query.min_num_imaging_sessions,
+        min_num_phenotypic_sessions=query.min_num_phenotypic_sessions,
+        assessment=query.assessment,
+        image_modal=query.image_modal,
+        pipeline_name=query.pipeline_name,
+        pipeline_version=query.pipeline_version,
+        is_datasets_query=True,
     )
 
     return response

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -45,18 +45,20 @@ async def get_query(
             )
         verify_token(token)
 
+    # TODO: See if we can pass the query object directly to crud.get() instead of unpacking it
     response = await crud.get(
-        query.min_age,
-        query.max_age,
-        query.sex,
-        query.diagnosis,
-        query.is_control,
-        query.min_num_imaging_sessions,
-        query.min_num_phenotypic_sessions,
-        query.assessment,
-        query.image_modal,
-        query.pipeline_name,
-        query.pipeline_version,
+        min_age=query.min_age,
+        max_age=query.max_age,
+        sex=query.sex,
+        diagnosis=query.diagnosis,
+        is_control=query.is_control,
+        min_num_imaging_sessions=query.min_num_imaging_sessions,
+        min_num_phenotypic_sessions=query.min_num_phenotypic_sessions,
+        assessment=query.assessment,
+        image_modal=query.image_modal,
+        pipeline_name=query.pipeline_name,
+        pipeline_version=query.pipeline_version,
+        is_datasets_query=False,
     )
 
     return response

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -45,8 +45,8 @@ async def get_query(
             )
         verify_token(token)
 
-    # TODO: See if we can pass the query object directly to crud.get() instead of unpacking it
-    response = await crud.get(
+    # TODO: See if we can pass the query object directly to crud.query_records() instead of unpacking it
+    response = await crud.query_records(
         min_age=query.min_age,
         max_age=query.max_age,
         sex=query.sex,

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -314,10 +314,10 @@ def construct_matching_sub_results_for_dataset(
             "session_type": "first",
             "age": "first",
             "sex": "first",
-            "diagnosis": lambda x: list(x.unique()),
+            "diagnosis": lambda record_group: list(record_group.unique()),
             "subject_group": "first",
-            "assessment": lambda x: list(x.unique()),
-            "image_modal": lambda x: list(x.unique()),
+            "assessment": lambda record_group: list(record_group.unique()),
+            "image_modal": lambda record_group: list(record_group.unique()),
             "session_file_path": "first",
         }
     )
@@ -335,7 +335,13 @@ def construct_matching_sub_results_for_dataset(
             # would otherwise be completely removed and in an extreme case where no matching sessions have pipeline info,
             # we'd end up with an empty dataframe.
             dropna=False,
-        ).agg({"pipeline_version": lambda x: list(x.dropna().unique())})
+        ).agg(
+            {
+                "pipeline_version": lambda record_group: list(
+                    record_group.dropna().unique()
+                )
+            }
+        )
         # Turn indices from the groupby back into dataframe columns
         .reset_index()
     )

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -6,6 +6,9 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
+import pandas as pd
+
 QUERY_HEADER = {
     "Content-Type": "application/sparql-query",
     "Accept": "application/sparql-results+json",
@@ -294,6 +297,93 @@ def create_multidataset_size_query(dataset_uuids: list) -> str:
     """
 
     return "\n".join([create_context(), query_string])
+
+
+def construct_matching_sub_results_for_dataset(
+    matching_records: pd.DataFrame,
+) -> list:
+    subject_data = matching_records.groupby(
+        by=["sub_id", "session_id", "session_type"],
+        dropna=True,
+    ).agg(
+        {
+            "sub_id": "first",
+            "session_id": "first",
+            "num_matching_phenotypic_sessions": "first",
+            "num_matching_imaging_sessions": "first",
+            "session_type": "first",
+            "age": "first",
+            "sex": "first",
+            "diagnosis": lambda x: list(x.unique()),
+            "subject_group": "first",
+            "assessment": lambda x: list(x.unique()),
+            "image_modal": lambda x: list(x.unique()),
+            "session_file_path": "first",
+        }
+    )
+
+    # Get the unique versions of each pipeline that was run on each session
+    pipeline_grouped_data = (
+        matching_records.groupby(
+            [
+                "sub_id",
+                "session_id",
+                "session_type",
+                "pipeline_name",
+            ],
+            # We cannot drop NaNs here because sessions without pipelines (i.e., with empty values for pipeline_name)
+            # would otherwise be completely removed and in an extreme case where no matching sessions have pipeline info,
+            # we'd end up with an empty dataframe.
+            dropna=False,
+        ).agg({"pipeline_version": lambda x: list(x.dropna().unique())})
+        # Turn indices from the groupby back into dataframe columns
+        .reset_index()
+    )
+
+    # Aggregate all completed pipelines for each session
+    session_grouped_data = pipeline_grouped_data.groupby(
+        ["sub_id", "session_id", "session_type"],
+    )
+    session_completed_pipeline_data = (
+        session_grouped_data.apply(
+            lambda x: {
+                pname: pvers
+                for pname, pvers in zip(
+                    x["pipeline_name"], x["pipeline_version"]
+                )
+                if not pd.isnull(pname)
+            }
+        )
+        # NOTE: The below function expects a pd.Series only.
+        # This can break if the result of the apply function is a pd.DataFrame
+        # (pd.DataFrame.reset_index() doesn't have a "name" arg),
+        # which can happen if the original dataframe being operated on is empty.
+        # For example, see https://github.com/neurobagel/api/issues/367.
+        # (Related: https://github.com/pandas-dev/pandas/issues/55225)
+        .reset_index(name="completed_pipelines")
+    )
+
+    subject_data = pd.merge(
+        subject_data.reset_index(drop=True),
+        session_completed_pipeline_data,
+        on=["sub_id", "session_id", "session_type"],
+        how="left",
+    )
+
+    # TODO: Revisit this as there may be a more elegant solution.
+    # The following code replaces columns with all NaN values with values of None, to ensure they show up in the final JSON as `null`.
+    # This is needed as the above .agg() seems to turn NaN into None for object-type columns (which have some non-missing values)
+    # but not for columns with all NaN, which end up with a column type of float64. This is a problem because
+    # if the column corresponds to a SessionResponse attribute with an expected str type, then the column values will be converted
+    # to the string "nan" in the response JSON, which we don't want.
+    all_nan_columns = subject_data.columns[subject_data.isna().all()]
+    subject_data[all_nan_columns] = subject_data[all_nan_columns].replace(
+        {np.nan: None}
+    )
+
+    subject_data = list(subject_data.to_dict("records"))
+
+    return subject_data
 
 
 def create_terms_query(data_element_URI: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,14 @@ from fastapi.responses import HTMLResponse, ORJSONResponse, RedirectResponse
 
 from .api import utility as util
 from .api.config import Settings, settings
-from .api.routers import assessments, attributes, diagnoses, pipelines, query
+from .api.routers import (
+    assessments,
+    attributes,
+    datasets,
+    diagnoses,
+    pipelines,
+    query,
+)
 from .api.security import check_client_id
 
 BACKUP_VOCAB_DIR = (
@@ -177,6 +184,7 @@ def overridden_redoc(request: Request):
 
 
 app.include_router(query.router)
+app.include_router(datasets.router)
 app.include_router(attributes.router)
 app.include_router(assessments.router)
 app.include_router(diagnoses.router)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,6 +726,7 @@ def mock_get_with_exception(request):
         image_modal,
         pipeline_version,
         pipeline_name,
+        is_datasets_query,
     ):
         raise request.param
 
@@ -756,6 +757,7 @@ def mock_get(request):
         image_modal,
         pipeline_version,
         pipeline_name,
+        is_datasets_query,
     ):
         return request.param
 
@@ -778,6 +780,7 @@ def mock_successful_get(test_data):
         image_modal,
         pipeline_version,
         pipeline_name,
+        is_datasets_query,
     ):
         return test_data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -693,7 +693,7 @@ def mock_query_matching_dataset_sizes():
     """
     Mock query_matching_dataset_sizes function that returns the total number of subjects for a toy dataset 12345.
     Can be used together with mock_post_*_query_to_graph fixtures to mock both the POST step of a cohort query and
-    the corresponding query for dataset size, in order to test how the response from the graph is processed by the API (crud.get).
+    the corresponding query for dataset size, in order to test how the response from the graph is processed by the API (crud.query_records).
     """
 
     def _mock_query_matching_dataset_sizes(dataset_uuids):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -16,7 +16,7 @@ def test_datasets_response_structure(
         crud, "query_matching_dataset_sizes", mock_query_matching_dataset_sizes
     )
 
-    response = test_app.get("/datasets")
+    response = test_app.post("/datasets", json={})
     assert response.status_code == 200
     assert all(
         "subject_data" not in matching_dataset

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,7 +8,7 @@ def test_datasets_response_structure(
     disable_auth,
     monkeypatch,
 ):
-    """Test that the datasets endpoint returns a list of dicts with the expected keys."""
+    """Test that the datasets endpoint does not include subject data in the response."""
     monkeypatch.setattr(
         crud, "post_query_to_graph", mock_post_agg_query_to_graph
     )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,24 @@
+from app.api import crud
+
+
+def test_datasets_response_structure(
+    test_app,
+    mock_post_agg_query_to_graph,
+    mock_query_matching_dataset_sizes,
+    disable_auth,
+    monkeypatch,
+):
+    """Test that the datasets endpoint returns a list of dicts with the expected keys."""
+    monkeypatch.setattr(
+        crud, "post_query_to_graph", mock_post_agg_query_to_graph
+    )
+    monkeypatch.setattr(
+        crud, "query_matching_dataset_sizes", mock_query_matching_dataset_sizes
+    )
+
+    response = test_app.get("/datasets")
+    assert response.status_code == 200
+    assert all(
+        "subject_data" not in matching_dataset
+        for matching_dataset in response.json()
+    )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -88,7 +88,7 @@ def test_get_all(
 ):
     """Given no input for any query parameters, returns a 200 status code and a non-empty list of results (should correspond to all subjects in graph)."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(ROUTE, headers=mock_auth_header)
     assert response.status_code == 200
     assert response.json() != []
@@ -109,7 +109,7 @@ def test_get_valid_age_range(
 ):
     """Given a valid age range, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?min_age={valid_min_age}&max_age={valid_max_age}",
         headers=mock_auth_header,
@@ -132,7 +132,7 @@ def test_get_valid_age_single_bound(
 ):
     """Given only a valid lower/upper age bound, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(f"{ROUTE}?{age_keyval}", headers=mock_auth_header)
     assert response.status_code == 200
     assert response.json() != []
@@ -158,7 +158,7 @@ def test_get_invalid_age(
 ):
     """Given an invalid age range, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?min_age={invalid_min_age}&max_age={invalid_max_age}",
         headers=mock_auth_header,
@@ -180,7 +180,7 @@ def test_get_valid_sex(
 ):
     """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?sex={valid_sex}", headers=mock_auth_header
     )
@@ -194,7 +194,7 @@ def test_get_invalid_sex(
 ):
     """Given an invalid sex string, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(f"{ROUTE}?sex=apple", headers=mock_auth_header)
     assert response.status_code == 422
 
@@ -212,7 +212,7 @@ def test_get_valid_diagnosis(
 ):
     """Given a valid diagnosis, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?diagnosis={valid_diagnosis}", headers=mock_auth_header
     )
@@ -234,7 +234,7 @@ def test_get_invalid_diagnosis(
 ):
     """Given an invalid diagnosis, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?diagnosis={invalid_diagnosis}", headers=mock_auth_header
     )
@@ -252,7 +252,7 @@ def test_get_valid_iscontrol(
 ):
     """Given a valid is_control value, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?is_control={valid_iscontrol}", headers=mock_auth_header
     )
@@ -283,7 +283,7 @@ def test_get_invalid_iscontrol(
 ):
     """Given an invalid is_control value, returns a 422 status code and informative error."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?is_control={invalid_iscontrol}", headers=mock_auth_header
     )
@@ -297,7 +297,7 @@ def test_get_invalid_control_diagnosis_pair(
 ):
     """Given a non-default diagnosis value and is_control value of True, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?diagnosis=snomed:35489007&is_control=True",
         headers=mock_auth_header,
@@ -326,7 +326,7 @@ def test_get_valid_min_num_sessions(
 ):
     """Given a valid minimum number of imaging sessions, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?{session_param}={valid_min_num_sessions}",
         headers=mock_auth_header,
@@ -352,7 +352,7 @@ def test_get_invalid_min_num_sessions(
 ):
     """Given an invalid minimum number of imaging sessions, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?{session_param}={invalid_min_num_sessions}",
         headers=mock_auth_header,
@@ -369,7 +369,7 @@ def test_get_valid_assessment(
 ):
     """Given a valid assessment, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?assessment=nb:cogAtlas-1234", headers=mock_auth_header
     )
@@ -391,7 +391,7 @@ def test_get_invalid_assessment(
 ):
     """Given an invalid assessment, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?assessment={invalid_assessment}", headers=mock_auth_header
     )
@@ -418,7 +418,7 @@ def test_get_valid_available_image_modal(
 ):
     """Given a valid and available image modality, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?image_modal={valid_available_image_modal}",
         headers=mock_auth_header,
@@ -442,7 +442,7 @@ def test_get_valid_unavailable_image_modal(
 ):
     """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and an empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?image_modal={valid_unavailable_image_modal}",
         headers=mock_auth_header,
@@ -466,7 +466,7 @@ def test_get_invalid_image_modal(
 ):
     """Given an invalid image modality, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?image_modal={invalid_image_modal}", headers=mock_auth_header
     )
@@ -490,7 +490,7 @@ def test_get_undefined_prefix_image_modal(
 ):
     """Given a valid and undefined prefix image modality, returns a 500 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get_with_exception)
+    monkeypatch.setattr(crud, "query_records", mock_get_with_exception)
     response = test_app.get(
         f"{ROUTE}?image_modal={undefined_prefix_image_modal}",
         headers=mock_auth_header,
@@ -511,7 +511,7 @@ def test_get_valid_pipeline_version(
 ):
     """Given a valid pipeline version, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?pipeline_version={valid_pipeline_version}",
         headers=mock_auth_header,
@@ -532,7 +532,7 @@ def test_get_invalid_pipeline_version(
 ):
     """Given an invalid pipeline version, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?pipeline_version={invalid_pipeline_version}",
         headers=mock_auth_header,
@@ -553,7 +553,7 @@ def test_get_valid_pipeline_name(
 ):
     """Given a valid pipeline name, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?pipeline_name={valid_pipeline_name}",
         headers=mock_auth_header,
@@ -576,7 +576,7 @@ def test_get_invalid_pipeline_name(
 ):
     """Given an invalid pipeline name, returns a 422 status code."""
 
-    monkeypatch.setattr(crud, "get", mock_get)
+    monkeypatch.setattr(crud, "query_records", mock_get)
     response = test_app.get(
         f"{ROUTE}?pipeline_name={invalid_pipeline_name}",
         headers=mock_auth_header,
@@ -604,7 +604,7 @@ def test_get_valid_pipeline_name_version(
 ):
     """Given a valid pipeline name and version, returns a 200 status code and a non-empty list of results."""
 
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(
         f"{ROUTE}?pipeline_name={valid_pipeline_name}&pipeline_version={valid_pipeline_version}",
         headers=mock_auth_header,
@@ -642,7 +642,7 @@ def test_query_without_token_succeeds_when_auth_disabled(
     """
     Test that when authentication is disabled, a request to the /query route without a token succeeds.
     """
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(ROUTE)
     assert response.status_code == 200
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -27,7 +27,7 @@ def test_request_without_trailing_slash_not_redirected(
     test_app, monkeypatch, mock_successful_get, disable_auth, valid_route
 ):
     """Test that a request to a route without a / is not redirected to have a trailing slash."""
-    monkeypatch.setattr(crud, "get", mock_successful_get)
+    monkeypatch.setattr(crud, "query_records", mock_successful_get)
     response = test_app.get(valid_route, follow_redirects=False)
     assert response.status_code == 200
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #432 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add new router for `/datasets` path with a `POST` path operation
- Create new response model for datasets metadata
- Rename and refactor get CRUD function to handle requests from both `/query` and `/datasets`
- Refactor `QueryModel` to use Pydantic's `Field` for simpler syntax and metadata addition

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Introduce a `/datasets` endpoint for dataset-level metadata queries and refactor query logic for both dataset and subject-level responses.

New Features:
- Add a `GET /datasets` endpoint to retrieve aggregated dataset metadata matching query parameters.

Enhancements:
- Refactor the core query logic to support dataset-only and subject-level responses based on a flag.
- Extract subject data aggregation logic into a utility function.
- Introduce distinct response models for dataset-level (`DatasetQueryResponse`) and subject-level (`SubjectsQueryResponse`) queries.
- Update the `GET /query` endpoint to use the refactored logic for subject-level data.

## Summary by Sourcery

Introduce a `POST /datasets` endpoint for dataset-level metadata queries and refactor the query logic to serve both dataset and subject-level requests.

New Features:
- Add `POST /datasets` endpoint for querying aggregated dataset metadata.

Enhancements:
- Refactor query logic (`crud.query_records`) to return either dataset-level or subject-level data.
- Extract subject data processing into a utility function.
- Define separate response models for dataset (`DatasetQueryResponse`) and subject (`SubjectsQueryResponse`) queries.
- Update `GET /query` to use the refactored logic and new response model.
- Update `QueryModel` to use Pydantic `Field` definitions.

Tests:
- Add tests for the `/datasets` endpoint.
- Adapt existing query tests for refactored logic.