### PR TITLE
[FIX] Add back missing API root path to docs link in root UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -191,11 +191,11 @@ def root(request: Request):
     """
     Display a welcome message and a link to the API documentation.
     """
-    return """
+    return f"""
  <html>
         <head>
             <style>
-                body {
+                body {{
                     display: flex;
                     justify-content: center;
                     align-items: center;
@@ -203,37 +203,37 @@ def root(request: Request):
                     background-color: #f0f0f0;
                     font-family: Arial, sans-serif;
                     margin: 0;
-                }
-                .container {
+                }}
+                .container {{
                     text-align: center;
-                }
-                .logo {
+                }}
+                .logo {{
                     animation: spin 5s linear infinite;
-                }
-                @keyframes spin {
-                    0% { transform: rotate(0deg); }
-                    100% { transform: rotate(360deg); }
-                }
-                h1 {
+                }}
+                @keyframes spin {{
+                    0% {{ transform: rotate(0deg); }}
+                    100% {{ transform: rotate(360deg); }}
+                }}
+                h1 {{
                     color: #333;
-                }
-                p {
+                }}
+                p {{
                     color: #666;
-                }
-                a {
+                }}
+                a {{
                     color: #007bff;
                     text-decoration: none;
-                }
-                a:hover {
+                }}
+                a:hover {{
                     text-decoration: underline;
-                }
+                }}
             </style>
         </head>
         <body>
             <div class="container">
                 <img src="https://raw.githubusercontent.com/neurobagel/documentation/main/docs/imgs/logo/neurobagel_logo.png" alt="Neurobagel Logo" class="logo" width="144" height="144">
                 <h1>Welcome to the Neurobagel REST API!</h1>
-                <p>Please visit the <a href="/docs">API documentation</a> to view available API endpoints.</p>
+                <p>Please visit the <a href="{request.scope.get('root_path', '')}/docs">API documentation</a> to view available API endpoints.</p>
             </div>
         </body>
     </html>

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,18 +5,21 @@ from app.main import app, favicon_url
 
 
 @pytest.mark.parametrize(
-    "route",
-    ["/", ""],
+    "root_path",
+    ["", "/node"],
 )
-def test_root(test_app, route, monkeypatch):
-    """Given a GET request to the root endpoint, Check for 200 status and expected content."""
+def test_root(test_app, root_path, monkeypatch):
+    """
+    Given a GET request to the root endpoint as defined by the root_path,
+    check for 200 status and expected content.
+    """
     # root_path determines the path prefix for the docs link on the welcome page
-    monkeypatch.setattr(app, "root_path", "")
-    response = test_app.get(route, follow_redirects=False)
+    monkeypatch.setattr(app, "root_path", root_path)
+    response = test_app.get(root_path + "/", follow_redirects=False)
 
     assert response.status_code == 200
     assert "<h1>Welcome to the Neurobagel REST API!</h1>" in response.text
-    assert '<a href="/docs">API documentation</a>' in response.text
+    assert f'<a href="{root_path}/docs">API documentation</a>' in response.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #483 

> [!NOTE]
> We should redeploy the OpenNeuro node for the changes to take effect on https://openneuro.neurobagel.org/node`

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [ ] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Prefix the docs link on the root UI page with the configured API root path and update tests to match

Bug Fixes:
- Include API root path prefix in the /docs link on the welcome page

Tests:
- Parameterize root endpoint tests with root_path and validate the prefixed docs link