### PR TITLE
[MNT] Change default value of NB_ENABLE_AUTH to False #530

### DIFF
--- a/app/api/env_settings.py
+++ b/app/api/env_settings.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     )
     return_agg: bool = Field(alias="NB_RETURN_AGG", default=True)
     min_cell_size: int = Field(alias="NB_MIN_CELL_SIZE", default=0)
-    auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=True)
+    auth_enabled: bool = Field(alias="NB_ENABLE_AUTH", default=False)
     client_id: str | None = Field(alias="NB_QUERY_CLIENT_ID", default=None)
     config: str = Field(
         alias="NB_CONFIG",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_settings_read_correctly(monkeypatch):
     # Check that defaults are applied correctly for environment variables that are undefined
     assert settings.root_path == ""
     assert settings.graph_address == "127.0.0.1"
-    assert settings.auth_enabled is True
+    assert settings.auth_enabled is False
     assert settings.client_id is None
     assert settings.config == "Neurobagel"
     assert settings.datasets_metadata_path == Path(


### PR DESCRIPTION
Closes #530
Changes proposed in this pull request:
Updated the NB_ENABLE_AUTH environment-backed setting to default to False (previously True).
This ensures that authentication is not required by default, aligning with the requirements in issue #530.
Verified the change manually via a Python script. 

Checklist:

- [x] PR has an interpretable title with a prefix ([ENH], [FIX], [REF], [TST], [CI], [MNT], [INF], [MODEL], [DOC]) (see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)
- [x]  PR has a label for the release changelog or skip-release (to be applied by maintainers only)
- [x]  PR links to GitHub issue with mention Closes #XXXX
- [x]  Tests pass
- [x]  Checks pass
- [ ]  If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:

- [ ]  Tests have been added

For bug fixes:

- [ ] There is at least one test that would fail under the original bug conditions.