### PR TITLE
Add caching layer for vocabulary fetching during API startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -327,3 +327,5 @@ docs/_book
 
 # TODO: where does this rule come from?
 test/
+
+.cache/

--- a/app/api/cache.py
+++ b/app/api/cache.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+from typing import Any
+
+CACHE_DIR = Path(".cache")
+VOCAB_CACHE_FILE = CACHE_DIR / "vocabs.json"
+
+
+def save_vocab_cache(data: dict[str, Any]) -> None:
+    CACHE_DIR.mkdir(exist_ok=True)
+    with open(VOCAB_CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def load_vocab_cache() -> dict | None:
+    if VOCAB_CACHE_FILE.exists():
+        with open(VOCAB_CACHE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return None


### PR DESCRIPTION
## Summary
This PR introduces a lightweight caching mechanism for vocabulary fetching during API startup.

Currently, vocabularies are fetched from GitHub on every startup, which can slow initialization and create a dependency on network availability.

## Changes
- Added `cache.py` helper to store and load vocabularies locally
- Load vocabularies from cache when available
- Fetch and persist vocabularies when cache is missing
- Added fallback to cached vocabularies if fetching fails
- Added logging to clarify when cache vs remote fetch is used

## Impact
- Faster startup for local development
- Improved reliability when external services are unavailable
- No change to existing API behavior

## Notes
Cached vocabularies can be refreshed by removing the `.cache` directory.

## Summary by Sourcery

Introduce a local caching mechanism for vocabulary data during API startup to reduce reliance on remote fetching and improve startup performance.

New Features:
- Add a cache helper module to persist and load vocabularies from a local .cache directory.
- Load vocabularies from the local cache on startup when available instead of always fetching from GitHub.

Enhancements:
- Add a fallback to use cached vocabularies when remote fetching fails to improve startup robustness.
- Add logging to indicate whether vocabularies are loaded from cache or fetched remotely.

#534 