### PR TITLE
[REF] remove stale python setup step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,13 +29,10 @@ jobs:
     - name: Check running containers
       run: docker ps
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+    - name: Set up Python 3.10 with uv
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.10"
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
To make CI consistent across apps

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- remove separate uv and python setup step
- set python version via ENV var to uv action, see https://docs.astral.sh/uv/guides/integration/github/#multiple-python-versions

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

CI:
- Configure the test workflow to use the uv GitHub Action to set up Python 3.10, removing the separate Python and uv setup steps.