### PR TITLE
[DOC] Fix heading link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please refer to our [**official documentation**](https://neurobagel.org/user_gui
     - [Option 2: Use the latest image from Docker Hub](#option-2-use-the-latest-image-from-docker-hub)
     - [Option 3: Build the image using the Dockerfile](#option-3-build-the-image-using-the-dockerfile)
     - [Send a test query to the API](#send-a-test-query-to-the-api)
-  - [Python](#python)
+  - [Python](#python-development-environment)
     - [Install dependencies](#install-dependencies)
     - [Launch the API](#launch-the-api)
   - [Troubleshooting](#troubleshooting)
@@ -146,6 +146,7 @@ You can then launch the API using either of these methods:
 uv run python -m app.main
 ```
 This launches the API inside the project environment without requiring you to activate a virtual environment first.
+
 **Option 2: Activate the virtual environment manually**
 ```bash
 source .venv/bin/activate


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Fix broken heading link (currently causing Linkspector failure) and section formatting in README

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass
- [ ] If the PR changes the SPARQL query template, the default Neurobagel query file has also been [regenerated](https://github.com/neurobagel/api?tab=readme-ov-file#the-default-neurobagel-sparql-query)

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Update README documentation to fix a broken Python section link and improve section formatting.

Documentation:
- Fix the README table of contents entry for the Python section so it correctly links to the Python development environment heading.
- Adjust README spacing around the virtual environment instructions for clearer section separation.